### PR TITLE
Enhance docs/CI guidance and harden CI-1 workflow tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Repository-level operational rules for maintaining the knowledgebase.
 
 ## Mission
 
-Keep wiki content deterministic, provenance-first, and policy-aligned with `SPEC.md`.
+Keep wiki content deterministic, provenance-first, and policy-aligned with `raw/inbox/SPEC.md`.
 
 ## Repository zones
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
 # knowledgebase
 
-Self-contained, self-organizing knowledgebase.
+Self-contained, self-organizing knowledgebase with deterministic ingest, indexing,
+linting, query, and policy-gated persistence workflows.
+
+## Quick start
+
+```bash
+# 1) ingest one source from inbox
+python3 scripts/kb/ingest.py --source raw/inbox/<source-file>.md --wiki-root wiki --schema AGENTS.md
+
+# 2) rebuild index
+python3 scripts/kb/update_index.py --wiki-root wiki --write
+
+# 3) run strict lint
+python3 scripts/kb/lint_wiki.py --wiki-root wiki --strict
+
+# 4) run tests
+python3 -m unittest discover -s tests -p "test_*.py"
+```
+
+For full operational flow (including qmd and query-persist behavior), see
+[`docs/mvp-runbook.md`](docs/mvp-runbook.md).
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `python3 scripts/kb/ingest.py --source ...` | Ingest one inbox source into wiki artifacts. |
+| `python3 scripts/kb/ingest.py --sources-manifest ... --batch-policy continue_and_report_per_source --report-json` | Batch ingest with deterministic partial-success semantics. |
+| `python3 scripts/kb/update_index.py --wiki-root wiki --write` | Rebuild deterministic `wiki/index.md`. |
+| `python3 scripts/kb/lint_wiki.py --wiki-root wiki --strict` | Run read-only strict wiki validation. |
+| `qmd collection add wiki --name wiki && qmd embed && qmd query "<query>"` | Build/query local semantic index. |
+| `python3 scripts/kb/persist_query.py ... --result-json` | Policy-gated persistence of high-value query outputs. |
+| `python3 -m unittest discover -s tests -p "test_*.py"` | Run repository test suite. |
+
+## Architecture and decisions
+
+- Canonical specification baseline: [`raw/inbox/SPEC.md`](raw/inbox/SPEC.md)
+- Architecture overview: [`docs/architecture.md`](docs/architecture.md)
+- Architecture Decision Records (ADRs): [`docs/decisions/README.md`](docs/decisions/README.md)
+- MVP operator runbook: [`docs/mvp-runbook.md`](docs/mvp-runbook.md)
 
 ## Included packages
 
 - `.github/skills/`, `.github/agents/`, `.github/prompts/`, and `.github/hooks/` — ported from [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills)
   - Upstream license: MIT (`.github/third_party/agent-skills-LICENSE`)
