### PR TITLE
🛡️ Sentinel: [MEDIUM] Pin GitHub Actions to secure commit SHAs in CI-5

### DIFF
--- a/.github/workflows/ci-5-github-monitor.yml
+++ b/.github/workflows/ci-5-github-monitor.yml
@@ -34,11 +34,11 @@ jobs:
       drift_detected: ${{ steps.detect.outputs.drift_detected }}
       artifact_name: ${{ steps.detect.outputs.artifact_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.GITHUB_APP_ID }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -46,7 +46,7 @@ jobs:
       - name: Mask GitHub App token
         run: echo "::add-mask::${{ steps.app-token.outputs.token }}"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload drift report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.detect.outputs.artifact_name || format('drift-report-{0}', github.run_id) }}
           path: drift-report.json
@@ -113,7 +113,7 @@ jobs:
     env:
       WRITE_ALLOWLIST: raw/assets/**,raw/github-sources/**
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: true
           fetch-depth: 0
@@ -121,7 +121,7 @@ jobs:
       # Regenerate token close to use to avoid 55-minute expiry on long jobs.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.GITHUB_APP_ID }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -129,7 +129,7 @@ jobs:
       - name: Mask GitHub App token
         run: echo "::add-mask::${{ steps.app-token.outputs.token }}"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -138,7 +138,7 @@ jobs:
         run: pip install -e . --quiet
 
       - name: Download drift report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ needs.check-drift.outputs.artifact_name }}
 
@@ -240,12 +240,12 @@ jobs:
     env:
       WRITE_ALLOWLIST: raw/assets/**,raw/github-sources/**,wiki/**
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: true
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -254,7 +254,7 @@ jobs:
         run: pip install -e . --quiet
 
       - name: Download AFK-classified entries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: drift-classification-${{ github.run_id }}
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unpinned GitHub Actions in CI workflows. Mutable tags like `@v4` can be hijacked by a malicious actor if the action's repository is compromised, allowing them to execute arbitrary code in our CI environment.
🎯 **Impact:** Potential supply chain compromise, leading to arbitrary code execution, secret exfiltration, or malicious repository modifications.
🔧 **Fix:** Replaced mutable version tags (`@v4`, `@v1`, etc.) with their exact, secure commit SHAs for `actions/checkout`, `actions/create-github-app-token`, `actions/setup-python`, `actions/upload-artifact`, and `actions/download-artifact` in `.github/workflows/ci-5-github-monitor.yml`.
✅ **Verification:** Verified syntax using `actionlint` and ensured test suites continue to pass correctly.

---
*PR created automatically by Jules for task [3998438835768720793](https://jules.google.com/task/3998438835768720793) started by @wryenmeek*