### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API Key Exposure by Centralizing Redaction in Fleet Scripts

### DIFF
--- a/scripts/fleet/env.ts
+++ b/scripts/fleet/env.ts
@@ -1,0 +1,44 @@
+import * as util from "node:util";
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const JULES_API_KEY = process.env.JULES_API_KEY;
+
+if (!GITHUB_TOKEN) {
+  process.stdout.write("❌ GITHUB_TOKEN environment variable is required.\n");
+  process.exit(1);
+}
+
+if (!JULES_API_KEY) {
+  process.stdout.write("❌ JULES_API_KEY environment variable is required.\n");
+  process.exit(1);
+}
+
+export { GITHUB_TOKEN, JULES_API_KEY };
+
+export function redactToken(str: string): string {
+  let redacted = str;
+  if (GITHUB_TOKEN) {
+    redacted = redacted.replaceAll(GITHUB_TOKEN, "***REDACTED***");
+  }
+  if (JULES_API_KEY) {
+    redacted = redacted.replaceAll(JULES_API_KEY, "***REDACTED***");
+  }
+  return redacted;
+}
+
+export function setupRedactedLogging(): void {
+  console.log = (...args: any[]) => {
+    const formatted = util.format(...args);
+    process.stdout.write(redactToken(formatted) + "\n");
+  };
+
+  console.error = (...args: any[]) => {
+    const formatted = util.format(...args);
+    process.stderr.write(redactToken(formatted) + "\n");
+  };
+
+  console.warn = (...args: any[]) => {
+    const formatted = util.format(...args);
+    process.stderr.write(redactToken(formatted) + "\n");
+  };
+}

--- a/scripts/fleet/fleet-analyze.ts
+++ b/scripts/fleet/fleet-analyze.ts
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { setupRedactedLogging } from "./env.js";
 import { getIssuesAsMarkdown } from "./github/markdown.js";
+
+setupRedactedLogging();
 
 async function main() {
   try {

--- a/scripts/fleet/fleet-dispatch.ts
+++ b/scripts/fleet/fleet-dispatch.ts
@@ -18,19 +18,9 @@ import { Octokit } from "octokit";
 import type { IssueAnalysis } from "./types.js";
 import { jules } from "@google/jules-sdk";
 import { getGitRepoInfo, getCurrentBranch } from "./github/git.js";
+import { GITHUB_TOKEN, setupRedactedLogging } from "./env.js";
 
-const JULES_API_KEY = process.env.JULES_API_KEY;
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-
-if (!JULES_API_KEY) {
-  console.error("❌ JULES_API_KEY environment variable is required.");
-  process.exit(1);
-}
-
-if (!GITHUB_TOKEN) {
-  console.error("❌ GITHUB_TOKEN environment variable is required.");
-  process.exit(1);
-}
+setupRedactedLogging();
 
 const octokit = new Octokit({ auth: GITHUB_TOKEN });
 

--- a/scripts/fleet/fleet-merge.ts
+++ b/scripts/fleet/fleet-merge.ts
@@ -17,28 +17,19 @@ import { findUpSync } from "find-up";
 import type { IssueAnalysis, Task } from "./types.js";
 import { getGitRepoInfo, getCurrentBranch } from "./github/git.js";
 import { jules } from "@google/jules-sdk";
+import { GITHUB_TOKEN, setupRedactedLogging } from "./env.js";
+
+setupRedactedLogging();
 
 const repoInfo = await getGitRepoInfo();
 const OWNER = repoInfo.owner;
 const REPO = repoInfo.repo;
 const BASE_BRANCH = process.env.FLEET_BASE_BRANCH ?? "main";
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const JULES_API_KEY = process.env.JULES_API_KEY;
 
 // Re-dispatch configuration
 const MAX_RETRIES = Number(process.env.FLEET_MAX_RETRIES ?? 2);
 const PR_POLL_INTERVAL_MS = 30_000;
 const PR_POLL_TIMEOUT_MS = 15 * 60 * 1000;
-
-if (!GITHUB_TOKEN) {
-  console.error("❌ GITHUB_TOKEN environment variable is required.");
-  process.exit(1);
-}
-
-if (!JULES_API_KEY) {
-  console.error("❌ JULES_API_KEY environment variable is required.");
-  process.exit(1);
-}
 
 const headers = {
   Authorization: `Bearer ${GITHUB_TOKEN}`,

--- a/scripts/fleet/fleet-plan.ts
+++ b/scripts/fleet/fleet-plan.ts
@@ -17,19 +17,9 @@ import { jules } from '@google/jules-sdk'
 import { analyzeIssuesPrompt } from './prompts/analyze-issues.js'
 import { getIssuesAsMarkdown } from './github/markdown.js'
 import { getGitRepoInfo, getCurrentBranch } from './github/git.js'
+import { setupRedactedLogging } from './env.js'
 
-const JULES_API_KEY = process.env.JULES_API_KEY;
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-
-if (!JULES_API_KEY) {
-  console.error("❌ JULES_API_KEY environment variable is required.");
-  process.exit(1);
-}
-
-if (!GITHUB_TOKEN) {
-  console.error("❌ GITHUB_TOKEN environment variable is required.");
-  process.exit(1);
-}
+setupRedactedLogging();
 
 const repoInfo = await getGitRepoInfo()
 const baseBranch = process.env.FLEET_BASE_BRANCH ?? await getCurrentBranch()

--- a/scripts/fleet/github/logging.ts
+++ b/scripts/fleet/github/logging.ts
@@ -1,10 +1,1 @@
-export function redactToken(str: string): string {
-  let redacted = str;
-  if (process.env.GITHUB_TOKEN) {
-    redacted = redacted.replaceAll(process.env.GITHUB_TOKEN, '***REDACTED***');
-  }
-  if (process.env.JULES_API_KEY) {
-    redacted = redacted.replaceAll(process.env.JULES_API_KEY, '***REDACTED***');
-  }
-  return redacted;
-}
+export { redactToken } from "../env.js";


### PR DESCRIPTION
This PR centralizes the redaction of `JULES_API_KEY` and `GITHUB_TOKEN` across the `scripts/fleet` codebase.

Previously, each entrypoint script individually validated and attempted to redact these secrets, leading to inconsistencies and a risk of leaking tokens when logging errors or strings that were not explicitly run through the `redactToken` utility.

Changes:
- Created `scripts/fleet/env.ts` as the single source of truth for environment validation and token redaction.
- Overrode global `console.log`, `console.error`, and `console.warn` methods at the top of all fleet entry points (`fleet-analyze.ts`, `fleet-dispatch.ts`, `fleet-merge.ts`, `fleet-plan.ts`) to automatically apply the redaction utility using safe `process.stdout.write(util.format(...))` calls.
- Removed duplicated environment validation logic from individual scripts.

---
*PR created automatically by Jules for task [14145297297212089812](https://jules.google.com/task/14145297297212089812) started by @wryenmeek*