-
-## MVP runbook
-
-For end-to-end MVP operations, see [`docs/mvp-runbook.md`](docs/mvp-runbook.md).  
-It covers local ingest/index/lint/qmd/persist/test flow, fail-closed exit handling,
-CI-1..CI-3 fallback/manual execution, and M0..M4 milestone evidence mapping.  
-It also documents CI-1 trusted-trigger prerequisites (protected default branch and
-strict `raw/inbox/**` commit scope).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,63 @@
+# Knowledgebase Architecture
+
+This document summarizes the implemented architecture and governance model from
+[`raw/inbox/SPEC.md`](../raw/inbox/SPEC.md), and points to stable ADRs for key decisions.
+
+## Goals
+
+The system is designed to keep knowledge:
+
+1. **Persistent** (wiki artifacts are stored in-repo, not only generated at query-time).
+2. **Traceable** (claims are tied to canonical SourceRef citations).
+3. **Deterministic** (policy-driven behavior with explicit failure semantics).
+4. **Auditable** (state changes are visible through git history and `wiki/log.md`).
+
+## Repository zones
+
+| Zone | Role | Trust level |
+|---|---|---|
+| `raw/inbox/**` | New source inputs pending ingest | Untrusted input |
+| `raw/processed/**` | Post-ingest source artifacts | Immutable source-of-truth |
+| `raw/assets/**` | Vendored external assets | Authoritative only when checksummed |
+| `wiki/**` | Synthesized knowledge artifacts | Controlled write surface |
+| `schema/**` | Page/ingest contracts | Controlled write surface |
+| `scripts/kb/**` + `tests/kb/**` | Automation implementation and verification | Controlled write surface |
+
+## Core workflow
+
+1. Ingest source content from `raw/inbox/**`.
+2. Generate/update wiki pages (`wiki/sources/**`, `wiki/entities/**`, `wiki/concepts/**`).
+3. Rebuild deterministic index (`wiki/index.md`).
+4. Append `wiki/log.md` only when a real state change occurred.
+5. Move successfully ingested inputs to `raw/processed/**`.
+6. Enforce strict lint and test gates before write-capable automation proceeds.
+
+## Automation model (CI-1..CI-3)
+
+| CI | Responsibility | Write capability |
+|---|---|---|
+| **CI-1** | Trusted-trigger gatekeeper/handoff | No |
+| **CI-2** | Read-only diagnostics and analysis | No |
+| **CI-3** | PR-producing write path with allowlists and preflight | Yes (allowlisted paths only) |
+
+This split is intentional: it isolates trust checks, diagnostics, and write operations
+so permission scope can stay minimal for each path.
+
+## Write and safety controls
+
+- Canonical write allowlist for automation: `wiki/**`, `wiki/index.md`, `wiki/log.md`, `raw/processed/**`.
+- Raw immutability: `raw/processed/**` must not be mutated after ingest.
+- Concurrency guard: workflow-level concurrency group plus local lock file (`wiki/.kb_write.lock`).
+- Fail-closed behavior: missing prerequisites, permission mismatches, or lock contention stop writes.
+- Policy-gated query persistence: write only when `auto_persist_when_high_value` criteria pass.
+
+## Decision records
+
+Key architecture decisions are captured in ADRs:
+
+- [`ADR-001`](decisions/ADR-001-persistent-wiki-architecture.md): persistent repository-scoped wiki model
+- [`ADR-002`](decisions/ADR-002-frontmatter-and-sourceref-contract.md): required frontmatter and SourceRef provenance
+- [`ADR-003`](decisions/ADR-003-policy-gated-query-persistence.md): deterministic query-persist policy and envelopes
+- [`ADR-004`](decisions/ADR-004-split-ci-workflow-governance.md): split CI governance and permission profiles
+- [`ADR-005`](decisions/ADR-005-write-concurrency-guards.md): workflow + local lock concurrency model
+- [`ADR-006`](decisions/ADR-006-authoritative-source-boundary.md): repository-local authoritative source boundary

--- a/docs/decisions/ADR-001-persistent-wiki-architecture.md
+++ b/docs/decisions/ADR-001-persistent-wiki-architecture.md
@@ -1,0 +1,54 @@
+# ADR-001: Adopt a persistent repository-scoped wiki architecture
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+The knowledgebase needs cumulative, auditable output that can be reviewed and
+improved over time. Query-time-only retrieval would not preserve synthesized
+artifacts or operational history in repository state.
+
+The spec requires:
+
+- a durable wiki layer under `wiki/**`,
+- explicit source zones under `raw/**`,
+- append-only audit behavior for state changes,
+- and deterministic scripts/tests around those surfaces.
+
+## Decision
+
+Adopt a persistent repository-scoped wiki model with these structural boundaries:
+
+- `raw/inbox/**` for untrusted incoming sources,
+- `raw/processed/**` for immutable post-ingest source artifacts,
+- `wiki/**` for generated knowledge artifacts (`sources`, `entities`, `concepts`, `analyses`),
+- `wiki/index.md` as deterministic discovery anchor,
+- `wiki/log.md` as append-only audit log for state changes.
+
+## Alternatives considered
+
+### Query-time-only RAG (no persistent wiki artifacts)
+
+- **Pros:** lower storage overhead, simpler write surface.
+- **Cons:** poor auditability, weak long-term knowledge compounding, less reviewable history.
+- **Rejected:** conflicts with repository-first knowledge accumulation goals.
+
+### External knowledge store as primary state
+
+- **Pros:** potentially richer indexing/serving features.
+- **Cons:** reduced git-native auditability and higher integration overhead for MVP.
+- **Rejected:** MVP requires repository-local, reviewable state as source of truth.
+
+## Consequences
+
+- Wiki artifacts become first-class repository outputs and review surfaces.
+- Ingest/index/lint/persist tooling must preserve deterministic behavior.
+- Git history and `wiki/log.md` jointly provide operational audit evidence.
+
+## References
+
+- `raw/inbox/SPEC.md` (Objective; Scope; Architecture and Repository Structure; Decision Log)

