### PR TITLE
🧪 Add tests for path_utils.py

### DIFF
--- a/submission.patch
+++ b/submission.patch
@@ -1,0 +1,92 @@
+From 1051b55ef57ef481c0ffa0c572db084ff3277066 Mon Sep 17 00:00:00 2001
+From: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
+Date: Tue, 21 Apr 2026 06:24:56 +0000
+Subject: [PATCH] =?UTF-8?q?=F0=9F=A7=AA=20Add=20tests=20for=20path=5Futils?=
+ =?UTF-8?q?.py?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Tests 'try_normalize_repo_relative_path' for valid, invalid, and traversal paths.
+- Tests 'normalize_repo_relative_path' for correct validation and exception throwing.
+- Tests 'resolve_within_repo' for secure path resolution within the repo root boundary.
+---
+ tests/kb/test_path_utils.py | 67 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 67 insertions(+)
+ create mode 100644 tests/kb/test_path_utils.py
+
+diff --git a/tests/kb/test_path_utils.py b/tests/kb/test_path_utils.py
+new file mode 100644
+index 0000000..f96020c
+--- /dev/null
++++ b/tests/kb/test_path_utils.py
+@@ -0,0 +1,67 @@
++import unittest
++from pathlib import Path
++
++from scripts.kb.path_utils import (
++    ERROR_KIND_INVALID_PATH,
++    ERROR_KIND_PATH_TRAVERSAL,
++    RepoRelativePathError,
++    normalize_repo_relative_path,
++    resolve_within_repo,
++    try_normalize_repo_relative_path,
++)
++
++class TestPathUtils(unittest.TestCase):
++    def test_try_normalize_repo_relative_path_valid(self):
++        # Valid string
++        self.assertEqual(try_normalize_repo_relative_path("wiki/pages/index.md"), ("wiki/pages/index.md", None))
++        # Valid Path object
++        self.assertEqual(try_normalize_repo_relative_path(Path("wiki/pages/index.md")), ("wiki/pages/index.md", None))
++
++    def test_try_normalize_repo_relative_path_invalid(self):
++        # Empty string
++        self.assertEqual(try_normalize_repo_relative_path("")[1], ERROR_KIND_INVALID_PATH)
++        # Leading slash
++        self.assertEqual(try_normalize_repo_relative_path("/wiki/pages")[1], ERROR_KIND_INVALID_PATH)
++        # Backslash
++        self.assertEqual(try_normalize_repo_relative_path("wiki\\pages")[1], ERROR_KIND_INVALID_PATH)
++        # Double slash
++        self.assertEqual(try_normalize_repo_relative_path("wiki//pages")[1], ERROR_KIND_INVALID_PATH)
++        # Dot segment
++        self.assertEqual(try_normalize_repo_relative_path("wiki/./pages")[1], ERROR_KIND_INVALID_PATH)
++
++    def test_try_normalize_repo_relative_path_traversal(self):
++        self.assertEqual(try_normalize_repo_relative_path("wiki/../pages")[1], ERROR_KIND_PATH_TRAVERSAL)
++        self.assertEqual(try_normalize_repo_relative_path("../wiki/pages")[1], ERROR_KIND_PATH_TRAVERSAL)
++
++    def test_normalize_repo_relative_path_valid(self):
++        self.assertEqual(normalize_repo_relative_path("wiki/pages/index.md"), "wiki/pages/index.md")
++        self.assertEqual(normalize_repo_relative_path(Path("wiki/pages/index.md")), "wiki/pages/index.md")
++
++    def test_normalize_repo_relative_path_invalid(self):
++        with self.assertRaises(RepoRelativePathError):
++            normalize_repo_relative_path("/wiki/pages")
++        with self.assertRaises(RepoRelativePathError):
++            normalize_repo_relative_path("wiki/../pages")
++
++    def test_resolve_within_repo_valid(self):
++        repo_root = Path("/fake/repo").resolve()
++
++        # Relative path within repo
++        self.assertEqual(resolve_within_repo(repo_root, "wiki/pages"), repo_root / "wiki/pages")
++
++        # Absolute path within repo
++        self.assertEqual(resolve_within_repo(repo_root, str(repo_root / "wiki/pages")), repo_root / "wiki/pages")
++
++    def test_resolve_within_repo_invalid(self):
++        repo_root = Path("/fake/repo").resolve()
++
++        # Relative path escaping repo
++        with self.assertRaises(RepoRelativePathError):
++            resolve_within_repo(repo_root, "../outside")
++
++        # Absolute path escaping repo
++        with self.assertRaises(RepoRelativePathError):
++            resolve_within_repo(repo_root, "/outside/repo")
++
++if __name__ == '__main__':
++    unittest.main()
+--
+2.34.1

