### PR TITLE
⚡ Bolt: Use `Path.is_relative_to()` for faster bounds checking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 **💡 Learning:** `Path.resolve()` is significantly slower than building and asserting paths, and `Path.is_relative_to()` is much faster than `Path.relative_to()`. When validating large amounts of files, defer resolving to absolute paths if not necessary.
 
 **🎯 Action:** Replace `Path.relative_to(root)` in try/except blocks with `Path.is_relative_to(root)`. Avoid unnecessary `Path.resolve()` calls in hot paths like link target resolution in the wiki linter.
+## 2026-04-15 - [Path bounds checking optimization]
+**Learning:** Using `try/except Path.relative_to()` is slower than the natively implemented string comparison under the hood of `Path.is_relative_to()` for bounds checking. This is an anti-pattern that slows down path validation logic.
+**Action:** Replace `try/except Path.relative_to()` with `Path.is_relative_to()` for performance gains across the python codebase.

--- a/scripts/kb/ingest.py
+++ b/scripts/kb/ingest.py
@@ -356,14 +356,13 @@ def _resolve_path_within_repo(repo_root: Path, raw_path: str) -> tuple[Path, str
     resolved = (candidate if candidate.is_absolute() else (repo_root / candidate)).resolve(
         strict=False
     )
-    try:
-        relative = resolved.relative_to(repo_root)
-    except ValueError as exc:
+    # ⚡ Bolt Optimization: Use is_relative_to instead of try/except for bounds checking
+    if not resolved.is_relative_to(repo_root):
         raise IngestError(
             contracts.ReasonCode.INVALID_INPUT.value,
             f"path escapes repository boundary: {raw_path}",
-        ) from exc
-    return resolved, relative.as_posix()
+        )
+    return resolved, resolved.relative_to(repo_root).as_posix()
 
 
 def _resolve_inbox_path(repo_root: Path, raw_path: str) -> tuple[Path, str]:

--- a/scripts/kb/persist_query.py
+++ b/scripts/kb/persist_query.py
@@ -135,10 +135,9 @@ def _resolve_within_repo(repo_root: Path, raw_path: str, *, label: str) -> Path:
     if not candidate.is_absolute():
         candidate = repo_root / candidate
     resolved = candidate.resolve()
-    try:
-        resolved.relative_to(repo_root)
-    except ValueError as exc:
-        raise PersistQueryInputError(f"{label} escapes repository boundary: {raw_path}") from exc
+    # ⚡ Bolt Optimization: Use is_relative_to instead of try/except for bounds checking
+    if not resolved.is_relative_to(repo_root):
+        raise PersistQueryInputError(f"{label} escapes repository boundary: {raw_path}")
     return resolved
 
 

--- a/scripts/kb/qmd_preflight.py
+++ b/scripts/kb/qmd_preflight.py
@@ -225,9 +225,8 @@ def _resolve_resource_path(repo_root: Path, resource: str) -> Path | None:
     if not candidate.is_absolute():
         candidate = repo_root / candidate
     resolved_candidate = candidate.resolve()
-    try:
-        resolved_candidate.relative_to(repo_root)
-    except ValueError:
+    # ⚡ Bolt Optimization: Use is_relative_to instead of try/except for bounds checking
+    if not resolved_candidate.is_relative_to(repo_root):
         return None
     return resolved_candidate
 


### PR DESCRIPTION
💡 What: Replaced `try/except Path.relative_to()` with `Path.is_relative_to()` for bounds checking across `scripts/kb/qmd_preflight.py`, `scripts/kb/ingest.py`, and `scripts/kb/persist_query.py`.
🎯 Why: Exception handling has overhead in Python. Furthermore, `is_relative_to()` directly computes string comparison without needing to construct a new Path object just to test bounds and discard it.
📊 Impact: Micro-optimization reducing object allocation and path manipulation overhead for path validation logic inside python tools.
🔬 Measurement: Verify with `python3 -m unittest discover -s tests -p "test_*.py"`.

---
*PR created automatically by Jules for task [14484425701813540307](https://jules.google.com/task/14484425701813540307) started by @wryenmeek*