--- a/docs/decisions/ADR-002-frontmatter-and-sourceref-contract.md
+++ b/docs/decisions/ADR-002-frontmatter-and-sourceref-contract.md
@@ -1,0 +1,53 @@
+# ADR-002: Require frontmatter schema and canonical SourceRef provenance
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+Generated wiki content must remain verifiable and safe for future automation.
+Without strict metadata and provenance rules, claims become hard to audit and
+sensitivity handling can drift.
+
+The spec defines mandatory frontmatter fields and a canonical SourceRef format:
+
+`repo://<owner>/<repo>/<path>@<git_sha>#<anchor>?sha256=<64-hex>`
+
+## Decision
+
+Require all generated wiki pages to include the frontmatter contract from the spec,
+including `type`, `status`, `sources`, `open_questions`, `confidence`,
+`sensitivity`, `updated_at`, and `tags`.
+
+Require `sources` entries to be canonical SourceRef values with:
+
+1. an anchor (`#Lx-Ly` or `#asset`),
+2. a `sha256` checksum,
+3. repository-relative paths scoped to `raw/inbox/**`, `raw/processed/**`, or `raw/assets/**`.
+
+## Alternatives considered
+
+### Looser metadata with optional fields
+
+- **Pros:** lower authoring overhead.
+- **Cons:** weaker validation, inconsistent policy enforcement, poorer downstream automation reliability.
+- **Rejected:** conflicts with deterministic ingest/lint and traceability requirements.
+
+### Path-only citations without checksum
+
+- **Pros:** simpler citation strings.
+- **Cons:** cannot detect content drift; provenance becomes ambiguous across revisions.
+- **Rejected:** checksum is required for reliable integrity guarantees.
+
+## Consequences
+
+- Ingest/lint tooling must validate frontmatter completeness and SourceRef shape.
+- Provenance checks become deterministic and testable.
+- Sensitive-content classification is explicit and machine-checkable.
+
+## References
+
+- `raw/inbox/SPEC.md` (Assumptions and Defaults; Terminology; Frontmatter Contract; Security and Trust Model)

--- a/docs/decisions/ADR-003-policy-gated-query-persistence.md
+++ b/docs/decisions/ADR-003-policy-gated-query-persistence.md
@@ -1,0 +1,54 @@
+# ADR-003: Enforce policy-gated query persistence with machine-readable envelopes
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+Persisting every query result would create noise and weak signal quality in
+`wiki/analyses/**`. Automation also needs deterministic outcomes for both write
+and no-write scenarios.
+
+The spec introduces `auto_persist_when_high_value` and requires result envelopes
+for write-capable paths.
+
+## Decision
+
+Use `auto_persist_when_high_value` as the default persistence gate.
+
+Persist query outputs only when all conditions hold:
+
+1. `confidence >= 4`,
+2. at least two source references,
+3. no unresolved contradiction flag.
+
+Require machine-readable JSON envelopes on automation paths with stable fields:
+`status`, `reason_code`, `policy`, `analysis_path`, `index_updated`,
+`log_appended`, and `sources`.
+
+## Alternatives considered
+
+### Always persist query outputs
+
+- **Pros:** captures every run.
+- **Cons:** high noise, low average quality, increased review burden.
+- **Rejected:** does not meet high-value-only persistence goal.
+
+### Manual-only persistence
+
+- **Pros:** human quality control before writes.
+- **Cons:** lower throughput and inconsistent behavior across runs.
+- **Rejected:** MVP requires deterministic automation behavior with explicit policy gates.
+
+## Consequences
+
+- Automation can distinguish policy no-write from hard failures without ambiguity.
+- `wiki/analyses/**` remains higher signal with bounded growth.
+- Downstream workflows can key behavior on stable envelope values.
+
+## References
+
+- `raw/inbox/SPEC.md` (Assumptions and Defaults; Machine-readable result envelopes; Interface contract matrix; Final Ambiguity Checklist)

