### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in git utils

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** GITHUB_TOKEN and JULES_API_KEY were partially validated and redacted across different fleet scripts, leading to potential sensitive key exposure in error logs and missing validations where they were needed.
 **Learning:** Partial token validation and redaction across a multi-script fleet can lead to sensitive key leakage. Every script must validate all necessary keys on startup and ensure redaction utilities cover all sensitive tokens.
 **Prevention:** Centralize token validation and redaction logic. Ensure any string interpolation or logging involving potentially tainted input uses a comprehensive redaction utility for all known sensitive keys in the environment.
+## 2026-04-18 - [Command Injection]
+**Vulnerability:** Found `child_process.exec` being used to run git commands with unvalidated input (e.g., `remoteName`) via string concatenation in `scripts/fleet/github/git.ts`. This could allow command injection or option injection.
+**Learning:** Using string interpolation with `exec` creates a shell execution context where arbitrary shell metacharacters can be injected by untrusted input.
+**Prevention:** Always use `child_process.execFile` (or similar execution without a shell) combined with passing arguments as a discrete array. Furthermore, ensure the `--` separator is included before variable arguments to guard against option injection vulnerabilities.

--- a/scripts/fleet/github/git.ts
+++ b/scripts/fleet/github/git.ts
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+// Wrap internal utilities in exported objects to facilitate mocking in the Bun testing environment
+export const gitCommands = {
+  execFileAsync
+};
 
 export interface GitRepoInfo {
   owner: string;
@@ -37,7 +42,8 @@ export interface GitRepoInfo {
  * console.log(repo.fullName); // "owner/repo"
  */
 export async function getGitRepoInfo(remoteName = "origin"): Promise<GitRepoInfo> {
-  const { stdout } = await execAsync(`git remote get-url ${remoteName}`);
+  // Use execFile with `--` to prevent command and option injection
+  const { stdout } = await gitCommands.execFileAsync("git", ["remote", "get-url", "--", remoteName]);
   const remoteUrl = stdout.trim();
   
   return parseGitRemoteUrl(remoteUrl);
@@ -86,6 +92,6 @@ export function parseGitRemoteUrl(remoteUrl: string): GitRepoInfo {
  * @throws Error if not in a git repository
  */
 export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+  const { stdout } = await gitCommands.execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   return stdout.trim();
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: Found `child_process.exec` being used to run git commands with unvalidated input (e.g., `remoteName`) via string concatenation in `scripts/fleet/github/git.ts`. This created a shell execution context where arbitrary shell metacharacters could be injected by untrusted input.
🎯 Impact: This could allow a malicious actor to inject arbitrary shell commands or inject unintended options into the git CLI execution, potentially leading to unauthorized access, data exfiltration, or remote code execution on the machine running the fleet scripts.
🔧 Fix: Replaced `exec` with `child_process.execFile`, which bypasses shell evaluation entirely by executing the binary directly. Added the `--` separator before passing variable arguments to prevent option injection. Refactored the module to maintain testability by wrapping the utility in an exported object.
✅ Verification: Ran `cd scripts/fleet && bun test` and verified that the `git.test.ts` suite (including the regression tests for malicious payloads) passes successfully. Addressed the learnings by creating a journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6232498020187244787](https://jules.google.com/task/6232498020187244787) started by @wryenmeek*