--- a/tests/kb/test_path_utils.py
+++ b/tests/kb/test_path_utils.py
@@ -1,0 +1,67 @@
+import unittest
+from pathlib import Path
+
+from scripts.kb.path_utils import (
+    ERROR_KIND_INVALID_PATH,
+    ERROR_KIND_PATH_TRAVERSAL,
+    RepoRelativePathError,
+    normalize_repo_relative_path,
+    resolve_within_repo,
+    try_normalize_repo_relative_path,
+)
+
+class TestPathUtils(unittest.TestCase):
+    def test_try_normalize_repo_relative_path_valid(self):
+        # Valid string
+        self.assertEqual(try_normalize_repo_relative_path("wiki/pages/index.md"), ("wiki/pages/index.md", None))
+        # Valid Path object
+        self.assertEqual(try_normalize_repo_relative_path(Path("wiki/pages/index.md")), ("wiki/pages/index.md", None))
+
+    def test_try_normalize_repo_relative_path_invalid(self):
+        # Empty string
+        self.assertEqual(try_normalize_repo_relative_path("")[1], ERROR_KIND_INVALID_PATH)
+        # Leading slash
+        self.assertEqual(try_normalize_repo_relative_path("/wiki/pages")[1], ERROR_KIND_INVALID_PATH)
+        # Backslash
+        self.assertEqual(try_normalize_repo_relative_path("wiki\\pages")[1], ERROR_KIND_INVALID_PATH)
+        # Double slash
+        self.assertEqual(try_normalize_repo_relative_path("wiki//pages")[1], ERROR_KIND_INVALID_PATH)
+        # Dot segment
+        self.assertEqual(try_normalize_repo_relative_path("wiki/./pages")[1], ERROR_KIND_INVALID_PATH)
+
+    def test_try_normalize_repo_relative_path_traversal(self):
+        self.assertEqual(try_normalize_repo_relative_path("wiki/../pages")[1], ERROR_KIND_PATH_TRAVERSAL)
+        self.assertEqual(try_normalize_repo_relative_path("../wiki/pages")[1], ERROR_KIND_PATH_TRAVERSAL)
+
+    def test_normalize_repo_relative_path_valid(self):
+        self.assertEqual(normalize_repo_relative_path("wiki/pages/index.md"), "wiki/pages/index.md")
+        self.assertEqual(normalize_repo_relative_path(Path("wiki/pages/index.md")), "wiki/pages/index.md")
+
+    def test_normalize_repo_relative_path_invalid(self):
+        with self.assertRaises(RepoRelativePathError):
+            normalize_repo_relative_path("/wiki/pages")
+        with self.assertRaises(RepoRelativePathError):
+            normalize_repo_relative_path("wiki/../pages")
+
+    def test_resolve_within_repo_valid(self):
+        repo_root = Path("/fake/repo").resolve()
+
+        # Relative path within repo
+        self.assertEqual(resolve_within_repo(repo_root, "wiki/pages"), repo_root / "wiki/pages")
+
+        # Absolute path within repo
+        self.assertEqual(resolve_within_repo(repo_root, str(repo_root / "wiki/pages")), repo_root / "wiki/pages")
+
+    def test_resolve_within_repo_invalid(self):
+        repo_root = Path("/fake/repo").resolve()
+
+        # Relative path escaping repo
+        with self.assertRaises(RepoRelativePathError):
+            resolve_within_repo(repo_root, "../outside")
+
+        # Absolute path escaping repo
+        with self.assertRaises(RepoRelativePathError):
+            resolve_within_repo(repo_root, "/outside/repo")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
The file `scripts/kb/path_utils.py` had a missing test file, meaning its core path manipulation logic was not tested.

📊 **Coverage:**
The new test file `tests/kb/test_path_utils.py` covers:
* `try_normalize_repo_relative_path`: Tests for valid paths, invalid paths (empty strings, leading slashes, backslashes, double slashes, dot segments), and path traversal (`..`).
* `normalize_repo_relative_path`: Tests for valid path resolution and accurate exceptions (`RepoRelativePathError`) on invalid/traversal paths.
* `resolve_within_repo`: Tests for secure path resolution within the repo boundaries, rejecting path escaping.

✨ **Result:**
Test coverage and reliability for path manipulation functions in the knowledge base tooling are significantly improved. All 7 new test cases pass reliably.

---
*PR created automatically by Jules for task [646965782171117973](https://jules.google.com/task/646965782171117973) started by @wryenmeek*