--- a/docs/decisions/ADR-004-split-ci-workflow-governance.md
+++ b/docs/decisions/ADR-004-split-ci-workflow-governance.md
@@ -1,0 +1,50 @@
+# ADR-004: Split CI governance into gatekeeper, analyst, and PR-producing workflows
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+Knowledgebase automation needs strong trust boundaries and least-privilege
+permissions while still supporting end-to-end ingest and update flows.
+
+A single monolithic workflow would combine trigger validation, diagnostics, and
+write operations under one permission context, increasing risk.
+
+## Decision
+
+Adopt the three-workflow governance model:
+
+- **CI-1:** trusted-trigger gatekeeper/handoff (`tp-gatekeeper`).
+- **CI-2:** read-only diagnostics/analysis (`tp-analyst-readonly`).
+- **CI-3:** PR-producing write-capable path (`tp-pr-producer`).
+
+Enforce fail-closed preflight checks for trust context, permissions scope,
+allowlisted write paths, and prerequisite readiness before write-capable steps.
+
+## Alternatives considered
+
+### Monolithic all-in-one workflow
+
+- **Pros:** fewer workflow files and handoffs.
+- **Cons:** weaker privilege isolation, harder auditing, larger blast radius on failure.
+- **Rejected:** conflicts with least-privilege and explicit boundary requirements.
+
+### Direct-main write automation
+
+- **Pros:** lower latency from ingest to main.
+- **Cons:** bypasses PR-centered review gates and increases governance risk.
+- **Rejected:** incompatible with controlled merge and review model.
+
+## Consequences
+
+- Permission scope is explicit and bounded per workflow role.
+- Trust gating and diagnostics are independently observable.
+- Write-capable operations remain constrained to PR-producing automation.
+
+## References
+
+- `raw/inbox/SPEC.md` (gh-aw Automation Model; Token permission profiles; Runtime prerequisite checks; CI quality gate requirements; Security and Trust Model)

--- a/docs/decisions/ADR-005-write-concurrency-guards.md
+++ b/docs/decisions/ADR-005-write-concurrency-guards.md
@@ -1,0 +1,48 @@
+# ADR-005: Enforce write concurrency with workflow group and local file lock
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+Concurrent write-capable runs can race while updating shared wiki artifacts
+(`wiki/index.md`, `wiki/log.md`, and generated pages). Workflow-level controls
+alone do not cover all local write races, while local locks alone do not guard
+parallel workflow dispatch.
+
+## Decision
+
+Use a dual-layer concurrency control model:
+
+1. workflow-level `concurrency.group` for write-capable CI paths,
+2. local exclusive lock file (`wiki/.kb_write.lock`) inside write-capable scripts.
+
+Lock contention must fail closed, return non-zero, and emit
+`reason_code=lock_unavailable` in machine-readable envelopes.
+
+## Alternatives considered
+
+### Workflow concurrency only
+
+- **Pros:** simple CI-level guard.
+- **Cons:** does not prevent all runtime-level local lock races.
+- **Rejected:** insufficient protection for script-level shared state.
+
+### Local lock only
+
+- **Pros:** protects local write critical sections.
+- **Cons:** weaker control over workflow-level parallelization and queue behavior.
+- **Rejected:** insufficient end-to-end orchestration for CI write paths.
+
+## Consequences
+
+- Write race conditions are substantially reduced.
+- Failure mode is explicit and diagnosable.
+- Automation remains deterministic under parallel triggering conditions.
+
+## References
+
+- `raw/inbox/SPEC.md` (Assumptions and Defaults; Concurrency controls; Runtime prerequisite checks; CI quality gate requirements)

