### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix shell injection vulnerability in GitHub Action workflows

### DIFF
--- a/.github/workflows/ci-5-github-monitor.yml
+++ b/.github/workflows/ci-5-github-monitor.yml
@@ -49,7 +49,9 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Mask GitHub App token
-        run: echo "::add-mask::${{ steps.app-token.outputs.token }}"
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "::add-mask::${APP_TOKEN}"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
@@ -223,7 +225,9 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Mask GitHub App token
-        run: echo "::add-mask::${{ steps.app-token.outputs.token }}"
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "::add-mask::${APP_TOKEN}"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Shell command injection and option injection via user-controllable input (e.g. `remoteName`) in git commands due to the use of `child_process.exec` allowing shell interpolation.
 **Learning:** Never use `child_process.exec` for shell commands that interpolate external or variable inputs. Even if the variable seems benign, it can contain malicious payload (e.g., `; echo pwned`) or options (`--help`). Wrapping the implementation in an exported object `gitCommands` was required to test this securely while also supporting mockability in Bun test environments.
 **Prevention:** Use `child_process.execFile` (or its promisified version) and separate arguments into an array. Always include the `--` separator before positional variable arguments to prevent them from being parsed as CLI flags.
+
+## 2026-05-10 - [Shell Injection in GitHub Actions via add-mask]
+**Vulnerability:** Shell command injection via string interpolation in GitHub Actions `run:` steps, specifically when masking secrets (`echo "::add-mask::${{ steps.app-token.outputs.token }}"`).
+**Learning:** String interpolation (`${{ ... }}`) in a `run:` block is evaluated by the GitHub Actions runner before the shell script is generated, allowing malicious strings to break out of the shell quotes or syntax.
+**Prevention:** Never interpolate `github.*`, `inputs.*`, or `steps.*` variables directly into `run:` blocks. Pass them to the shell using the step's `env:` block instead (e.g. `env: TOKEN: ${{ steps.token.outputs.token }}` and `run: echo "::add-mask::${TOKEN}"`).


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: String interpolation in a `run:` block in GitHub Actions can lead to shell injection vulnerabilities.
🎯 Impact: An attacker who can control the interpolated string could break out of the string quotation and execute arbitrary commands in the workflow's shell context.
🔧 Fix: Replaced direct interpolation of `${{ steps.app-token.outputs.token }}` in `echo "::add-mask::${{...}}"` with the more secure usage of passing the secret via the step's `env` context (`env: APP_TOKEN: ${{ steps.app-token.outputs.token }}` and `run: echo "::add-mask::${APP_TOKEN}"`).
✅ Verification: Tested workflow syntax using `actionlint`. Added an entry to `.jules/sentinel.md` detailing the security mitigation.

---
*PR created automatically by Jules for task [2897118278320578636](https://jules.google.com/task/2897118278320578636) started by @wryenmeek*