### PR TITLE
🧪 test coverage for sourceref whitespace inputs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,8 @@
 - Established baseline: ~0.22s
 - Improved time: ~0.18s
 - Impact: 18% execution time reduction and lower peak memory allocations because generators `rglob` are now streamed continuously in parallel chunks into `ProcessPoolExecutor` without materializing in memory just to be sorted. On larger wikis, the impact of avoiding `N log N` operations and an entire secondary `N` OS stat traversal scales highly.
+
+## 🧪 test coverage for sourceref whitespace inputs
+
+- Learned that `scripts/kb/sourceref.py` implements input validation.
+- Enhanced boundary conditions tests by ensuring various types of whitespace are handled correctly by the parser in `validate_sourceref`.

--- a/tests/kb/test_sourceref.py
+++ b/tests/kb/test_sourceref.py
@@ -80,7 +80,7 @@ class SourceRefValidatorTests(unittest.TestCase):
                 self.assertEqual(ctx.exception.reason_code, expected_reason)
 
     def test_empty_string(self) -> None:
-        cases = ("", "   ")
+        cases = ("", "   ", "\n", "\t", "\r\n")
         for value in cases:
             with self.subTest(value=value):
                 with self.assertRaises(SourceRefValidationError) as ctx:


### PR DESCRIPTION
🎯 **What:** The `validate_sourceref` function requires a test validating that empty strings correctly raise the `SourceRefReasonCode.INVALID_FORMAT` validation error. Previously, only space (`" "`) characters and `""` strings were tested.
📊 **Coverage:** This PR expands testing to cover all whitespace structures, including carriage returns, tabs, and newline literals (`"\n"`, `"\t"`, `"\r\n"`). The unit testing suite ensures the boundary validations correctly capture and handle invalid empty/whitespace combinations gracefully.
✨ **Result:** Improved robustness by confirming string formatting restrictions across a wider array of invalid blank inputs for testing stability.

---
*PR created automatically by Jules for task [1260265772475979147](https://jules.google.com/task/1260265772475979147) started by @wryenmeek*