### PR TITLE
⚡ Bolt: Optimize Frontmatter Parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2026-04-21 - [File chunk reading optimization]
 **Learning:** When reading files in chunks (e.g., for hashing), using `iter(lambda: handle.read(size), b"")` introduces significant lambda closure overhead, which hurts efficiency in hot loops.
 **Action:** Always prefer using a `while` loop with the walrus operator (`while chunk := handle.read(size):`) to eliminate lambda closure overhead and improve performance.
+
+## 2024-03-24 - [Avoid `splitlines` for parsing frontmatter]
+**Learning:** `string.splitlines()` on large text files allocates an array of strings in memory. For extracting YAML frontmatter from large markdown files, this memory and processing overhead is significant.
+**Action:** Use string fast paths (`text.startswith('---')`) and pre-compiled regex with `re.DOTALL` to efficiently extract frontmatter blocks without allocating arrays for the entire file.

--- a/scripts/kb/page_template_utils.py
+++ b/scripts/kb/page_template_utils.py
@@ -16,6 +16,7 @@ TEMPLATE_SECTION_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "analysis": ("## Summary", "## Evidence", "## Open Questions"),
 }
 _FRONTMATTER_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$")
+_FRONTMATTER_BLOCK_RE = re.compile(r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|$)", re.DOTALL)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
 
 TOPICAL_NAMESPACES: frozenset[str] = frozenset({"sources", "entities", "concepts", "analyses"})
@@ -99,12 +100,13 @@ def validate_page_template_path(
 
 
 def extract_frontmatter(text: str) -> tuple[str | None, str]:
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
+    if not text.startswith("---"):
         return None, text
-    for index in range(1, len(lines)):
-        if lines[index].strip() == "---":
-            return "\n".join(lines[1:index]), "\n".join(lines[index + 1 :])
+    match = _FRONTMATTER_BLOCK_RE.match(text)
+    if match:
+        body = text[match.end():]
+        # Drop the trailing newline from the body to match legacy splitlines() behavior
+        return match.group(1), (body[:-1] if body.endswith('\n') else body)
     return None, text
 
 


### PR DESCRIPTION
💡 **What**: Replaced the `text.splitlines()` approach in `page_template_utils.py:extract_frontmatter` with a fast-path `text.startswith('---')` check and a pre-compiled `re.DOTALL` regular expression.

🎯 **Why**: The original implementation allocated a list of string objects for every line in the file, even if the file was a massive markdown document and the frontmatter was just 3 lines at the top. This caused an O(N) memory allocation and processing overhead for something that should be near-constant time.

📊 **Impact**: This change drastically cuts down on the string allocation required to parse markdown files, dropping the parsing time overhead down substantially for larger pages. Local benchmarking showed parsing large text files bypassing the body splitting is significantly faster.

🔬 **Measurement**: Verify by running `python3 -m unittest discover -s tests -p "test_*.py"` to ensure no parsing regressions were introduced. Note that memory profiling on large string payloads will demonstrate significantly less array churn.

---
*PR created automatically by Jules for task [12684186171861995403](https://jules.google.com/task/12684186171861995403) started by @wryenmeek*