### PR TITLE
🧪 Add unit test for lock_unavailable_reason

### DIFF
--- a/tests/kb/test_write_utils.py
+++ b/tests/kb/test_write_utils.py
@@ -63,6 +63,19 @@ class WriteUtilitiesTests(unittest.TestCase):
 
         return json.loads(completed.stdout.strip().splitlines()[-1])
 
+    def test_lock_unavailable_reason_returns_deterministic_string(self) -> None:
+        # Default path
+        self.assertEqual(
+            write_utils.lock_unavailable_reason(),
+            f"{contracts.ReasonCode.LOCK_UNAVAILABLE.value}:{contracts.WRITE_LOCK_PATH}",
+        )
+        # Custom path
+        custom_path = "custom/lock.path"
+        self.assertEqual(
+            write_utils.lock_unavailable_reason(custom_path),
+            f"{contracts.ReasonCode.LOCK_UNAVAILABLE.value}:{custom_path}",
+        )
+
     def test_exclusive_write_lock_uses_spec_lock_path(self) -> None:
         with write_utils.exclusive_write_lock(self.workspace_root) as lock_path:
             self.assertEqual(lock_path, self.workspace_root / contracts.WRITE_LOCK_PATH)


### PR DESCRIPTION
Added a unit test for `lock_unavailable_reason` to `tests/kb/test_write_utils.py`. The test verifies that the function returns the correct string format for both default and custom lock paths. I also verified the test by temporarily breaking the implementation and confirming it fails, then reverting and confirming it passes. All 79 tests in `tests/kb/` passed.

---
*PR created automatically by Jules for task [11172900815105805574](https://jules.google.com/task/11172900815105805574) started by @wryenmeek*