--- a/docs/decisions/ADR-006-authoritative-source-boundary.md
+++ b/docs/decisions/ADR-006-authoritative-source-boundary.md
@@ -1,0 +1,47 @@
+# ADR-006: Restrict authoritative ingestion scope to repository-local inputs
+
+## Status
+Accepted
+
+## Date
+2026-04-12
+
+## Context
+
+The MVP must prevent uncontrolled corpus expansion and preserve provenance
+quality. Unbounded external input ingestion introduces trust and verification
+risks that are difficult to audit.
+
+## Decision
+
+Define authoritative source scope as:
+
+- repository-local sources under `raw/inbox/**`,
+- checksummed external assets vendored under `raw/assets/**`.
+
+Treat all non-vendored or non-checksummed external material as citation-only
+context in MVP (not authoritative ingest input).
+
+## Alternatives considered
+
+### Allow arbitrary external URLs/files as authoritative inputs
+
+- **Pros:** broader source coverage with less prep work.
+- **Cons:** weak provenance guarantees and larger abuse surface.
+- **Rejected:** violates deterministic trust-boundary requirements.
+
+### Disallow all external assets
+
+- **Pros:** simplest trust model.
+- **Cons:** blocks valid asset-backed evidence use cases needed in practice.
+- **Rejected:** too restrictive for expected knowledgebase workflows.
+
+## Consequences
+
+- Corpus scope remains bounded and auditable.
+- External assets can still be used authoritatively when vendored and checksummed.
+- Tooling and tests must enforce checksum and path-boundary rules.
+
+## References
+
+- `raw/inbox/SPEC.md` (Assumptions and Defaults; Scope; Canonical sources format; Security and Trust Model; Threat model mapping)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+This directory captures durable architecture and governance decisions derived from
+[`raw/inbox/SPEC.md`](../../raw/inbox/SPEC.md).
+
+## ADR index
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-001](ADR-001-persistent-wiki-architecture.md) | Adopt a persistent repository-scoped wiki architecture | Accepted |
+| [ADR-002](ADR-002-frontmatter-and-sourceref-contract.md) | Require frontmatter schema and canonical SourceRef provenance | Accepted |
+| [ADR-003](ADR-003-policy-gated-query-persistence.md) | Enforce policy-gated query persistence with machine-readable envelopes | Accepted |
+| [ADR-004](ADR-004-split-ci-workflow-governance.md) | Split CI governance into gatekeeper, analyst, and PR-producing workflows | Accepted |
+| [ADR-005](ADR-005-write-concurrency-guards.md) | Enforce write concurrency with workflow group and local file lock | Accepted |
+| [ADR-006](ADR-006-authoritative-source-boundary.md) | Restrict authoritative ingestion scope to repository-local inputs | Accepted |

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -79,8 +79,8 @@ python3 -m unittest discover -s tests -p "test_*.py"
 
 | Gate | Concrete evidence in this repo |
 |---|---|
-| **M0: terminology/assumptions freeze** | `SPEC.md` (Assumptions/Terminology sections) + `tests/kb/test_contracts.py` (canonical policy IDs, token profiles, reason/envelope constants). |
+| **M0: terminology/assumptions freeze** | `raw/inbox/SPEC.md` (Assumptions/Terminology sections) + `tests/kb/test_contracts.py` (canonical policy IDs, token profiles, reason/envelope constants). |
 | **M1: interface executability** | `scripts/kb/ingest.py`, `update_index.py`, `lint_wiki.py`, `qmd_preflight.py`, `persist_query.py`; validated by `tests/kb/test_ingest.py`, `test_update_index.py`, `test_lint_wiki.py`, `test_qmd_preflight.py`, `test_persist_query.py`. |
 | **M2: security/automation enforcement** | `.github/workflows/ci-1-gatekeeper.yml`, `ci-2-analyst-diagnostics.yml`, `ci-3-pr-producer.yml`; enforced by `tests/kb/test_ci1_workflow.py`, `test_ci2_workflow.py`, `test_ci3_workflow.py`, `test_ci_permission_asserts.py`. |
