### PR TITLE
⚡ Bolt: Optimize path operations in wiki linter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-14 - [Pathlib Operations Performance Anti-pattern]
+**Learning:** Eager `pathlib.Path.resolve()` calls inside hot loops (like `Path.rglob()`) cause a severe performance bottleneck due to excessive and expensive OS stat calls. Additionally, using `try/except Path.relative_to()` for bounds checking is slower and less pythonic than `Path.is_relative_to()`.
+**Action:** Remove eager `.resolve()` calls in hot loops when iterating over paths, resolving only when strictly necessary. Use `.is_relative_to()` for bounds checking instead of `try/except ValueError` with `.relative_to()`.

--- a/scripts/kb/lint_wiki.py
+++ b/scripts/kb/lint_wiki.py
@@ -127,16 +127,17 @@ def _resolve_internal_markdown_target(
 
 
 def _display_path(path: Path, wiki_root: Path) -> str:
-    try:
+    # ⚡ Bolt Optimization: Use is_relative_to instead of try/except for bounds checking
+    if path.is_relative_to(wiki_root):
         return str(path.relative_to(wiki_root))
-    except ValueError:
-        return str(path)
+    return str(path)
 
 
 def lint_wiki(wiki_root: Path) -> list[Violation]:
     """Run lint checks over markdown pages under wiki_root."""
     wiki_root = wiki_root.resolve()
-    pages = sorted(path.resolve() for path in wiki_root.rglob("*.md") if path.is_file())
+    # ⚡ Bolt Optimization: Avoid eager resolve() in hot loop to save OS stat calls
+    pages = sorted(path for path in wiki_root.rglob("*.md") if path.is_file())
 
     violations: list[Violation] = []
     referenced_by: dict[Path, set[Path]] = {page: set() for page in pages}


### PR DESCRIPTION
💡 What: Removed an eager `.resolve()` call inside the hot `rglob` loop in `lint_wiki.py` and replaced the `try/except ValueError` with a direct `.is_relative_to()` check for bounding paths.
🎯 Why: `.resolve()` triggers an expensive `stat` OS call for every segment of every path. Doing this inside a large recursive glob loop leads to a significant performance bottleneck. Additionally, `is_relative_to` is a faster and more Pythonic way to do bounds checking compared to catching an exception.
📊 Impact: Considerably faster execution of `lint_wiki.py` on large wiki structures by reducing OS calls.
🔬 Measurement: Can be verified by running the linter across a large knowledge base and comparing the overall execution time or profiling the script to observe a drop in system calls.

---
*PR created automatically by Jules for task [15517909455230311263](https://jules.google.com/task/15517909455230311263) started by @wryenmeek*