### PR TITLE
🔒 [security] Fix command injection in getGitRepoInfo

### DIFF
--- a/scripts/fleet/github/git.test.ts
+++ b/scripts/fleet/github/git.test.ts
@@ -1,0 +1,30 @@
+import { expect, test, describe } from "bun:test";
+import { getGitRepoInfo, getCurrentBranch, parseGitRemoteUrl } from "./git.ts";
+
+describe("git utils", () => {
+  test("parseGitRemoteUrl handles HTTPS", () => {
+    const info = parseGitRemoteUrl("https://github.com/owner/repo.git");
+    expect(info.owner).toBe("owner");
+    expect(info.repo).toBe("repo");
+    expect(info.fullName).toBe("owner/repo");
+  });
+
+  test("parseGitRemoteUrl handles SSH", () => {
+    const info = parseGitRemoteUrl("git@github.com:owner/repo.git");
+    expect(info.owner).toBe("owner");
+    expect(info.repo).toBe("repo");
+    expect(info.fullName).toBe("owner/repo");
+  });
+
+  test("getGitRepoInfo works", async () => {
+    const info = await getGitRepoInfo("origin");
+    expect(info.owner).toBeDefined();
+    expect(info.repo).toBeDefined();
+  });
+
+  test("getCurrentBranch works", async () => {
+    const branch = await getCurrentBranch();
+    expect(branch).toBeDefined();
+    expect(branch.length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/fleet/github/git.test.ts
+++ b/scripts/fleet/github/git.test.ts
@@ -1,30 +1,78 @@
-import { expect, test, describe } from "bun:test";
-import { getGitRepoInfo, getCurrentBranch, parseGitRemoteUrl } from "./git.ts";
+import { expect, test, describe, mock } from "bun:test";
+import * as git from "./git.ts";
 
 describe("git utils", () => {
   test("parseGitRemoteUrl handles HTTPS", () => {
-    const info = parseGitRemoteUrl("https://github.com/owner/repo.git");
+    const info = git.parseGitRemoteUrl("https://github.com/owner/repo.git");
     expect(info.owner).toBe("owner");
     expect(info.repo).toBe("repo");
     expect(info.fullName).toBe("owner/repo");
   });
 
   test("parseGitRemoteUrl handles SSH", () => {
-    const info = parseGitRemoteUrl("git@github.com:owner/repo.git");
+    const info = git.parseGitRemoteUrl("git@github.com:owner/repo.git");
     expect(info.owner).toBe("owner");
     expect(info.repo).toBe("repo");
     expect(info.fullName).toBe("owner/repo");
   });
 
-  test("getGitRepoInfo works", async () => {
-    const info = await getGitRepoInfo("origin");
-    expect(info.owner).toBeDefined();
-    expect(info.repo).toBeDefined();
+  test("getGitRepoInfo calls git remote get-url with correct arguments", async () => {
+    const mockExecFileAsync = mock((file: string, args: string[]) => {
+      if (file === "git" && args[0] === "remote" && args[1] === "get-url") {
+        return Promise.resolve({ stdout: "https://github.com/owner/repo.git\n" });
+      }
+      return Promise.reject(new Error("Unknown command"));
+    });
+
+    git.gitCommands.execFileAsync = mockExecFileAsync as any;
+
+    const info = await git.getGitRepoInfo("origin");
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["remote", "get-url", "--", "origin"]);
+    expect(info.fullName).toBe("owner/repo");
   });
 
-  test("getCurrentBranch works", async () => {
-    const branch = await getCurrentBranch();
-    expect(branch).toBeDefined();
-    expect(branch.length).toBeGreaterThan(0);
+  test("getCurrentBranch calls git rev-parse with correct arguments", async () => {
+    const mockExecFileAsync = mock((file: string, args: string[]) => {
+      if (file === "git" && args[0] === "rev-parse") {
+        return Promise.resolve({ stdout: "main\n" });
+      }
+      return Promise.reject(new Error("Unknown command"));
+    });
+
+    git.gitCommands.execFileAsync = mockExecFileAsync as any;
+
+    const branch = await git.getCurrentBranch();
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+    expect(branch).toBe("main");
+  });
+});
+
+describe("security regressions", () => {
+  test("getGitRepoInfo handles malicious remote names safely (no shell injection)", async () => {
+    const mockExecFileAsync = mock((file: string, args: string[]) => {
+      return Promise.resolve({ stdout: "https://github.com/owner/repo.git\n" });
+    });
+    git.gitCommands.execFileAsync = mockExecFileAsync as any;
+
+    const malicious = "origin; echo pwned";
+    const info = await git.getGitRepoInfo(malicious);
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["remote", "get-url", "--", malicious]);
+    expect(info.fullName).toBe("owner/repo");
+  });
+
+  test("getGitRepoInfo handles malicious remote names safely (no option injection)", async () => {
+    const mockExecFileAsync = mock((file: string, args: string[]) => {
+      return Promise.resolve({ stdout: "https://github.com/owner/repo.git\n" });
+    });
+    git.gitCommands.execFileAsync = mockExecFileAsync as any;
+
+    const malicious = "--help";
+    const info = await git.getGitRepoInfo(malicious);
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith("git", ["remote", "get-url", "--", malicious]);
+    expect(info.fullName).toBe("owner/repo");
   });
 });

--- a/scripts/fleet/github/git.ts
+++ b/scripts/fleet/github/git.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface GitRepoInfo {
   owner: string;
@@ -37,7 +37,7 @@ export interface GitRepoInfo {
  * console.log(repo.fullName); // "owner/repo"
  */
 export async function getGitRepoInfo(remoteName = "origin"): Promise<GitRepoInfo> {
-  const { stdout } = await execAsync(`git remote get-url ${remoteName}`);
+  const { stdout } = await execFileAsync("git", ["remote", "get-url", remoteName]);
   const remoteUrl = stdout.trim();
   
   return parseGitRemoteUrl(remoteUrl);
@@ -86,6 +86,6 @@ export function parseGitRemoteUrl(remoteUrl: string): GitRepoInfo {
  * @throws Error if not in a git repository
  */
 export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+  const { stdout } = await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();
 }

--- a/scripts/fleet/github/git.ts
+++ b/scripts/fleet/github/git.ts
@@ -15,7 +15,9 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execFileAsync = promisify(execFile);
+export const gitCommands = {
+  execFileAsync: promisify(execFile)
+};
 
 export interface GitRepoInfo {
   owner: string;
@@ -37,7 +39,7 @@ export interface GitRepoInfo {
  * console.log(repo.fullName); // "owner/repo"
  */
 export async function getGitRepoInfo(remoteName = "origin"): Promise<GitRepoInfo> {
-  const { stdout } = await execFileAsync("git", ["remote", "get-url", remoteName]);
+  const { stdout } = await gitCommands.execFileAsync("git", ["remote", "get-url", "--", remoteName]);
   const remoteUrl = stdout.trim();
   
   return parseGitRemoteUrl(remoteUrl);
@@ -86,6 +88,6 @@ export function parseGitRemoteUrl(remoteUrl: string): GitRepoInfo {
  * @throws Error if not in a git repository
  */
 export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const { stdout } = await gitCommands.execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();
 }


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in the `getGitRepoInfo` function in `scripts/fleet/github/git.ts`.

⚠️ **Risk:** The previous implementation used `exec` with string interpolation for the `remoteName` parameter. An attacker could provide a malicious remote name (e.g., `origin; rm -rf /`) to execute arbitrary commands on the system.

🛡️ **Solution:** Switched from `exec` to `execFile`. This ensures that the `remoteName` is treated as a literal argument to the `git` command rather than being interpreted by a shell. I also proactively updated `getCurrentBranch` to use `execFile` for improved security and consistency. Unit tests were added to verify the functionality and a temporary reproduction script confirmed the fix.

---
*PR created automatically by Jules for task [3314562215902451522](https://jules.google.com/task/3314562215902451522) started by @wryenmeek*