-| **M3: verification readiness** | `SPEC.md` Verification Matrix + `tests/kb/test_unit_verification_matrix.py`, `test_integration_verification_matrix.py`, `test_regression_verification_matrix.py`. |
-| **M4: pre-implementation go/no-go** | `SPEC.md` Implementation-ready milestone gates + Final Pre-Implementation Ambiguity Review Checklist, plus this runbook (`docs/mvp-runbook.md`) as executable operator evidence. |
+| **M3: verification readiness** | `raw/inbox/SPEC.md` Verification Matrix + `tests/kb/test_unit_verification_matrix.py`, `test_integration_verification_matrix.py`, `test_regression_verification_matrix.py`. |
+| **M4: pre-implementation go/no-go** | `raw/inbox/SPEC.md` Implementation-ready milestone gates + Final Pre-Implementation Ambiguity Review Checklist, plus this runbook (`docs/mvp-runbook.md`) as executable operator evidence. |

--- a/tests/kb/test_ci1_workflow.py
+++ b/tests/kb/test_ci1_workflow.py
@@ -14,6 +14,10 @@ import unittest
 WORKFLOW_PATH = Path(".github/workflows/ci-1-gatekeeper.yml")
 
 
+def _leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
 def _parse_top_level_mapping_block(text: str, key: str) -> dict[str, str]:
     lines = text.splitlines()
     target = f"{key}:"
@@ -47,33 +51,35 @@ def _extract_ci1_preflight_script(workflow_text: str) -> str:
     )
     if step_start is None:
         raise AssertionError("Unable to locate CI-1 trusted-trigger preflight step")
+    step_indent = _leading_spaces(lines[step_start])
 
     run_index = next(
         (
             index
             for index in range(step_start + 1, len(lines))
-            if lines[index].strip() == "run: |"
+            if lines[index].strip() == "run: |" and _leading_spaces(lines[index]) > step_indent
         ),
         None,
     )
     if run_index is None:
         raise AssertionError("Unable to locate run block for CI-1 trusted-trigger preflight step")
+    run_indent = _leading_spaces(lines[run_index])
 
-    script_lines: list[str] = []
+    raw_script_lines: list[str] = []
     for line in lines[run_index + 1 :]:
-        if line.startswith("      - name: "):
+        if line.strip() and _leading_spaces(line) <= run_indent:
             break
-        if line.startswith("          "):
-            script_lines.append(line[10:])
-            continue
         if line.strip() == "":
-            script_lines.append("")
+            raw_script_lines.append("")
             continue
-        break
+        raw_script_lines.append(line)
 
-    if not script_lines:
+    non_empty_lines = [line for line in raw_script_lines if line.strip()]
+    if not non_empty_lines:
         raise AssertionError("CI-1 trusted-trigger preflight run block is empty")
 
+    script_indent = min(_leading_spaces(line) for line in non_empty_lines)
+    script_lines = [line[script_indent:] if line.strip() else "" for line in raw_script_lines]
     return "\n".join(script_lines)
 
 
@@ -249,6 +255,33 @@ class Ci1WorkflowContractTests(unittest.TestCase):
         combined_output = f"{result.stdout}\n{result.stderr}"
         self.assertEqual(result.returncode, 0, combined_output)
         self.assertIn("CI-1 gatekeeper preflight PASS", combined_output)
+
+    def test_preflight_script_extraction_handles_alternate_indentation(self) -> None:
+        workflow_text = textwrap.dedent(
+            """\
+            name: CI-1 Gatekeeper Trusted Handoff
+            jobs:
+              gatekeeper:
+                runs-on: ubuntu-latest
+                steps:
+                    - name: Run CI-1 trusted-trigger preflight checks
+                      run: |
+                        set -euo pipefail
+                        echo "ok"
+                    - name: Next step
+                      run: echo "done"
+            """
+        )
+        script = _extract_ci1_preflight_script(workflow_text)
+        self.assertEqual(
+            script,
+            textwrap.dedent(
+                """\
+                set -euo pipefail
+                echo "ok"
+                """
+            ).strip(),
+        )
 
     def test_preflight_behavior_rejects_non_push_events(self) -> None:
         result = _run_ci1_preflight_script(


### PR DESCRIPTION
Update CI workflow and knowledgebase documentation for clearer governance, including architecture decision records and quick-start guidance.\n\nAlso addresses PR review feedback by hardening CI-1 preflight script extraction in tests (removing hardcoded indentation assumptions) and adding an indentation-variation regression test so workflow formatting changes are less brittle.