### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in git utils

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** GITHUB_TOKEN and JULES_API_KEY were partially validated and redacted across different fleet scripts, leading to potential sensitive key exposure in error logs and missing validations where they were needed.
 **Learning:** Partial token validation and redaction across a multi-script fleet can lead to sensitive key leakage. Every script must validate all necessary keys on startup and ensure redaction utilities cover all sensitive tokens.
 **Prevention:** Centralize token validation and redaction logic. Ensure any string interpolation or logging involving potentially tainted input uses a comprehensive redaction utility for all known sensitive keys in the environment.
+
+## 2026-04-17 - [Command Injection Risk in Fleet Git Utils]
+**Vulnerability:** The `getGitRepoInfo` function in `scripts/fleet/github/git.ts` was passing user-controlled input (`remoteName`) into `child_process.exec` via string interpolation (`git remote get-url ${remoteName}`). This allows command injection if a malicious remote name like `; rm -rf /` is supplied. It also risked option injection if the remote name was like `--help`.
+**Learning:** Using `exec` with variable arguments creates shell injection vulnerabilities because the argument is evaluated by the shell.
+**Prevention:** Always use `child_process.execFile` (or its promisified version) instead of `exec` when executing shell commands with variable arguments. Additionally, always include the `--` separator before variable arguments to prevent option injection attacks.

--- a/scripts/fleet/github/git.ts
+++ b/scripts/fleet/github/git.ts
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+export const gitCommands = {
+  execFileAsync
+};
 
 export interface GitRepoInfo {
   owner: string;
@@ -37,7 +41,7 @@ export interface GitRepoInfo {
  * console.log(repo.fullName); // "owner/repo"
  */
 export async function getGitRepoInfo(remoteName = "origin"): Promise<GitRepoInfo> {
-  const { stdout } = await execAsync(`git remote get-url ${remoteName}`);
+  const { stdout } = await gitCommands.execFileAsync("git", ["remote", "get-url", "--", remoteName]);
   const remoteUrl = stdout.trim();
   
   return parseGitRemoteUrl(remoteUrl);
@@ -86,6 +90,6 @@ export function parseGitRemoteUrl(remoteUrl: string): GitRepoInfo {
  * @throws Error if not in a git repository
  */
 export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+  const { stdout } = await gitCommands.execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();
 }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `getGitRepoInfo` function in `scripts/fleet/github/git.ts` was passing a user-controlled parameter (`remoteName`) into `child_process.exec` via string interpolation (`git remote get-url ${remoteName}`). Since `exec` evaluates commands in a shell, an attacker could supply a malicious remote name like `; rm -rf /` and achieve remote code execution. Additionally, it was vulnerable to option injection.
🎯 **Impact**: Remote code execution or unexpected command behaviors via shell injection or option injection.
🔧 **Fix**: Replaced `child_process.exec` with `child_process.execFile` (promisified) which does not evaluate commands in a shell. Added the `--` separator before the variable argument (`remoteName`) to completely prevent option injection attacks.
✅ **Verification**: Run `cd scripts/fleet && bun test` to verify `git.test.ts` unit tests pass and security regression tests are successful.

---
*PR created automatically by Jules for task [5613627877394735853](https://jules.google.com/task/5613627877394735853) started by @wryenmeek*