### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in git utility

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** GITHUB_TOKEN and JULES_API_KEY were partially validated and redacted across different fleet scripts, leading to potential sensitive key exposure in error logs and missing validations where they were needed.
 **Learning:** Partial token validation and redaction across a multi-script fleet can lead to sensitive key leakage. Every script must validate all necessary keys on startup and ensure redaction utilities cover all sensitive tokens.
 **Prevention:** Centralize token validation and redaction logic. Ensure any string interpolation or logging involving potentially tainted input uses a comprehensive redaction utility for all known sensitive keys in the environment.
+
+## 2026-04-16 - [Command Injection via exec]
+**Vulnerability:** Shell and option injection vulnerability in `scripts/fleet/github/git.ts` due to dynamic arguments being interpolated directly into `child_process.exec()` strings (e.g., `git remote get-url ${remoteName}`).
+**Learning:** Using `exec()` with variable arguments exposes CLI utilities to both shell syntax injection (e.g., `; echo pwned`) and option injection (e.g., `--help` or other flags that alter command behavior). This was particularly risky here because fleet operates on potentially untrusted repositories.
+**Prevention:** Always use `child_process.execFile()` instead of `exec()` when invoking shell commands with variable arguments. Additionally, ensure the `--` separator is passed before the variable argument list to prevent option injection attacks. Wrap standard node module exports in an object (e.g., `export const gitCommands = { ... }`) to permit unit test mocking under Bun's module resolution.

--- a/scripts/fleet/github/git.ts
+++ b/scripts/fleet/github/git.ts
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+export const gitCommands = {
+  execFileAsync: promisify(execFile)
+};
 
 export interface GitRepoInfo {
   owner: string;
@@ -37,7 +39,7 @@ export interface GitRepoInfo {
  * console.log(repo.fullName); // "owner/repo"
  */
 export async function getGitRepoInfo(remoteName = "origin"): Promise<GitRepoInfo> {
-  const { stdout } = await execAsync(`git remote get-url ${remoteName}`);
+  const { stdout } = await gitCommands.execFileAsync("git", ["remote", "get-url", "--", remoteName]);
   const remoteUrl = stdout.trim();
   
   return parseGitRemoteUrl(remoteUrl);
@@ -86,6 +88,6 @@ export function parseGitRemoteUrl(remoteUrl: string): GitRepoInfo {
  * @throws Error if not in a git repository
  */
 export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+  const { stdout } = await gitCommands.execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `scripts/fleet/github/git.ts` utility invoked `exec` with string interpolation (e.g., `git remote get-url ${remoteName}`), opening the door for command and option injection when executing commands on potentially untrusted repositories.
🎯 Impact: An attacker or untrusted codebase context providing a malicious remote name could gain arbitrary remote code execution context on the machine running the dispatch script.
🔧 Fix: Replaced `exec` with `execFile`, utilizing the `--` argument separator to securely execute variables without inadvertently executing malicious shell operations.
✅ Verification: Successfully verified with existing security tests (`bun test`) that were failing due to the mocking framework limitations with `exec`. These pass flawlessly under the refactored approach. Also added a journal entry to `.jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [11471321619650356151](https://jules.google.com/task/11471321619650356151) started by @wryenmeek*