### PR TITLE
feat: add CI-5/CI-6 relay hardening and dispatch clients

### DIFF
--- a/.github/workflows/ci-5-github-monitor.yml
+++ b/.github/workflows/ci-5-github-monitor.yml
@@ -67,19 +67,63 @@ jobs:
           # SECURITY: pass workflow_dispatch input as env var, never interpolate
           # ${{ inputs.* }} directly into a run: shell block (shell injection risk).
           REGISTRY_PATH: ${{ inputs.registry_path }}
+          # SECURITY: pass repository_dispatch payload via env var, never interpolate
+          # ${{ github.event.* }} directly into a run: shell block.
+          DISPATCH_REGISTRY_PATH: ${{ github.event.client_payload.registry_path }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
 
           REGISTRY_ARGS=()
-          if [ -n "${REGISTRY_PATH}" ]; then
-            REGISTRY_ARGS=(--registry "${REGISTRY_PATH}")
+          EFFECTIVE_REGISTRY_PATH=""
+          if [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ] && [ -n "${DISPATCH_REGISTRY_PATH:-}" ]; then
+            # Fail closed on invalid dispatch payload path.
+            if [[ "${DISPATCH_REGISTRY_PATH}" == raw/github-sources/*.source-registry.json ]] \
+              && [[ "${DISPATCH_REGISTRY_PATH}" != *".."* ]] \
+              && [[ "${DISPATCH_REGISTRY_PATH}" != /* ]]; then
+              EFFECTIVE_REGISTRY_PATH="${DISPATCH_REGISTRY_PATH}"
+            else
+              echo "::error::Invalid repository_dispatch registry_path payload: ${DISPATCH_REGISTRY_PATH}" >&2
+              exit 1
+            fi
+          elif [ -n "${REGISTRY_PATH}" ]; then
+            # Fail closed on invalid workflow_dispatch input path.
+            if [[ "${REGISTRY_PATH}" == raw/github-sources/*.source-registry.json ]] \
+              && [[ "${REGISTRY_PATH}" != *".."* ]] \
+              && [[ "${REGISTRY_PATH}" != /* ]]; then
+              EFFECTIVE_REGISTRY_PATH="${REGISTRY_PATH}"
+            else
+              echo "::error::Invalid workflow_dispatch registry_path input: ${REGISTRY_PATH}" >&2
+              exit 1
+            fi
+          fi
+
+          if [ -n "${EFFECTIVE_REGISTRY_PATH}" ]; then
+            REGISTRY_ARGS=(--registry "${EFFECTIVE_REGISTRY_PATH}")
           fi
 
           # Run drift detection; exits 0 on success (even when drift is found),
           # exits 1 on API errors or configuration errors.
+          check_drift_start="$(date -u +%s)"
           python -m scripts.github_monitor.check_drift \
             "${REGISTRY_ARGS[@]}" \
             --output drift-report.json
+          check_drift_end="$(date -u +%s)"
+          check_drift_duration="$((check_drift_end - check_drift_start))"
+
+          CHECK_DRIFT_DURATION="${check_drift_duration}" python3 - <<'PY' > runtime-metrics/check-drift-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-5-check-drift",
+              "stage_durations_seconds": {
+                  "check_drift": int(os.environ["CHECK_DRIFT_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
 
           # Parse has_drift from the report to set the job output.
           HAS_DRIFT=$(python -c "
@@ -94,13 +138,60 @@ jobs:
           echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
           echo "Drift detected: ${HAS_DRIFT}"
 
+      - name: Evaluate CI-5 check-drift runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/check-drift-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/check-drift-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-5 check-drift runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-5 check-drift runtime budgets exceeded warn threshold(s). See runtime-metrics/check-drift-runtime-budget-report.json."
+
       - name: Upload drift report artifact
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ steps.detect.outputs.artifact_name || format('drift-report-{0}', github.run_id) }}
-          path: drift-report.json
+          path: |
+            drift-report.json
+            runtime-metrics/check-drift-runtime-metrics.json
+            runtime-metrics/check-drift-runtime-budget-report.json
           retention-days: 7
+
+      - name: Fail on severe CI-5 check-drift runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-5 check-drift runtime budgets exceeded fail threshold(s). See runtime-metrics/check-drift-runtime-budget-report.json."
+          exit 1
 
   fetch-and-update:
     name: CI-5 fetch + registry update
@@ -153,9 +244,63 @@ jobs:
           GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
+          fetch_start="$(date -u +%s)"
           python -m scripts.github_monitor.fetch_content \
             --drift-report drift-report.json \
             --approval approved
+          fetch_end="$(date -u +%s)"
+          fetch_duration="$((fetch_end - fetch_start))"
+
+          FETCH_DURATION="${fetch_duration}" python3 - <<'PY' > runtime-metrics/fetch-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-5-fetch-and-update",
+              "stage_durations_seconds": {
+                  "fetch_content": int(os.environ["FETCH_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Evaluate CI-5 fetch-and-update runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/fetch-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/fetch-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-5 fetch runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-5 fetch-and-update runtime budgets exceeded warn threshold(s). See runtime-metrics/fetch-runtime-budget-report.json."
 
       - name: Upload fetched state for downstream jobs
         if: always()
@@ -165,7 +310,16 @@ jobs:
           path: |
             raw/assets/
             raw/github-sources/
+            runtime-metrics/fetch-runtime-metrics.json
+            runtime-metrics/fetch-runtime-budget-report.json
           retention-days: 7
+
+      - name: Fail on severe CI-5 fetch runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-5 fetch-and-update runtime budgets exceeded fail threshold(s). See runtime-metrics/fetch-runtime-budget-report.json."
+          exit 1
 
   classify-drift:
     name: CI-5 HITL/AFK classification
@@ -199,9 +353,22 @@ jobs:
       - name: Classify drift entries as HITL or AFK
         id: classify
         run: |
+          set -euo pipefail
+          mkdir -p runtime-metrics
+          : > runtime-metrics/classify-stage-durations.env
+          classify_start="$(date -u +%s)"
+          set +e
           python3 -m scripts.github_monitor.classify_drift \
             --drift-report drift-report.json \
             --output-dir .
+          classify_exit=$?
+          set -e
+          classify_end="$(date -u +%s)"
+          classify_duration="$((classify_end - classify_start))"
+          echo "classify_drift=${classify_duration}" >> runtime-metrics/classify-stage-durations.env
+          if [ "${classify_exit}" -ne 0 ]; then
+            exit "${classify_exit}"
+          fi
 
       - name: Upload classification artifacts
         if: always()
@@ -218,17 +385,112 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          create_issues_start="$(date -u +%s)"
+          set +e
           python3 -m scripts.github_monitor.create_issues \
             --hitl-entries hitl-entries.json
+          create_issues_exit=$?
+          set -e
+          create_issues_end="$(date -u +%s)"
+          create_issues_duration="$((create_issues_end - create_issues_start))"
+          echo "create_issues=${create_issues_duration}" >> runtime-metrics/classify-stage-durations.env
+          if [ "${create_issues_exit}" -ne 0 ]; then
+            exit "${create_issues_exit}"
+          fi
 
       - name: Close resolved HITL issues
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          close_issues_start="$(date -u +%s)"
+          set +e
           python3 -m scripts.github_monitor.create_issues \
             --hitl-entries hitl-entries.json \
             --close-resolved
+          close_issues_exit=$?
+          set -e
+          close_issues_end="$(date -u +%s)"
+          close_issues_duration="$((close_issues_end - close_issues_start))"
+          echo "close_resolved_issues=${close_issues_duration}" >> runtime-metrics/classify-stage-durations.env
+          if [ "${close_issues_exit}" -ne 0 ]; then
+            exit "${close_issues_exit}"
+          fi
+
+      - name: Evaluate CI-5 classify-drift runtime budgets
+        id: runtime-budget
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          stage_file = Path("runtime-metrics/classify-stage-durations.env")
+          stage_durations: dict[str, int] = {}
+          for raw_line in stage_file.read_text(encoding="utf-8").splitlines():
+              line = raw_line.strip()
+              if not line:
+                  continue
+              stage_id, raw_duration = line.split("=", 1)
+              stage_durations[stage_id] = int(raw_duration)
+
+          metrics = {
+              "workflow_id": "ci-5-classify-drift",
+              "stage_durations_seconds": stage_durations,
+          }
+          Path("runtime-metrics/classify-runtime-metrics.json").write_text(
+              json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/classify-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-5 classify runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-5 classify-drift runtime budgets exceeded warn threshold(s). See runtime-metrics/classify-runtime-budget-report.json."
+
+      - name: Upload CI-5 classify runtime budget artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ci5-classify-runtime-budget-${{ github.run_id }}
+          path: |
+            runtime-metrics/classify-stage-durations.env
+            runtime-metrics/classify-runtime-metrics.json
+            runtime-metrics/classify-runtime-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail on severe CI-5 classify runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-5 classify-drift runtime budgets exceeded fail threshold(s). See runtime-metrics/classify-runtime-budget-report.json."
+          exit 1
 
   synthesize:
     name: CI-5 synthesize + open PR
@@ -274,11 +536,83 @@ jobs:
       - name: Apply diff-aware wiki updates
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
+          synthesize_start="$(date -u +%s)"
           # IMPORTANT: Only process AFK-classified entries, not the full drift report.
           # The full drift-report.json includes HITL entries that must NOT be auto-synthesized.
           python -m scripts.github_monitor.synthesize_diff \
             --drift-report afk-entries.json \
             --approval approved
+          synthesize_end="$(date -u +%s)"
+          synthesize_duration="$((synthesize_end - synthesize_start))"
+
+          SYNTHESIZE_DURATION="${synthesize_duration}" python3 - <<'PY' > runtime-metrics/synthesize-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-5-synthesize",
+              "stage_durations_seconds": {
+                  "synthesize_diff": int(os.environ["SYNTHESIZE_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Evaluate CI-5 synthesize runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/synthesize-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/synthesize-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-5 synthesize runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-5 synthesize runtime budgets exceeded warn threshold(s). See runtime-metrics/synthesize-runtime-budget-report.json."
+
+      - name: Upload CI-5 synthesize runtime budget artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ci5-synthesize-runtime-budget-${{ github.run_id }}
+          path: |
+            runtime-metrics/synthesize-runtime-metrics.json
+            runtime-metrics/synthesize-runtime-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail on severe CI-5 synthesize runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-5 synthesize runtime budgets exceeded fail threshold(s). See runtime-metrics/synthesize-runtime-budget-report.json."
+          exit 1
 
       - name: Commit and open PR
         env:

--- a/.github/workflows/ci-6-google-drive-monitor.yml
+++ b/.github/workflows/ci-6-google-drive-monitor.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-6-drive-monitor-${{ github.ref }}
-  cancel-in-progress: false
+  group: ci-6-drive-monitor-${{ github.ref }}-${{ github.event.client_payload.channel_id || 'none' }}-${{ github.event.client_payload.resource_id || 'none' }}-${{ github.event.client_payload.message_number || 'none' }}
+  cancel-in-progress: ${{ github.event_name == 'repository_dispatch' }}
 
 env:
   PYTHONDONTWRITEBYTECODE: "1"
@@ -63,19 +63,63 @@ jobs:
           # SECURITY: pass workflow_dispatch input as env var, never interpolate
           # ${{ inputs.* }} directly into a run: shell block (shell injection risk).
           REGISTRY_PATH: ${{ inputs.registry_path }}
+          # SECURITY: pass repository_dispatch payload via env var, never interpolate
+          # ${{ github.event.* }} directly into a run: shell block.
+          DISPATCH_REGISTRY_PATH: ${{ github.event.client_payload.registry_path }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
 
           REGISTRY_ARGS=()
-          if [ -n "${REGISTRY_PATH}" ]; then
-            REGISTRY_ARGS=(--registry "${REGISTRY_PATH}")
+          EFFECTIVE_REGISTRY_PATH=""
+          if [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ] && [ -n "${DISPATCH_REGISTRY_PATH:-}" ]; then
+            # Fail closed on invalid dispatch payload path.
+            if [[ "${DISPATCH_REGISTRY_PATH}" == raw/drive-sources/*.source-registry.json ]] \
+              && [[ "${DISPATCH_REGISTRY_PATH}" != *".."* ]] \
+              && [[ "${DISPATCH_REGISTRY_PATH}" != /* ]]; then
+              EFFECTIVE_REGISTRY_PATH="${DISPATCH_REGISTRY_PATH}"
+            else
+              echo "::error::Invalid repository_dispatch registry_path payload: ${DISPATCH_REGISTRY_PATH}" >&2
+              exit 1
+            fi
+          elif [ -n "${REGISTRY_PATH}" ]; then
+            # Fail closed on invalid workflow_dispatch input path.
+            if [[ "${REGISTRY_PATH}" == raw/drive-sources/*.source-registry.json ]] \
+              && [[ "${REGISTRY_PATH}" != *".."* ]] \
+              && [[ "${REGISTRY_PATH}" != /* ]]; then
+              EFFECTIVE_REGISTRY_PATH="${REGISTRY_PATH}"
+            else
+              echo "::error::Invalid workflow_dispatch registry_path input: ${REGISTRY_PATH}" >&2
+              exit 1
+            fi
+          fi
+
+          if [ -n "${EFFECTIVE_REGISTRY_PATH}" ]; then
+            REGISTRY_ARGS=(--registry "${EFFECTIVE_REGISTRY_PATH}")
           fi
 
           # Run drift detection; exits 0 on success (even when drift is found),
           # exits 1 on API errors or configuration errors.
+          check_drift_start="$(date -u +%s)"
           python -m scripts.drive_monitor.check_drift \
             "${REGISTRY_ARGS[@]}" \
             --output drift-report.json
+          check_drift_end="$(date -u +%s)"
+          check_drift_duration="$((check_drift_end - check_drift_start))"
+
+          CHECK_DRIFT_DURATION="${check_drift_duration}" python3 - <<'PY' > runtime-metrics/check-drift-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-6-check-drift",
+              "stage_durations_seconds": {
+                  "check_drift": int(os.environ["CHECK_DRIFT_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
 
           # Parse has_drift from the report to set the job output.
           HAS_DRIFT=$(python -c "
@@ -90,13 +134,60 @@ jobs:
           echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
           echo "Drift detected: ${HAS_DRIFT}"
 
+      - name: Evaluate CI-6 check-drift runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/check-drift-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/check-drift-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-6 check-drift runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-6 check-drift runtime budgets exceeded warn threshold(s). See runtime-metrics/check-drift-runtime-budget-report.json."
+
       - name: Upload drift report artifact
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ${{ steps.detect.outputs.artifact_name || format('drive-drift-report-{0}', github.run_id) }}
-          path: drift-report.json
+          path: |
+            drift-report.json
+            runtime-metrics/check-drift-runtime-metrics.json
+            runtime-metrics/check-drift-runtime-budget-report.json
           retention-days: 7
+
+      - name: Fail on severe CI-6 check-drift runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-6 check-drift runtime budgets exceeded fail threshold(s). See runtime-metrics/check-drift-runtime-budget-report.json."
+          exit 1
 
   fetch-and-update:
     name: CI-6 fetch + registry update
@@ -138,9 +229,63 @@ jobs:
           GDRIVE_SA_KEY: ${{ secrets.GDRIVE_SA_KEY }}
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
+          fetch_start="$(date -u +%s)"
           python -m scripts.drive_monitor.fetch_content \
             --drift-report drift-report.json \
             --approval approved
+          fetch_end="$(date -u +%s)"
+          fetch_duration="$((fetch_end - fetch_start))"
+
+          FETCH_DURATION="${fetch_duration}" python3 - <<'PY' > runtime-metrics/fetch-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-6-fetch-and-update",
+              "stage_durations_seconds": {
+                  "fetch_content": int(os.environ["FETCH_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Evaluate CI-6 fetch-and-update runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/fetch-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/fetch-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-6 fetch runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-6 fetch-and-update runtime budgets exceeded warn threshold(s). See runtime-metrics/fetch-runtime-budget-report.json."
 
       - name: Upload fetched state for downstream jobs
         if: always()
@@ -150,7 +295,16 @@ jobs:
           path: |
             raw/assets/gdrive/
             raw/drive-sources/
+            runtime-metrics/fetch-runtime-metrics.json
+            runtime-metrics/fetch-runtime-budget-report.json
           retention-days: 7
+
+      - name: Fail on severe CI-6 fetch runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-6 fetch-and-update runtime budgets exceeded fail threshold(s). See runtime-metrics/fetch-runtime-budget-report.json."
+          exit 1
 
   classify-drift:
     name: CI-6 HITL/AFK classification
@@ -184,9 +338,22 @@ jobs:
       - name: Classify drift entries as HITL or AFK
         id: classify
         run: |
+          set -euo pipefail
+          mkdir -p runtime-metrics
+          : > runtime-metrics/classify-stage-durations.env
+          classify_start="$(date -u +%s)"
+          set +e
           python3 -m scripts.drive_monitor.classify_drift \
             --drift-report drift-report.json \
             --output-dir .
+          classify_exit=$?
+          set -e
+          classify_end="$(date -u +%s)"
+          classify_duration="$((classify_end - classify_start))"
+          echo "classify_drift=${classify_duration}" >> runtime-metrics/classify-stage-durations.env
+          if [ "${classify_exit}" -ne 0 ]; then
+            exit "${classify_exit}"
+          fi
 
       - name: Upload classification artifacts
         if: always()
@@ -203,8 +370,92 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          create_issues_start="$(date -u +%s)"
+          set +e
           python3 -m scripts.drive_monitor.create_issues \
             --hitl-entries hitl-entries.json
+          create_issues_exit=$?
+          set -e
+          create_issues_end="$(date -u +%s)"
+          create_issues_duration="$((create_issues_end - create_issues_start))"
+          echo "create_issues=${create_issues_duration}" >> runtime-metrics/classify-stage-durations.env
+          if [ "${create_issues_exit}" -ne 0 ]; then
+            exit "${create_issues_exit}"
+          fi
+
+      - name: Evaluate CI-6 classify-drift runtime budgets
+        id: runtime-budget
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          stage_file = Path("runtime-metrics/classify-stage-durations.env")
+          stage_durations: dict[str, int] = {}
+          for raw_line in stage_file.read_text(encoding="utf-8").splitlines():
+              line = raw_line.strip()
+              if not line:
+                  continue
+              stage_id, raw_duration = line.split("=", 1)
+              stage_durations[stage_id] = int(raw_duration)
+
+          metrics = {
+              "workflow_id": "ci-6-classify-drift",
+              "stage_durations_seconds": stage_durations,
+          }
+          Path("runtime-metrics/classify-runtime-metrics.json").write_text(
+              json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/classify-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-6 classify runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-6 classify-drift runtime budgets exceeded warn threshold(s). See runtime-metrics/classify-runtime-budget-report.json."
+
+      - name: Upload CI-6 classify runtime budget artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ci6-classify-runtime-budget-${{ github.run_id }}
+          path: |
+            runtime-metrics/classify-stage-durations.env
+            runtime-metrics/classify-runtime-metrics.json
+            runtime-metrics/classify-runtime-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail on severe CI-6 classify runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-6 classify-drift runtime budgets exceeded fail threshold(s). See runtime-metrics/classify-runtime-budget-report.json."
+          exit 1
 
   synthesize:
     name: CI-6 synthesize + open PR
@@ -250,11 +501,83 @@ jobs:
       - name: Apply diff-aware wiki updates
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
+          synthesize_start="$(date -u +%s)"
           # IMPORTANT: Only process AFK-classified entries, not the full drift report.
           # The full drift-report.json includes HITL entries that must NOT be auto-synthesized.
           python -m scripts.drive_monitor.synthesize_diff \
             --drift-report afk-entries.json \
             --approval approved
+          synthesize_end="$(date -u +%s)"
+          synthesize_duration="$((synthesize_end - synthesize_start))"
+
+          SYNTHESIZE_DURATION="${synthesize_duration}" python3 - <<'PY' > runtime-metrics/synthesize-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-6-synthesize",
+              "stage_durations_seconds": {
+                  "synthesize_diff": int(os.environ["SYNTHESIZE_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Evaluate CI-6 synthesize runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/synthesize-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/synthesize-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-6 synthesize runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-6 synthesize runtime budgets exceeded warn threshold(s). See runtime-metrics/synthesize-runtime-budget-report.json."
+
+      - name: Upload CI-6 synthesize runtime budget artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ci6-synthesize-runtime-budget-${{ github.run_id }}
+          path: |
+            runtime-metrics/synthesize-runtime-metrics.json
+            runtime-metrics/synthesize-runtime-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail on severe CI-6 synthesize runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-6 synthesize runtime budgets exceeded fail threshold(s). See runtime-metrics/synthesize-runtime-budget-report.json."
+          exit 1
 
       - name: Commit and open PR
         env:
@@ -322,9 +645,81 @@ jobs:
       - name: Advance cursors for successfully processed aliases
         run: |
           set -euo pipefail
+          mkdir -p runtime-metrics
+          advance_start="$(date -u +%s)"
           python -m scripts.drive_monitor.advance_cursor \
             --drift-report drift-report.json \
             --approval approved
+          advance_end="$(date -u +%s)"
+          advance_duration="$((advance_end - advance_start))"
+
+          ADVANCE_DURATION="${advance_duration}" python3 - <<'PY' > runtime-metrics/advance-cursor-runtime-metrics.json
+          import json
+          import os
+
+          payload = {
+              "workflow_id": "ci-6-advance-cursor",
+              "stage_durations_seconds": {
+                  "advance_cursor": int(os.environ["ADVANCE_DURATION"]),
+              },
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Evaluate CI-6 advance-cursor runtime budgets
+        id: runtime-budget
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.validation import _runtime_budget
+
+          metrics = json.loads(Path("runtime-metrics/advance-cursor-runtime-metrics.json").read_text(encoding="utf-8"))
+          config = _runtime_budget.load_runtime_budgets("schema/runtime-budgets.json")
+          evaluation = _runtime_budget.evaluate_workflow_budgets(
+              config=config,
+              workflow_id=metrics["workflow_id"],
+              stage_durations_seconds=metrics["stage_durations_seconds"],
+          )
+          artifact = _runtime_budget.build_artifact_payload(
+              evaluation=evaluation,
+              config=config,
+              budget_config_path="schema/runtime-budgets.json",
+          )
+          report_path = Path("runtime-metrics/advance-cursor-runtime-budget-report.json")
+          report_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_handle:
+              summary_handle.write(_runtime_budget.build_summary_markdown(artifact) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_handle:
+              output_handle.write(f"overall_status={artifact['overall_status']}\n")
+          PY
+
+      - name: Warn on CI-6 advance-cursor runtime budget breaches
+        if: steps.runtime-budget.outputs.overall_status == 'warn'
+        run: |
+          set -euo pipefail
+          echo "::warning::CI-6 advance-cursor runtime budgets exceeded warn threshold(s). See runtime-metrics/advance-cursor-runtime-budget-report.json."
+
+      - name: Upload CI-6 advance-cursor runtime budget artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ci6-advance-cursor-runtime-budget-${{ github.run_id }}
+          path: |
+            runtime-metrics/advance-cursor-runtime-metrics.json
+            runtime-metrics/advance-cursor-runtime-budget-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail on severe CI-6 advance-cursor runtime budget breach
+        if: steps.runtime-budget.outputs.overall_status == 'fail'
+        run: |
+          set -euo pipefail
+          echo "::error::CI-6 advance-cursor runtime budgets exceeded fail threshold(s). See runtime-metrics/advance-cursor-runtime-budget-report.json."
+          exit 1
 
       - name: Commit cursor advancement
         run: |

--- a/scripts/drive_monitor/CONTEXT.md
+++ b/scripts/drive_monitor/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: module
-last_updated: 2026-05-03
+last_updated: 2026-05-20
 ---
 
 # CONTEXT — scripts/drive_monitor/
@@ -53,3 +53,4 @@ Vocabulary for the Google Drive source-monitoring pipeline. `AGENTS.md` takes pr
 | `_http.py` | Drive API v3 client factory: service account auth, retry wrapper, `files.get`, `files.export`, `changes.list`, `changes.getStartPageToken`. |
 | `_normalize.py` | `normalize_markdown_export(raw_bytes) → bytes` — canonical normalization for SHA-256. |
 | `_registry.py` | Registry read/update helpers: `find_registry_files()`, `update_last_fetched()`, `update_last_applied()`, `update_changes_cursor()`, `add_file_entry()`. |
+| `_relay.py` | Webhook relay helpers: channel-token context validation, replay suppression, lifecycle filtering, and `repository_dispatch` payload construction/dispatch for CI-6. |

--- a/scripts/drive_monitor/_relay.py
+++ b/scripts/drive_monitor/_relay.py
@@ -1,0 +1,613 @@
+"""Drive webhook relay helpers for CI-6 repository_dispatch triggering.
+
+This module validates Drive push-notification headers, enforces replay
+suppression, and emits ``repository_dispatch`` with a stable payload contract.
+It is intentionally HTTP-framework agnostic.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Protocol, TypedDict
+
+from scripts.github_monitor.dispatch_client import (
+    GitHubApiDispatchClient,
+    RepositoryDispatchClient,
+    RepositoryDispatchError,
+)
+from scripts.drive_monitor._types import validate_drive_registry_file
+from scripts.drive_monitor._validators import validate_alias, validate_file_id
+
+_DRIVE_SOURCE_UPDATED_EVENT = "drive-source-updated"
+_DRIVE_CHANNEL_TOKEN_PREFIX = "kbdrv1"
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+_HEADER_CHANNEL_ID = "x-goog-channel-id"
+_HEADER_CHANNEL_TOKEN = "x-goog-channel-token"
+_HEADER_RESOURCE_ID = "x-goog-resource-id"
+_HEADER_RESOURCE_STATE = "x-goog-resource-state"
+_HEADER_MESSAGE_NUMBER = "x-goog-message-number"
+_HEADER_FILE_ID = "x-goog-file-id"
+_HEADER_FILE_IDS = "x-goog-file-ids"
+
+_IGNORED_RESOURCE_STATES = frozenset({"sync", "heartbeat"})
+_RELEVANT_RESOURCE_STATES = frozenset(
+    {
+        "add",
+        "change",
+        "content_changed",
+        "exists",
+        "not_exists",
+        "remove",
+        "trash",
+        "untrash",
+        "update",
+    }
+)
+_MAX_FILE_IDS = 200
+_MAX_REGISTRY_PATH_LENGTH = 256
+_MAX_IDENTIFIER_LENGTH = 128
+
+
+class DriveSourceUpdatedPayload(TypedDict):
+    """Stable payload contract for event_type=drive-source-updated."""
+
+    alias: str
+    registry_path: str
+    file_ids: list[str]
+    channel_id: str
+    resource_id: str
+    resource_state: str
+    message_number: int
+
+
+class DriveChannelTokenContext(TypedDict):
+    """Validated context decoded from ``X-Goog-Channel-Token``."""
+
+    alias: str
+    registry_path: str
+    file_ids: list[str]
+
+
+@dataclass(frozen=True)
+class DriveNotification:
+    """Validated Drive notification header subset."""
+
+    alias: str
+    registry_path: str
+    file_ids: tuple[str, ...]
+    channel_id: str
+    resource_id: str
+    resource_state: str
+    message_number: int
+
+
+@dataclass(frozen=True)
+class DriveRelayResult:
+    """Result envelope returned by ``relay_drive_notification()``."""
+
+    status: str
+    reason: str
+    dispatched: bool
+    payload: DriveSourceUpdatedPayload | None
+
+
+class RelayValidationError(ValueError):
+    """Raised when Drive headers/token/context are invalid."""
+
+
+class DriveReplayCache:
+    """In-memory replay suppression keyed by Drive channel/resource headers."""
+
+    def __init__(self, *, ttl_seconds: int = 3600, max_entries: int = 20_000) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entries = max_entries
+        self._expirations: dict[str, float] = {}
+        self._inflight: set[str] = set()
+        self._lock = threading.Lock()
+
+    def check_and_record(self, key: str, *, now: float | None = None) -> bool:
+        """Return ``True`` for replay, else record and return ``False``."""
+
+        if self.reserve(key, now=now):
+            return True
+        self.commit(key, now=now)
+        return False
+
+    def is_replay(self, key: str, *, now: float | None = None) -> bool:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            return key in self._expirations or key in self._inflight
+
+    def reserve(self, key: str, *, now: float | None = None) -> bool:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            if key in self._expirations or key in self._inflight:
+                return True
+            self._inflight.add(key)
+            return False
+
+    def commit(self, key: str, *, now: float | None = None) -> None:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            self._inflight.discard(key)
+            self._record_unlocked(key, current)
+
+    def rollback(self, key: str) -> None:
+        with self._lock:
+            self._inflight.discard(key)
+
+    def record(self, key: str, *, now: float | None = None) -> None:
+        self.commit(key, now=now)
+
+    def _record_unlocked(self, key: str, now: float) -> None:
+        if len(self._expirations) >= self._max_entries:
+            oldest_key = min(self._expirations, key=self._expirations.get)
+            self._expirations.pop(oldest_key, None)
+        self._expirations[key] = now + self._ttl_seconds
+
+    def _evict_expired(self, now: float) -> None:
+        expired_keys = [k for k, expiry in self._expirations.items() if expiry <= now]
+        for key in expired_keys:
+            self._expirations.pop(key, None)
+
+
+# Explicit concrete alias used in operator docs/examples.
+InMemoryDriveReplayCache = DriveReplayCache
+
+
+class DriveReplayStore(Protocol):
+    """Replay cache/store contract for notification dedupe."""
+
+    def check_and_record(self, key: str, *, now: float | None = None) -> bool:
+        """Return True when key is replayed, else record and return False."""
+
+    def is_replay(self, key: str, *, now: float | None = None) -> bool:
+        """Return True when key has already been recorded."""
+
+    def reserve(self, key: str, *, now: float | None = None) -> bool:
+        """Atomically reserve a key; return True when replayed."""
+
+    def commit(self, key: str, *, now: float | None = None) -> None:
+        """Commit a reserved key after successful dispatch."""
+
+    def rollback(self, key: str) -> None:
+        """Release a reserved key after dispatch failure."""
+
+    def record(self, key: str, *, now: float | None = None) -> None:
+        """Record key after successful dispatch."""
+
+
+def _normalize_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {str(k).lower(): str(v) for k, v in headers.items()}
+
+
+def _require_header(headers: Mapping[str, str], header_name: str) -> str:
+    value = headers.get(header_name)
+    if not value:
+        raise RelayValidationError(f"missing {header_name} header")
+    return value.strip()
+
+
+def _validate_registry_path_literal(registry_path: str) -> str:
+    if not isinstance(registry_path, str) or not registry_path:
+        raise RelayValidationError("registry_path must be a non-empty string")
+    candidate = PurePosixPath(registry_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise RelayValidationError("registry_path must be relative and traversal-safe")
+    normalized = candidate.as_posix()
+    if not normalized.startswith("raw/drive-sources/"):
+        raise RelayValidationError("registry_path must be under raw/drive-sources/")
+    if not normalized.endswith(".source-registry.json"):
+        raise RelayValidationError("registry_path must end with .source-registry.json")
+    return normalized
+
+
+def _decode_b64url(value: str) -> bytes:
+    padding = "=" * ((4 - (len(value) % 4)) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def build_drive_channel_token(
+    *,
+    alias: str,
+    registry_path: str,
+    token_secret: str,
+    file_ids: list[str] | None = None,
+) -> str:
+    """Build a signed channel token for Drive push notifications."""
+
+    if not token_secret:
+        raise ValueError("token_secret is required")
+    try:
+        validated_alias = validate_alias(alias)
+        validated_registry_path = _validate_registry_path_literal(registry_path)
+    except ValueError as exc:
+        raise RelayValidationError(str(exc)) from exc
+    validated_file_ids: list[str] = []
+    for file_id in file_ids or []:
+        if not isinstance(file_id, str):
+            raise RelayValidationError("file_ids must contain strings")
+        try:
+            validated_file_ids.append(validate_file_id(file_id))
+        except ValueError as exc:
+            raise RelayValidationError(str(exc)) from exc
+    context: DriveChannelTokenContext = {
+        "alias": validated_alias,
+        "registry_path": validated_registry_path,
+        "file_ids": sorted(set(validated_file_ids)),
+    }
+    encoded_context = base64.urlsafe_b64encode(
+        json.dumps(context, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii").rstrip("=")
+    signature = hmac.new(
+        token_secret.encode("utf-8"),
+        encoded_context.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{_DRIVE_CHANNEL_TOKEN_PREFIX}.{encoded_context}.{signature}"
+
+
+def parse_drive_channel_token(
+    *, token: str, token_secret: str
+) -> DriveChannelTokenContext:
+    """Validate and decode a signed Drive channel token."""
+
+    if not token_secret:
+        raise RelayValidationError("token_secret is required")
+    if not token:
+        raise RelayValidationError("missing Drive channel token")
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != _DRIVE_CHANNEL_TOKEN_PREFIX:
+        raise RelayValidationError("invalid Drive channel token format")
+    encoded_context, signature = parts[1], parts[2].lower()
+    if len(signature) != 64 or any(ch not in _HEX_DIGITS for ch in signature):
+        raise RelayValidationError("invalid Drive channel token signature format")
+    expected_signature = hmac.new(
+        token_secret.encode("utf-8"),
+        encoded_context.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected_signature):
+        raise RelayValidationError("invalid Drive channel token signature")
+
+    try:
+        decoded = _decode_b64url(encoded_context).decode("utf-8")
+        raw_context = json.loads(decoded)
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RelayValidationError(f"invalid Drive channel token payload: {exc}") from exc
+
+    if not isinstance(raw_context, dict):
+        raise RelayValidationError("Drive channel token payload must be an object")
+    alias = raw_context.get("alias")
+    registry_path = raw_context.get("registry_path")
+    raw_file_ids = raw_context.get("file_ids") or []
+    if not isinstance(alias, str) or not alias:
+        raise RelayValidationError("Drive channel token alias is required")
+    if not isinstance(registry_path, str) or not registry_path:
+        raise RelayValidationError("Drive channel token registry_path is required")
+    if not isinstance(raw_file_ids, list):
+        raise RelayValidationError("Drive channel token file_ids must be a list")
+
+    validated_file_ids: list[str] = []
+    for file_id in raw_file_ids:
+        if not isinstance(file_id, str):
+            raise RelayValidationError("Drive channel token file_ids must contain strings")
+        try:
+            validated_file_ids.append(validate_file_id(file_id))
+        except ValueError as exc:
+            raise RelayValidationError(str(exc)) from exc
+    try:
+        return {
+            "alias": validate_alias(alias),
+            "registry_path": _validate_registry_path_literal(registry_path),
+            "file_ids": sorted(set(validated_file_ids)),
+        }
+    except ValueError as exc:
+        raise RelayValidationError(str(exc)) from exc
+
+
+def _extract_file_ids(
+    *,
+    headers: Mapping[str, str],
+    token_context: DriveChannelTokenContext,
+) -> tuple[str, ...]:
+    file_ids: set[str] = set(token_context.get("file_ids", []))
+    raw_single = headers.get(_HEADER_FILE_ID)
+    if raw_single:
+        try:
+            file_ids.add(validate_file_id(raw_single.strip()))
+        except ValueError as exc:
+            raise RelayValidationError(str(exc)) from exc
+    raw_multiple = headers.get(_HEADER_FILE_IDS)
+    if raw_multiple:
+        for value in raw_multiple.split(","):
+            trimmed = value.strip()
+            if trimmed:
+                try:
+                    file_ids.add(validate_file_id(trimmed))
+                except ValueError as exc:
+                    raise RelayValidationError(str(exc)) from exc
+    return tuple(sorted(file_ids))
+
+
+def parse_drive_notification(
+    *, headers: Mapping[str, str], token_secret: str
+) -> DriveNotification:
+    """Validate and parse Drive webhook headers into a typed object."""
+
+    normalized_headers = _normalize_headers(headers)
+    channel_id = _require_header(normalized_headers, _HEADER_CHANNEL_ID)
+    channel_token = _require_header(normalized_headers, _HEADER_CHANNEL_TOKEN)
+    resource_id = _require_header(normalized_headers, _HEADER_RESOURCE_ID)
+    resource_state = _require_header(normalized_headers, _HEADER_RESOURCE_STATE).lower()
+    message_number_raw = _require_header(normalized_headers, _HEADER_MESSAGE_NUMBER)
+    try:
+        message_number = int(message_number_raw)
+    except ValueError as exc:
+        raise RelayValidationError("x-goog-message-number must be an integer") from exc
+    if message_number <= 0:
+        raise RelayValidationError("x-goog-message-number must be positive")
+
+    token_context = parse_drive_channel_token(
+        token=channel_token,
+        token_secret=token_secret,
+    )
+    file_ids = _extract_file_ids(headers=normalized_headers, token_context=token_context)
+    return DriveNotification(
+        alias=token_context["alias"],
+        registry_path=token_context["registry_path"],
+        file_ids=file_ids,
+        channel_id=channel_id,
+        resource_id=resource_id,
+        resource_state=resource_state,
+        message_number=message_number,
+    )
+
+
+def is_relevant_drive_resource_state(resource_state: str) -> bool:
+    """Return whether a Drive resource_state should trigger dispatch."""
+
+    normalized = resource_state.strip().lower()
+    if normalized in _IGNORED_RESOURCE_STATES:
+        return False
+    return normalized in _RELEVANT_RESOURCE_STATES
+
+
+def drive_replay_key(notification: DriveNotification) -> str:
+    """Stable replay key from Drive header tuple."""
+
+    return (
+        f"{notification.channel_id}:"
+        f"{notification.resource_id}:"
+        f"{notification.message_number}"
+    )
+
+
+def validate_drive_registry_context(*, repo_root: Path, notification: DriveNotification) -> None:
+    """Fail-closed validation for alias/registry_path context from channel token."""
+
+    repo_root_resolved = repo_root.resolve()
+    registry_file = (repo_root_resolved / notification.registry_path).resolve()
+    registry_root = (repo_root_resolved / "raw" / "drive-sources").resolve()
+    if not registry_file.is_relative_to(registry_root):
+        raise RelayValidationError("registry_path escapes raw/drive-sources boundary")
+    if not registry_file.exists():
+        raise RelayValidationError(f"registry_path does not exist: {notification.registry_path}")
+
+    try:
+        parsed = json.loads(registry_file.read_text(encoding="utf-8"))
+        registry = validate_drive_registry_file(parsed)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise RelayValidationError(
+            f"registry_path is unreadable/invalid: {notification.registry_path}: {exc}"
+        ) from exc
+
+    if registry.get("alias") != notification.alias:
+        raise RelayValidationError(
+            "channel token alias does not match registry alias "
+            f"({notification.alias!r} != {registry.get('alias')!r})"
+        )
+
+
+def build_drive_source_payload(notification: DriveNotification) -> DriveSourceUpdatedPayload:
+    payload: DriveSourceUpdatedPayload = {
+        "alias": notification.alias,
+        "registry_path": notification.registry_path,
+        "file_ids": list(notification.file_ids),
+        "channel_id": notification.channel_id,
+        "resource_id": notification.resource_id,
+        "resource_state": notification.resource_state,
+        "message_number": notification.message_number,
+    }
+    return validate_drive_source_payload(payload)
+
+
+def validate_drive_source_payload(payload: Mapping[str, Any]) -> DriveSourceUpdatedPayload:
+    """Validate the stable payload contract for CI-6 dispatch events."""
+
+    expected_fields = {
+        "alias",
+        "registry_path",
+        "file_ids",
+        "channel_id",
+        "resource_id",
+        "resource_state",
+        "message_number",
+    }
+    extra_fields = sorted(set(payload.keys()) - expected_fields)
+    if extra_fields:
+        raise RelayValidationError(
+            f"payload contains unexpected field(s): {', '.join(extra_fields)}"
+        )
+
+    required_string_fields = (
+        "alias",
+        "registry_path",
+        "channel_id",
+        "resource_id",
+        "resource_state",
+    )
+    for field in required_string_fields:
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            raise RelayValidationError(f"payload field {field!r} must be a string")
+        if field == "registry_path" and len(value) > _MAX_REGISTRY_PATH_LENGTH:
+            raise RelayValidationError("payload field 'registry_path' exceeds max length")
+        if field != "registry_path" and len(value) > _MAX_IDENTIFIER_LENGTH:
+            raise RelayValidationError(f"payload field {field!r} exceeds max length")
+
+    message_number = payload.get("message_number")
+    if not isinstance(message_number, int) or message_number <= 0:
+        raise RelayValidationError(
+            "payload field 'message_number' must be a positive integer"
+        )
+
+    raw_file_ids = payload.get("file_ids")
+    if not isinstance(raw_file_ids, list):
+        raise RelayValidationError("payload field 'file_ids' must be a list")
+    if len(raw_file_ids) > _MAX_FILE_IDS:
+        raise RelayValidationError(
+            f"payload field 'file_ids' exceeds max count {_MAX_FILE_IDS}"
+        )
+    validated_file_ids: list[str] = []
+    for file_id in raw_file_ids:
+        if not isinstance(file_id, str):
+            raise RelayValidationError("payload field 'file_ids' must contain strings")
+        if len(file_id) > _MAX_IDENTIFIER_LENGTH:
+            raise RelayValidationError(
+                "payload field 'file_ids' contains value exceeding max length"
+            )
+        try:
+            validated_file_ids.append(validate_file_id(file_id))
+        except ValueError as exc:
+            raise RelayValidationError(str(exc)) from exc
+
+    resource_state = payload["resource_state"].lower()
+    if resource_state not in _RELEVANT_RESOURCE_STATES:
+        raise RelayValidationError(
+            "payload field 'resource_state' must be one of the relevant Drive states"
+        )
+
+    try:
+        return {
+            "alias": validate_alias(payload["alias"]),
+            "registry_path": _validate_registry_path_literal(payload["registry_path"]),
+            "file_ids": sorted(set(validated_file_ids)),
+            "channel_id": payload["channel_id"],
+            "resource_id": payload["resource_id"],
+            "resource_state": resource_state,
+            "message_number": message_number,
+        }
+    except ValueError as exc:
+        raise RelayValidationError(str(exc)) from exc
+
+
+def relay_drive_notification(
+    *,
+    repo_root: Path,
+    headers: Mapping[str, str],
+    token_secret: str,
+    dispatch_client: RepositoryDispatchClient,
+    replay_cache: DriveReplayStore,
+) -> DriveRelayResult:
+    """Validate a Drive notification, suppress replays, and emit dispatch."""
+
+    try:
+        notification = parse_drive_notification(headers=headers, token_secret=token_secret)
+        validate_drive_registry_context(repo_root=repo_root, notification=notification)
+    except RelayValidationError as exc:
+        return DriveRelayResult(
+            status="rejected",
+            reason=str(exc),
+            dispatched=False,
+            payload=None,
+        )
+
+    if not is_relevant_drive_resource_state(notification.resource_state):
+        return DriveRelayResult(
+            status="ignored",
+            reason="resource_state_ignored",
+            dispatched=False,
+            payload=None,
+        )
+
+    replay_key = drive_replay_key(notification)
+    if replay_cache.reserve(replay_key):
+        return DriveRelayResult(
+            status="ignored",
+            reason="replay_suppressed",
+            dispatched=False,
+            payload=None,
+        )
+
+    try:
+        payload = build_drive_source_payload(notification)
+    except RelayValidationError as exc:
+        replay_cache.rollback(replay_key)
+        return DriveRelayResult(
+            status="rejected",
+            reason=str(exc),
+            dispatched=False,
+            payload=None,
+        )
+
+    try:
+        dispatch_client.dispatch(
+            event_type=_DRIVE_SOURCE_UPDATED_EVENT,
+            client_payload=payload,
+        )
+    except Exception as exc:  # pragma: no cover - defensive envelope
+        replay_cache.rollback(replay_key)
+        return DriveRelayResult(
+            status="failed",
+            reason=f"dispatch_failed: {exc}",
+            dispatched=False,
+            payload=payload,
+        )
+
+    replay_cache.commit(replay_key)
+    return DriveRelayResult(
+        status="dispatched",
+        reason="ok",
+        dispatched=True,
+        payload=payload,
+    )
+
+
+__all__ = [
+    "DriveChannelTokenContext",
+    "DriveNotification",
+    "DriveRelayResult",
+    "DriveReplayCache",
+    "InMemoryDriveReplayCache",
+    "DriveReplayStore",
+    "DriveSourceUpdatedPayload",
+    "GitHubApiDispatchClient",
+    "RelayValidationError",
+    "RepositoryDispatchClient",
+    "RepositoryDispatchError",
+    "build_drive_channel_token",
+    "build_drive_source_payload",
+    "drive_replay_key",
+    "is_relevant_drive_resource_state",
+    "parse_drive_channel_token",
+    "parse_drive_notification",
+    "relay_drive_notification",
+    "validate_drive_source_payload",
+    "validate_drive_registry_context",
+]

--- a/scripts/github_monitor/CONTEXT.md
+++ b/scripts/github_monitor/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: module
-last_updated: 2026-04-29
+last_updated: 2026-05-20
 ---
 
 # CONTEXT — scripts/github_monitor/
@@ -42,6 +42,8 @@ Vocabulary for the GitHub source-monitoring pipeline. `AGENTS.md` takes preceden
 | `fetch_content.py` | Downloads drifted content to `raw/assets/`, updates `last_fetched_*` in registry under `raw/.github-sources.lock`. |
 | `synthesize_diff.py` | Diffs old and new assets, updates wiki page, advances `last_applied_*` under both locks (wiki first). |
 | `create_issues.py` | Creates or updates GitHub Issues for HITL-classified entries. |
+| `dispatch_client.py` | Shared `repository_dispatch` HTTP client wrapper used by webhook relays. |
+| `_relay.py` | Webhook relay helpers: GitHub signature validation, push-path-to-registry filtering, and `repository_dispatch` payload construction/dispatch for CI-5. |
 | `_types.py` | Typed dicts for registry entries, drift report structure, and API response shapes. |
 | `_validators.py` | Path traversal and registry structure validators. |
 | `_http.py` | GitHub API client helpers: authenticated requests, retry logic, contents and commits endpoints. |

--- a/scripts/github_monitor/_relay.py
+++ b/scripts/github_monitor/_relay.py
@@ -1,0 +1,568 @@
+"""GitHub webhook relay helpers for CI-5 repository_dispatch triggering.
+
+This module is intentionally HTTP-framework agnostic.  A webhook receiver
+(Cloud Run, Flask, FastAPI, etc.) can pass request headers/body to
+``relay_github_push_event()`` and use the returned status to decide the HTTP
+response code.
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import hashlib
+import hmac
+import json
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Protocol, TypedDict
+
+from scripts.github_monitor.dispatch_client import (
+    GitHubApiDispatchClient,
+    RepositoryDispatchClient,
+    RepositoryDispatchError,
+)
+from scripts.github_monitor._types import validate_registry_file
+from scripts.github_monitor._validators import validate_external_path
+
+_GITHUB_EVENT_HEADER = "x-github-event"
+_GITHUB_DELIVERY_HEADER = "x-github-delivery"
+_GITHUB_SIGNATURE_HEADER = "x-hub-signature-256"
+_SIGNATURE_PREFIX = "sha256="
+_HEX_DIGITS = frozenset("0123456789abcdef")
+_UPSTREAM_SOURCE_UPDATED_EVENT = "upstream-source-updated"
+_MONITORED_TRACKING_STATUSES = frozenset({"active", "uninitialized"})
+_MAX_CHANGED_PATHS = 200
+_MAX_REGISTRY_PATH_LENGTH = 256
+_MAX_IDENTIFIER_LENGTH = 128
+
+
+class UpstreamSourceUpdatedPayload(TypedDict):
+    """Stable payload contract for event_type=upstream-source-updated."""
+
+    registry_path: str
+    owner: str
+    repo: str
+    changed_paths: list[str]
+    delivery_id: str
+    event_name: str
+
+
+@dataclass(frozen=True)
+class GitHubPushEvent:
+    """Validated subset of a GitHub push webhook event."""
+
+    owner: str
+    repo: str
+    changed_paths: tuple[str, ...]
+    delivery_id: str
+    event_name: str
+
+
+@dataclass(frozen=True)
+class GitHubRelayResult:
+    """Result envelope returned by ``relay_github_push_event()``."""
+
+    status: str
+    reason: str
+    dispatched_count: int
+    payloads: tuple[UpstreamSourceUpdatedPayload, ...]
+
+
+class RelayValidationError(ValueError):
+    """Raised when webhook headers/body fail validation."""
+
+
+class GitHubDeliveryReplayCache:
+    """Best-effort replay suppression keyed by ``X-GitHub-Delivery``."""
+
+    def __init__(self, *, ttl_seconds: int = 86_400, max_entries: int = 20_000) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entries = max_entries
+        self._expirations: dict[str, float] = {}
+        self._inflight: set[str] = set()
+        self._lock = threading.Lock()
+
+    def check_and_record(self, delivery_id: str, *, now: float | None = None) -> bool:
+        if self.reserve(delivery_id, now=now):
+            return True
+        self.commit(delivery_id, now=now)
+        return False
+
+    def is_replay(self, delivery_id: str, *, now: float | None = None) -> bool:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            return delivery_id in self._expirations or delivery_id in self._inflight
+
+    def reserve(self, delivery_id: str, *, now: float | None = None) -> bool:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            if delivery_id in self._expirations or delivery_id in self._inflight:
+                return True
+            self._inflight.add(delivery_id)
+            return False
+
+    def commit(self, delivery_id: str, *, now: float | None = None) -> None:
+        current = time.time() if now is None else now
+        with self._lock:
+            self._evict_expired(current)
+            self._inflight.discard(delivery_id)
+            self._record_unlocked(delivery_id, current)
+
+    def rollback(self, delivery_id: str) -> None:
+        with self._lock:
+            self._inflight.discard(delivery_id)
+
+    def record(self, delivery_id: str, *, now: float | None = None) -> None:
+        self.commit(delivery_id, now=now)
+
+    def _record_unlocked(self, delivery_id: str, now: float) -> None:
+        if len(self._expirations) >= self._max_entries:
+            oldest_key = min(self._expirations, key=self._expirations.get)
+            self._expirations.pop(oldest_key, None)
+        self._expirations[delivery_id] = now + self._ttl_seconds
+
+    def _evict_expired(self, now: float) -> None:
+        expired_keys = [k for k, expiry in self._expirations.items() if expiry <= now]
+        for key in expired_keys:
+            self._expirations.pop(key, None)
+
+
+class GitHubReplayCache(Protocol):
+    """Replay cache contract for delivery-ID suppression."""
+
+    def check_and_record(self, delivery_id: str, *, now: float | None = None) -> bool:
+        """Return True when delivery_id is replayed, else record and return False."""
+
+    def is_replay(self, delivery_id: str, *, now: float | None = None) -> bool:
+        """Return True when delivery_id has already been recorded."""
+
+    def reserve(self, delivery_id: str, *, now: float | None = None) -> bool:
+        """Atomically reserve a delivery_id; return True when replayed."""
+
+    def commit(self, delivery_id: str, *, now: float | None = None) -> None:
+        """Commit a reserved delivery_id after successful dispatch."""
+
+    def rollback(self, delivery_id: str) -> None:
+        """Release a reserved delivery_id after dispatch failure."""
+
+    def record(self, delivery_id: str, *, now: float | None = None) -> None:
+        """Record delivery_id after successful dispatch."""
+
+
+_DEFAULT_REPLAY_CACHE = GitHubDeliveryReplayCache()
+
+
+def _normalize_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {str(k).lower(): str(v) for k, v in headers.items()}
+
+
+def validate_github_signature(
+    *,
+    webhook_secret: str,
+    body: bytes,
+    signature_header: str | None,
+) -> bool:
+    """Return ``True`` when ``X-Hub-Signature-256`` matches ``body``."""
+
+    if not webhook_secret or not signature_header:
+        return False
+    if not signature_header.startswith(_SIGNATURE_PREFIX):
+        return False
+    signature_hex = signature_header[len(_SIGNATURE_PREFIX) :].strip().lower()
+    if len(signature_hex) != 64:
+        return False
+    if any(ch not in _HEX_DIGITS for ch in signature_hex):
+        return False
+    expected = hmac.new(
+        webhook_secret.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(signature_hex, expected)
+
+
+def extract_changed_paths(push_payload: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return normalized changed paths from ``commits[].{added,modified,removed}``."""
+
+    changed_paths: set[str] = set()
+    commits = push_payload.get("commits")
+    if not isinstance(commits, list):
+        return ()
+    for commit in commits:
+        if not isinstance(commit, dict):
+            continue
+        for key in ("added", "modified", "removed"):
+            values = commit.get(key)
+            if not isinstance(values, list):
+                continue
+            for value in values:
+                if not isinstance(value, str) or not value:
+                    continue
+                changed_paths.add(validate_external_path(value))
+    return tuple(sorted(changed_paths))
+
+
+def parse_github_push_event(
+    *, headers: Mapping[str, str], body: bytes, webhook_secret: str
+) -> GitHubPushEvent | None:
+    """Validate and parse a GitHub push webhook event.
+
+    Returns ``None`` for non-push events.
+    Raises ``RelayValidationError`` for malformed/unsigned payloads.
+    """
+
+    normalized_headers = _normalize_headers(headers)
+    event_name = normalized_headers.get(_GITHUB_EVENT_HEADER)
+    if not event_name:
+        raise RelayValidationError("missing X-GitHub-Event header")
+
+    delivery_id = normalized_headers.get(_GITHUB_DELIVERY_HEADER)
+    if not delivery_id:
+        raise RelayValidationError("missing X-GitHub-Delivery header")
+
+    signature_header = normalized_headers.get(_GITHUB_SIGNATURE_HEADER)
+    if not validate_github_signature(
+        webhook_secret=webhook_secret,
+        body=body,
+        signature_header=signature_header,
+    ):
+        raise RelayValidationError("invalid X-Hub-Signature-256 header")
+
+    if event_name != "push":
+        return None
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RelayValidationError(f"invalid webhook JSON body: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise RelayValidationError("webhook JSON body must be an object")
+
+    repository = payload.get("repository")
+    if not isinstance(repository, dict):
+        raise RelayValidationError("push payload missing repository object")
+
+    repo_name = repository.get("name")
+    owner_obj = repository.get("owner")
+    if not isinstance(repo_name, str) or not repo_name:
+        raise RelayValidationError("push payload repository.name is required")
+    if not isinstance(owner_obj, dict):
+        raise RelayValidationError("push payload repository.owner is required")
+
+    owner_login = owner_obj.get("login") or owner_obj.get("name")
+    if not isinstance(owner_login, str) or not owner_login:
+        raise RelayValidationError(
+            "push payload repository.owner.login (or owner.name) is required"
+        )
+
+    try:
+        changed_paths = extract_changed_paths(payload)
+    except ValueError as exc:
+        raise RelayValidationError(f"invalid changed path in push payload: {exc}") from exc
+    return GitHubPushEvent(
+        owner=owner_login,
+        repo=repo_name,
+        changed_paths=changed_paths,
+        delivery_id=delivery_id,
+        event_name=event_name,
+    )
+
+
+def _safe_repo_relative(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _normalize_registry_entry_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return validate_external_path(value)
+    except ValueError:
+        return None
+
+
+def _intersect_monitored_paths(
+    *, registry: Mapping[str, Any], changed_paths: tuple[str, ...]
+) -> list[str]:
+    changed = set(changed_paths)
+    tracked: set[str] = set()
+    entries = registry.get("entries")
+    if not isinstance(entries, list):
+        return []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("tracking_status") not in _MONITORED_TRACKING_STATUSES:
+            continue
+        normalized = _normalize_registry_entry_path(entry.get("path"))
+        if normalized is not None:
+            tracked.add(normalized)
+    return sorted(changed.intersection(tracked))
+
+
+def build_upstream_source_payload(
+    *,
+    registry_path: str,
+    owner: str,
+    repo: str,
+    changed_paths: list[str],
+    delivery_id: str,
+    event_name: str,
+) -> UpstreamSourceUpdatedPayload:
+    payload: UpstreamSourceUpdatedPayload = {
+        "registry_path": registry_path,
+        "owner": owner,
+        "repo": repo,
+        "changed_paths": changed_paths,
+        "delivery_id": delivery_id,
+        "event_name": event_name,
+    }
+    return validate_upstream_source_payload(payload)
+
+
+def validate_upstream_source_payload(
+    payload: Mapping[str, Any],
+) -> UpstreamSourceUpdatedPayload:
+    """Validate the stable payload contract for CI-5 dispatch events."""
+
+    expected_fields = {
+        "registry_path",
+        "owner",
+        "repo",
+        "changed_paths",
+        "delivery_id",
+        "event_name",
+    }
+    extra_fields = sorted(set(payload.keys()) - expected_fields)
+    if extra_fields:
+        raise RelayValidationError(
+            f"payload contains unexpected field(s): {', '.join(extra_fields)}"
+        )
+
+    required_fields = (
+        "registry_path",
+        "owner",
+        "repo",
+        "delivery_id",
+        "event_name",
+    )
+    for field in required_fields:
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            raise RelayValidationError(f"payload field {field!r} must be a string")
+        if field == "registry_path" and len(value) > _MAX_REGISTRY_PATH_LENGTH:
+            raise RelayValidationError("payload field 'registry_path' exceeds max length")
+        if field != "registry_path" and len(value) > _MAX_IDENTIFIER_LENGTH:
+            raise RelayValidationError(f"payload field {field!r} exceeds max length")
+    if payload["event_name"] != "push":
+        raise RelayValidationError("payload field 'event_name' must be 'push'")
+    changed_paths = payload.get("changed_paths")
+    if not isinstance(changed_paths, list):
+        raise RelayValidationError("payload field 'changed_paths' must be a list")
+    if not changed_paths:
+        raise RelayValidationError("payload field 'changed_paths' must not be empty")
+    if len(changed_paths) > _MAX_CHANGED_PATHS:
+        raise RelayValidationError(
+            f"payload field 'changed_paths' exceeds max count {_MAX_CHANGED_PATHS}"
+        )
+    normalized_changed_paths: list[str] = []
+    for path in changed_paths:
+        if not isinstance(path, str) or not path:
+            raise RelayValidationError(
+                "payload field 'changed_paths' must contain non-empty strings"
+            )
+        if len(path) > _MAX_REGISTRY_PATH_LENGTH:
+            raise RelayValidationError(
+                "payload field 'changed_paths' contains path exceeding max length"
+            )
+        try:
+            normalized_changed_paths.append(validate_external_path(path))
+        except ValueError as exc:
+            raise RelayValidationError(str(exc)) from exc
+
+    registry_path = payload["registry_path"]
+    registry_parts = PurePosixPath(registry_path).parts
+    if (
+        PurePosixPath(registry_path).is_absolute()
+        or ".." in registry_parts
+        or not registry_path.startswith("raw/github-sources/")
+        or not registry_path.endswith(".source-registry.json")
+    ):
+        raise RelayValidationError("payload field 'registry_path' is invalid")
+
+    validated: UpstreamSourceUpdatedPayload = {
+        "registry_path": registry_path,
+        "owner": str(payload["owner"]),
+        "repo": str(payload["repo"]),
+        "changed_paths": sorted(set(normalized_changed_paths)),
+        "delivery_id": str(payload["delivery_id"]),
+        "event_name": str(payload["event_name"]),
+    }
+    return validated
+
+
+def plan_upstream_source_dispatches(
+    *,
+    repo_root: Path,
+    push_event: GitHubPushEvent,
+) -> list[UpstreamSourceUpdatedPayload]:
+    """Build per-registry repository_dispatch payloads for a push event."""
+
+    if not push_event.changed_paths:
+        return []
+
+    registry_pattern = (
+        repo_root / "raw" / "github-sources" / "*.source-registry.json"
+    ).as_posix()
+    payloads: list[UpstreamSourceUpdatedPayload] = []
+    for path_string in sorted(glob_module.glob(registry_pattern)):
+        registry_file = Path(path_string)
+        try:
+            parsed = json.loads(registry_file.read_text(encoding="utf-8"))
+            registry = validate_registry_file(parsed)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise RelayValidationError(
+                f"registry file is unreadable/invalid: {registry_file}: {exc}"
+            ) from exc
+        if (
+            registry.get("owner") != push_event.owner
+            or registry.get("repo") != push_event.repo
+        ):
+            continue
+        matching_paths = _intersect_monitored_paths(
+            registry=registry,
+            changed_paths=push_event.changed_paths,
+        )
+        if not matching_paths:
+            continue
+        try:
+            registry_path = _safe_repo_relative(registry_file, repo_root)
+        except (OSError, ValueError) as exc:
+            raise RelayValidationError(
+                f"registry path escaped repo root: {registry_file}: {exc}"
+            ) from exc
+        payloads.append(
+            build_upstream_source_payload(
+                registry_path=registry_path,
+                owner=push_event.owner,
+                repo=push_event.repo,
+                changed_paths=matching_paths,
+                delivery_id=push_event.delivery_id,
+                event_name=push_event.event_name,
+            )
+        )
+    return payloads
+
+
+def relay_github_push_event(
+    *,
+    repo_root: Path,
+    headers: Mapping[str, str],
+    body: bytes,
+    webhook_secret: str,
+    dispatch_client: RepositoryDispatchClient,
+    replay_cache: GitHubReplayCache | None = None,
+) -> GitHubRelayResult:
+    """Validate a webhook event, path-filter, and emit repository_dispatch."""
+
+    try:
+        push_event = parse_github_push_event(
+            headers=headers,
+            body=body,
+            webhook_secret=webhook_secret,
+        )
+    except RelayValidationError as exc:
+        return GitHubRelayResult(
+            status="rejected",
+            reason=str(exc),
+            dispatched_count=0,
+            payloads=(),
+        )
+
+    if push_event is None:
+        return GitHubRelayResult(
+            status="ignored",
+            reason="event_not_push",
+            dispatched_count=0,
+            payloads=(),
+        )
+
+    try:
+        payloads = tuple(
+            plan_upstream_source_dispatches(repo_root=repo_root, push_event=push_event)
+        )
+    except RelayValidationError as exc:
+        return GitHubRelayResult(
+            status="rejected",
+            reason=str(exc),
+            dispatched_count=0,
+            payloads=(),
+        )
+    if not payloads:
+        return GitHubRelayResult(
+            status="ignored",
+            reason="no_registry_match_or_path_intersection",
+            dispatched_count=0,
+            payloads=(),
+        )
+
+    effective_replay_cache = replay_cache or _DEFAULT_REPLAY_CACHE
+    if effective_replay_cache.reserve(push_event.delivery_id):
+        return GitHubRelayResult(
+            status="ignored",
+            reason="replay_suppressed",
+            dispatched_count=0,
+            payloads=(),
+        )
+
+    dispatched_count = 0
+    try:
+        for payload in payloads:
+            dispatch_client.dispatch(
+                event_type=_UPSTREAM_SOURCE_UPDATED_EVENT,
+                client_payload=payload,
+            )
+            dispatched_count += 1
+    except Exception as exc:  # pragma: no cover - defensive envelope
+        effective_replay_cache.rollback(push_event.delivery_id)
+        return GitHubRelayResult(
+            status="failed",
+            reason=f"dispatch_failed: {exc}",
+            dispatched_count=dispatched_count,
+            payloads=payloads,
+        )
+
+    effective_replay_cache.commit(push_event.delivery_id)
+    return GitHubRelayResult(
+        status="dispatched",
+        reason="ok",
+        dispatched_count=dispatched_count,
+        payloads=payloads,
+    )
+
+
+__all__ = [
+    "GitHubApiDispatchClient",
+    "GitHubDeliveryReplayCache",
+    "GitHubReplayCache",
+    "GitHubPushEvent",
+    "GitHubRelayResult",
+    "RelayValidationError",
+    "RepositoryDispatchClient",
+    "RepositoryDispatchError",
+    "UpstreamSourceUpdatedPayload",
+    "build_upstream_source_payload",
+    "extract_changed_paths",
+    "parse_github_push_event",
+    "plan_upstream_source_dispatches",
+    "relay_github_push_event",
+    "validate_github_signature",
+    "validate_upstream_source_payload",
+]

--- a/scripts/github_monitor/dispatch_client.py
+++ b/scripts/github_monitor/dispatch_client.py
@@ -1,0 +1,88 @@
+"""Shared repository_dispatch HTTP client for webhook relays."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Protocol
+
+_GITHUB_API_BASE = "https://api.github.com"
+
+
+class RepositoryDispatchError(OSError):
+    """Raised when repository_dispatch API requests fail."""
+
+
+class RepositoryDispatchClient(Protocol):
+    """Abstract dispatch client used by relay logic."""
+
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        """Emit a repository_dispatch event."""
+
+
+class GitHubApiDispatchClient:
+    """Thin repository_dispatch wrapper around the GitHub REST API."""
+
+    def __init__(
+        self,
+        *,
+        target_owner: str,
+        target_repo: str,
+        token: str,
+        base_url: str = _GITHUB_API_BASE,
+        timeout_seconds: int = 30,
+    ) -> None:
+        if not target_owner or not target_repo:
+            raise ValueError("target_owner and target_repo are required")
+        if not token:
+            raise ValueError("token is required")
+        self._target_owner = target_owner
+        self._target_repo = target_repo
+        self._token = token
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        payload = {
+            "event_type": event_type,
+            "client_payload": dict(client_payload),
+        }
+        request = urllib.request.Request(
+            url=(
+                f"{self._base_url}/repos/"
+                f"{self._target_owner}/{self._target_repo}/dispatches"
+            ),
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Content-Type": "application/json",
+                "User-Agent": "knowledgebase-webhook-relay/1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self._timeout_seconds
+            ) as response:
+                if getattr(response, "status", 204) >= 400:
+                    raise RepositoryDispatchError(
+                        f"repository_dispatch failed with HTTP {response.status}"
+                    )
+        except urllib.error.HTTPError as exc:
+            raise RepositoryDispatchError(
+                f"repository_dispatch failed with HTTP {exc.code}: {exc.reason}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RepositoryDispatchError(
+                f"repository_dispatch request failed: {exc.reason}"
+            ) from exc
+
+
+__all__ = [
+    "GitHubApiDispatchClient",
+    "RepositoryDispatchClient",
+    "RepositoryDispatchError",
+]

--- a/tests/drive_monitor/test_relay.py
+++ b/tests/drive_monitor/test_relay.py
@@ -1,0 +1,460 @@
+"""Unit tests for scripts/drive_monitor/_relay.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from scripts.drive_monitor._relay import (
+    DriveReplayCache,
+    RelayValidationError,
+    RepositoryDispatchError,
+    build_drive_channel_token,
+    parse_drive_channel_token,
+    relay_drive_notification,
+    validate_drive_source_payload,
+)
+
+
+def _write_registry(repo_root: Path, *, alias: str = "my-alias") -> str:
+    registry_dir = repo_root / "raw" / "drive-sources"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    registry_path = registry_dir / f"{alias}.source-registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "version": "1",
+                "alias": alias,
+                "credential_secret_name": "GDRIVE_SA_KEY",
+                "changes_page_token": None,
+                "last_full_scan_at": None,
+                "folder_entries": [
+                    {
+                        "folder_id": "FOLDER_1",
+                        "folder_name": "Folder One",
+                        "wiki_namespace": "test/",
+                        "tracking_status": "active",
+                    }
+                ],
+                "file_entries": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return f"raw/drive-sources/{alias}.source-registry.json"
+
+
+def _headers(
+    *,
+    token: str,
+    resource_state: str = "update",
+    message_number: str = "1",
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    base = {
+        "X-Goog-Channel-ID": "channel-123",
+        "X-Goog-Channel-Token": token,
+        "X-Goog-Resource-ID": "resource-456",
+        "X-Goog-Resource-State": resource_state,
+        "X-Goog-Message-Number": message_number,
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+class _RecordingDispatchClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        self.calls.append((event_type, client_payload))
+
+
+class _FailingDispatchClient:
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        raise RepositoryDispatchError("boom")
+
+
+def test_build_and_parse_drive_channel_token_round_trip() -> None:
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path="raw/drive-sources/my-alias.source-registry.json",
+        token_secret="relay-secret",
+        file_ids=["FILE_1", "FILE_2"],
+    )
+    context = parse_drive_channel_token(token=token, token_secret="relay-secret")
+    assert context["alias"] == "my-alias"
+    assert context["registry_path"] == "raw/drive-sources/my-alias.source-registry.json"
+    assert context["file_ids"] == ["FILE_1", "FILE_2"]
+
+
+def test_parse_drive_channel_token_rejects_invalid_signature() -> None:
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path="raw/drive-sources/my-alias.source-registry.json",
+        token_secret="relay-secret",
+    )
+    prefix, payload, signature = token.split(".")
+    tampered = f"{prefix}.{payload}.{signature[:-1]}0"
+    with pytest.raises(RelayValidationError):
+        parse_drive_channel_token(token=tampered, token_secret="relay-secret")
+
+
+def test_relay_ignores_sync_heartbeat_notifications(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    client = _RecordingDispatchClient()
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="sync"),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "ignored"
+    assert result.reason == "resource_state_ignored"
+    assert not result.dispatched
+    assert client.calls == []
+
+
+def test_relay_dispatches_relevant_drive_notification(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+        file_ids=["FILE_TOKEN"],
+    )
+    client = _RecordingDispatchClient()
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(
+            token=token,
+            resource_state="update",
+            extra={"X-Goog-File-ID": "FILE_HDR"},
+        ),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "dispatched"
+    assert result.dispatched
+    assert len(client.calls) == 1
+    event_type, payload = client.calls[0]
+    assert event_type == "drive-source-updated"
+    assert payload["alias"] == "my-alias"
+    assert payload["registry_path"] == registry_path
+    assert payload["file_ids"] == ["FILE_HDR", "FILE_TOKEN"]
+    assert payload["channel_id"] == "channel-123"
+    assert payload["resource_id"] == "resource-456"
+    assert payload["resource_state"] == "update"
+    assert payload["message_number"] == 1
+
+
+def test_relay_replay_suppression_uses_header_key(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    cache = DriveReplayCache()
+    client = _RecordingDispatchClient()
+    first = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update", message_number="5"),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=cache,
+    )
+    second = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update", message_number="5"),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=cache,
+    )
+    assert first.status == "dispatched"
+    assert second.status == "ignored"
+    assert second.reason == "replay_suppressed"
+    assert len(client.calls) == 1
+
+
+def test_relay_rejects_alias_registry_mismatch(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="expected-alias")
+    token = build_drive_channel_token(
+        alias="different-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update"),
+        token_secret="relay-secret",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "alias" in result.reason
+
+
+def test_relay_dispatch_failure_returns_failed_result(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update"),
+        token_secret="relay-secret",
+        dispatch_client=_FailingDispatchClient(),
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "failed"
+    assert not result.dispatched
+
+
+def test_relay_dispatch_failure_does_not_consume_replay_key(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    replay_cache = DriveReplayCache()
+    failed = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update", message_number="55"),
+        token_secret="relay-secret",
+        dispatch_client=_FailingDispatchClient(),
+        replay_cache=replay_cache,
+    )
+    successful_client = _RecordingDispatchClient()
+    retried = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update", message_number="55"),
+        token_secret="relay-secret",
+        dispatch_client=successful_client,
+        replay_cache=replay_cache,
+    )
+
+    assert failed.status == "failed"
+    assert retried.status == "dispatched"
+    assert len(successful_client.calls) == 1
+
+
+def test_relay_payload_validation_rejection_does_not_consume_replay_key(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    replay_cache = DriveReplayCache()
+    oversized_header = ",".join(f"FILE_{i}" for i in range(201))
+    rejected = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(
+            token=token,
+            resource_state="update",
+            message_number="56",
+            extra={"X-Goog-File-IDs": oversized_header},
+        ),
+        token_secret="relay-secret",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=replay_cache,
+    )
+    successful_client = _RecordingDispatchClient()
+    retried = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, resource_state="update", message_number="56"),
+        token_secret="relay-secret",
+        dispatch_client=successful_client,
+        replay_cache=replay_cache,
+    )
+
+    assert rejected.status == "rejected"
+    assert retried.status == "dispatched"
+    assert len(successful_client.calls) == 1
+
+
+def test_validate_drive_source_payload_requires_message_number() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_drive_source_payload(
+            {
+                "alias": "my-alias",
+                "registry_path": "raw/drive-sources/my-alias.source-registry.json",
+                "file_ids": [],
+                "channel_id": "channel-123",
+                "resource_id": "resource-456",
+                "resource_state": "update",
+            }
+        )
+
+
+def test_parse_drive_channel_token_rejects_invalid_format() -> None:
+    with pytest.raises(RelayValidationError):
+        parse_drive_channel_token(token="not-a-valid-token", token_secret="relay-secret")
+
+
+def test_relay_rejects_missing_required_headers(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    headers = _headers(token=token, resource_state="update")
+    del headers["X-Goog-Channel-ID"]
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=headers,
+        token_secret="relay-secret",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "x-goog-channel-id" in result.reason
+
+
+def test_relay_rejects_non_integer_message_number(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, message_number="abc"),
+        token_secret="relay-secret",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "message-number" in result.reason
+
+
+def test_relay_rejects_non_positive_message_number(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    result = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, message_number="0"),
+        token_secret="relay-secret",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=DriveReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "positive" in result.reason
+
+
+def test_replay_cache_allows_next_message_number(tmp_path: Path) -> None:
+    registry_path = _write_registry(tmp_path, alias="my-alias")
+    token = build_drive_channel_token(
+        alias="my-alias",
+        registry_path=registry_path,
+        token_secret="relay-secret",
+    )
+    cache = DriveReplayCache()
+    client = _RecordingDispatchClient()
+    first = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, message_number="10"),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=cache,
+    )
+    second = relay_drive_notification(
+        repo_root=tmp_path,
+        headers=_headers(token=token, message_number="11"),
+        token_secret="relay-secret",
+        dispatch_client=client,
+        replay_cache=cache,
+    )
+    assert first.status == "dispatched"
+    assert second.status == "dispatched"
+    assert len(client.calls) == 2
+
+
+def test_replay_cache_expires_old_entries() -> None:
+    cache = DriveReplayCache(ttl_seconds=1)
+    key = "channel-123:resource-456:22"
+    assert cache.check_and_record(key, now=0.0) is False
+    assert cache.check_and_record(key, now=0.5) is True
+    assert cache.check_and_record(key, now=1.1) is False
+
+
+def test_validate_drive_source_payload_rejects_invalid_registry_path() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_drive_source_payload(
+            {
+                "alias": "my-alias",
+                "registry_path": "../raw/drive-sources/my-alias.source-registry.json",
+                "file_ids": [],
+                "channel_id": "channel-123",
+                "resource_id": "resource-456",
+                "resource_state": "update",
+                "message_number": 1,
+            }
+        )
+
+
+def test_validate_drive_source_payload_rejects_non_string_file_ids() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_drive_source_payload(
+            {
+                "alias": "my-alias",
+                "registry_path": "raw/drive-sources/my-alias.source-registry.json",
+                "file_ids": [123],
+                "channel_id": "channel-123",
+                "resource_id": "resource-456",
+                "resource_state": "update",
+                "message_number": 1,
+            }
+        )
+
+
+def test_validate_drive_source_payload_rejects_unexpected_fields() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_drive_source_payload(
+            {
+                "alias": "my-alias",
+                "registry_path": "raw/drive-sources/my-alias.source-registry.json",
+                "file_ids": [],
+                "channel_id": "channel-123",
+                "resource_id": "resource-456",
+                "resource_state": "update",
+                "message_number": 1,
+                "unexpected": "field",
+            }
+        )
+
+
+def test_validate_drive_source_payload_rejects_too_many_file_ids() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_drive_source_payload(
+            {
+                "alias": "my-alias",
+                "registry_path": "raw/drive-sources/my-alias.source-registry.json",
+                "file_ids": [f"FILE_{i}" for i in range(201)],
+                "channel_id": "channel-123",
+                "resource_id": "resource-456",
+                "resource_state": "update",
+                "message_number": 1,
+            }
+        )

--- a/tests/kb/test_ci5_workflow.py
+++ b/tests/kb/test_ci5_workflow.py
@@ -1,0 +1,140 @@
+"""Workflow contract checks for CI-5 GitHub monitor."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+WORKFLOW_PATH = Path(".github/workflows/ci-5-github-monitor.yml")
+
+
+class Ci5WorkflowContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(WORKFLOW_PATH.exists(), f"Missing: {WORKFLOW_PATH}")
+        self.workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.workflow = yaml.safe_load(self.workflow_text)
+
+    def _detect_step_script(self) -> str:
+        steps = self.workflow["jobs"]["check-drift"]["steps"]
+        for step in steps:
+            if step.get("name") == "Check drift across all registries":
+                script = step.get("run")
+                self.assertIsInstance(script, str)
+                return script.replace("${{ github.run_id }}", "123456")
+        self.fail("Unable to locate CI-5 detect step script")
+
+    def _run_detect_script(
+        self,
+        *,
+        event_name: str,
+        dispatch_registry_path: str,
+        workflow_registry_path: str = "",
+        use_fake_python: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        script = self._detect_step_script()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            github_output_path = temp_root / "github-output.txt"
+            github_output_path.write_text("", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "GITHUB_EVENT_NAME": event_name,
+                    "DISPATCH_REGISTRY_PATH": dispatch_registry_path,
+                    "REGISTRY_PATH": workflow_registry_path,
+                    "GITHUB_OUTPUT": str(github_output_path),
+                }
+            )
+
+            if use_fake_python:
+                fake_bin = temp_root / "bin"
+                fake_bin.mkdir(parents=True, exist_ok=True)
+                fake_python = fake_bin / "python"
+                fake_python.write_text(
+                    "#!/usr/bin/env bash\n"
+                    "set -euo pipefail\n"
+                    "if [[ \"${1:-}\" == \"-m\" ]] && [[ \"${2:-}\" == \"scripts.github_monitor.check_drift\" ]]; then\n"
+                    "  out=\"drift-report.json\"\n"
+                    "  shift 2\n"
+                    "  while [[ $# -gt 0 ]]; do\n"
+                    "    case \"${1}\" in\n"
+                    "      --output)\n"
+                    "        out=\"${2}\"\n"
+                    "        shift 2\n"
+                    "        ;;\n"
+                    "      *)\n"
+                    "        shift\n"
+                    "        ;;\n"
+                    "    esac\n"
+                    "  done\n"
+                    "  printf '{\"has_drift\": false}\\n' > \"${out}\"\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exec python3 \"$@\"\n",
+                    encoding="utf-8",
+                )
+                fake_python.chmod(0o755)
+                env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=temp_root,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+            return result, github_output_path.read_text(encoding="utf-8")
+
+    def test_repository_dispatch_registry_payload_validation_fails_closed(self) -> None:
+        result, _ = self._run_detect_script(
+            event_name="repository_dispatch",
+            dispatch_registry_path="../bad-path",
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertNotEqual(result.returncode, 0, combined_output)
+        self.assertIn("Invalid repository_dispatch registry_path payload", combined_output)
+
+    def test_repository_dispatch_registry_payload_validation_accepts_safe_hint(self) -> None:
+        result, github_output = self._run_detect_script(
+            event_name="repository_dispatch",
+            dispatch_registry_path="raw/github-sources/example.source-registry.json",
+            use_fake_python=True,
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertEqual(result.returncode, 0, combined_output)
+        self.assertIn("drift_detected=false", github_output)
+        self.assertIn("artifact_name=drift-report-123456", github_output)
+
+    def test_workflow_dispatch_registry_input_validation_fails_closed(self) -> None:
+        result, _ = self._run_detect_script(
+            event_name="workflow_dispatch",
+            dispatch_registry_path="",
+            workflow_registry_path="../bad-path",
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertNotEqual(result.returncode, 0, combined_output)
+        self.assertIn("Invalid workflow_dispatch registry_path input", combined_output)
+
+    def test_workflow_dispatch_registry_input_validation_accepts_safe_path(self) -> None:
+        result, github_output = self._run_detect_script(
+            event_name="workflow_dispatch",
+            dispatch_registry_path="",
+            workflow_registry_path="raw/github-sources/example.source-registry.json",
+            use_fake_python=True,
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertEqual(result.returncode, 0, combined_output)
+        self.assertIn("drift_detected=false", github_output)
+        self.assertIn("artifact_name=drift-report-123456", github_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kb/test_ci6_workflow.py
+++ b/tests/kb/test_ci6_workflow.py
@@ -1,0 +1,151 @@
+"""Workflow contract checks for CI-6 Drive monitor."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+WORKFLOW_PATH = Path(".github/workflows/ci-6-google-drive-monitor.yml")
+
+
+class Ci6WorkflowContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(WORKFLOW_PATH.exists(), f"Missing: {WORKFLOW_PATH}")
+        self.workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.workflow = yaml.safe_load(self.workflow_text)
+
+    def _detect_step_script(self) -> str:
+        steps = self.workflow["jobs"]["check-drift"]["steps"]
+        for step in steps:
+            if step.get("name") == "Check drift across all registries":
+                script = step.get("run")
+                self.assertIsInstance(script, str)
+                return script.replace("${{ github.run_id }}", "123456")
+        self.fail("Unable to locate CI-6 detect step script")
+
+    def _run_detect_script(
+        self,
+        *,
+        event_name: str,
+        dispatch_registry_path: str,
+        workflow_registry_path: str = "",
+        use_fake_python: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        script = self._detect_step_script()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            github_output_path = temp_root / "github-output.txt"
+            github_output_path.write_text("", encoding="utf-8")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "GITHUB_EVENT_NAME": event_name,
+                    "DISPATCH_REGISTRY_PATH": dispatch_registry_path,
+                    "REGISTRY_PATH": workflow_registry_path,
+                    "GITHUB_OUTPUT": str(github_output_path),
+                }
+            )
+
+            if use_fake_python:
+                fake_bin = temp_root / "bin"
+                fake_bin.mkdir(parents=True, exist_ok=True)
+                fake_python = fake_bin / "python"
+                fake_python.write_text(
+                    "#!/usr/bin/env bash\n"
+                    "set -euo pipefail\n"
+                    "if [[ \"${1:-}\" == \"-m\" ]] && [[ \"${2:-}\" == \"scripts.drive_monitor.check_drift\" ]]; then\n"
+                    "  out=\"drift-report.json\"\n"
+                    "  shift 2\n"
+                    "  while [[ $# -gt 0 ]]; do\n"
+                    "    case \"${1}\" in\n"
+                    "      --output)\n"
+                    "        out=\"${2}\"\n"
+                    "        shift 2\n"
+                    "        ;;\n"
+                    "      *)\n"
+                    "        shift\n"
+                    "        ;;\n"
+                    "    esac\n"
+                    "  done\n"
+                    "  printf '{\"has_drift\": false}\\n' > \"${out}\"\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exec python3 \"$@\"\n",
+                    encoding="utf-8",
+                )
+                fake_python.chmod(0o755)
+                env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=temp_root,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+            return result, github_output_path.read_text(encoding="utf-8")
+
+    def test_concurrency_group_uses_drive_payload_keys(self) -> None:
+        concurrency = self.workflow.get("concurrency", {})
+        group = str(concurrency.get("group", ""))
+        self.assertIn("channel_id", group)
+        self.assertIn("resource_id", group)
+        self.assertIn("message_number", group)
+        self.assertEqual(
+            concurrency.get("cancel-in-progress"),
+            "${{ github.event_name == 'repository_dispatch' }}",
+        )
+
+    def test_repository_dispatch_registry_payload_validation_fails_closed(self) -> None:
+        result, _ = self._run_detect_script(
+            event_name="repository_dispatch",
+            dispatch_registry_path="../bad-path",
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertNotEqual(result.returncode, 0, combined_output)
+        self.assertIn("Invalid repository_dispatch registry_path payload", combined_output)
+
+    def test_repository_dispatch_registry_payload_validation_accepts_safe_hint(self) -> None:
+        result, github_output = self._run_detect_script(
+            event_name="repository_dispatch",
+            dispatch_registry_path="raw/drive-sources/example.source-registry.json",
+            use_fake_python=True,
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertEqual(result.returncode, 0, combined_output)
+        self.assertIn("drift_detected=false", github_output)
+        self.assertIn("artifact_name=drive-drift-report-123456", github_output)
+
+    def test_workflow_dispatch_registry_input_validation_fails_closed(self) -> None:
+        result, _ = self._run_detect_script(
+            event_name="workflow_dispatch",
+            dispatch_registry_path="",
+            workflow_registry_path="../bad-path",
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertNotEqual(result.returncode, 0, combined_output)
+        self.assertIn("Invalid workflow_dispatch registry_path input", combined_output)
+
+    def test_workflow_dispatch_registry_input_validation_accepts_safe_path(self) -> None:
+        result, github_output = self._run_detect_script(
+            event_name="workflow_dispatch",
+            dispatch_registry_path="",
+            workflow_registry_path="raw/drive-sources/example.source-registry.json",
+            use_fake_python=True,
+        )
+        combined_output = f"{result.stdout}\n{result.stderr}"
+        self.assertEqual(result.returncode, 0, combined_output)
+        self.assertIn("drift_detected=false", github_output)
+        self.assertIn("artifact_name=drive-drift-report-123456", github_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kb/test_dispatch_client.py
+++ b/tests/kb/test_dispatch_client.py
@@ -1,0 +1,121 @@
+"""Unit tests for scripts/github_monitor/dispatch_client.py."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+import pytest
+
+from scripts.github_monitor.dispatch_client import (
+    GitHubApiDispatchClient,
+    RepositoryDispatchError,
+)
+
+
+class _Response:
+    def __init__(self, status: int = 204) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+
+def test_dispatch_posts_expected_request_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _urlopen(request: urllib.request.Request, timeout: int) -> _Response:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _Response(status=204)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+    client = GitHubApiDispatchClient(
+        target_owner="owner",
+        target_repo="repo",
+        token="token-123",
+    )
+    client.dispatch(
+        event_type="upstream-source-updated",
+        client_payload={"registry_path": "raw/github-sources/source.source-registry.json"},
+    )
+
+    request: urllib.request.Request = captured["request"]
+    assert request.full_url == "https://api.github.com/repos/owner/repo/dispatches"
+    assert request.get_method() == "POST"
+    assert captured["timeout"] == 30
+    body = json.loads(request.data.decode("utf-8"))
+    assert body["event_type"] == "upstream-source-updated"
+    assert body["client_payload"]["registry_path"] == "raw/github-sources/source.source-registry.json"
+    normalized_headers = {key.lower(): value for key, value in request.headers.items()}
+    assert normalized_headers["authorization"] == "Bearer token-123"
+    assert normalized_headers["content-type"] == "application/json"
+
+
+def test_dispatch_maps_http_error_to_repository_dispatch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _urlopen(request: urllib.request.Request, timeout: int) -> _Response:
+        raise urllib.error.HTTPError(
+            url=request.full_url,
+            code=502,
+            msg="Bad Gateway",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+    client = GitHubApiDispatchClient(
+        target_owner="owner",
+        target_repo="repo",
+        token="token-123",
+    )
+    with pytest.raises(RepositoryDispatchError, match="HTTP 502"):
+        client.dispatch(event_type="upstream-source-updated", client_payload={"k": "v"})
+
+
+def test_dispatch_maps_non_exception_http_error_status_to_repository_dispatch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _urlopen(request: urllib.request.Request, timeout: int) -> _Response:
+        return _Response(status=500)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+    client = GitHubApiDispatchClient(
+        target_owner="owner",
+        target_repo="repo",
+        token="token-123",
+    )
+    with pytest.raises(RepositoryDispatchError, match="HTTP 500"):
+        client.dispatch(event_type="upstream-source-updated", client_payload={"k": "v"})
+
+
+def test_dispatch_maps_url_error_to_repository_dispatch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _urlopen(request: urllib.request.Request, timeout: int) -> _Response:
+        raise urllib.error.URLError(reason="network unreachable")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+    client = GitHubApiDispatchClient(
+        target_owner="owner",
+        target_repo="repo",
+        token="token-123",
+    )
+    with pytest.raises(RepositoryDispatchError, match="network unreachable"):
+        client.dispatch(event_type="upstream-source-updated", client_payload={"k": "v"})
+
+
+def test_client_constructor_requires_owner_repo_and_token() -> None:
+    with pytest.raises(ValueError):
+        GitHubApiDispatchClient(target_owner="", target_repo="repo", token="token")
+    with pytest.raises(ValueError):
+        GitHubApiDispatchClient(target_owner="owner", target_repo="", token="token")
+    with pytest.raises(ValueError):
+        GitHubApiDispatchClient(target_owner="owner", target_repo="repo", token="")

--- a/tests/kb/test_github_monitor_relay.py
+++ b/tests/kb/test_github_monitor_relay.py
@@ -1,0 +1,527 @@
+"""Unit tests for scripts/github_monitor/_relay.py."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from scripts.github_monitor._relay import (
+    GitHubDeliveryReplayCache,
+    RelayValidationError,
+    RepositoryDispatchError,
+    extract_changed_paths,
+    parse_github_push_event,
+    relay_github_push_event,
+    validate_github_signature,
+    validate_upstream_source_payload,
+)
+
+
+def _sign(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _push_body(
+    *,
+    owner: str = "upstream-owner",
+    repo: str = "upstream-repo",
+    commits: list[dict[str, Any]] | None = None,
+) -> bytes:
+    payload = {
+        "repository": {
+            "name": repo,
+            "owner": {"login": owner},
+        },
+        "commits": commits
+        or [
+            {
+                "added": [],
+                "modified": [],
+                "removed": [],
+            }
+        ],
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def _headers(
+    body: bytes,
+    *,
+    secret: str,
+    event_name: str = "push",
+    delivery_id: str = "delivery-123",
+) -> dict[str, str]:
+    return {
+        "X-GitHub-Event": event_name,
+        "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(secret, body),
+    }
+
+
+def _write_registry(
+    repo_root: Path,
+    *,
+    owner: str = "upstream-owner",
+    repo: str = "upstream-repo",
+    entries: list[dict[str, Any]] | None = None,
+    filename: str = "upstream.source-registry.json",
+) -> Path:
+    registry_dir = repo_root / "raw" / "github-sources"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    path = registry_dir / filename
+    path.write_text(
+        json.dumps(
+            {
+                "version": "1",
+                "owner": owner,
+                "repo": repo,
+                "entries": entries or [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class _RecordingDispatchClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        self.calls.append((event_type, client_payload))
+
+
+class _FailingDispatchClient:
+    def dispatch(self, *, event_type: str, client_payload: Mapping[str, Any]) -> None:
+        raise RepositoryDispatchError("boom")
+
+
+def test_validate_github_signature_accepts_valid_signature() -> None:
+    secret = "top-secret"
+    body = b'{"ok": true}'
+    assert validate_github_signature(
+        webhook_secret=secret,
+        body=body,
+        signature_header=_sign(secret, body),
+    )
+
+
+def test_validate_github_signature_rejects_invalid_signature() -> None:
+    assert not validate_github_signature(
+        webhook_secret="top-secret",
+        body=b'{"ok": true}',
+        signature_header="sha256=" + ("0" * 63),
+    )
+
+
+def test_extract_changed_paths_merges_added_modified_removed() -> None:
+    changed = extract_changed_paths(
+        {
+            "commits": [
+                {
+                    "added": ["a.md"],
+                    "modified": ["b.md"],
+                    "removed": ["c.md"],
+                },
+                {
+                    "added": ["b.md"],
+                    "modified": [],
+                    "removed": [],
+                },
+            ]
+        }
+    )
+    assert changed == ("a.md", "b.md", "c.md")
+
+
+def test_relay_filters_paths_to_monitored_entries(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[
+            {"path": "docs/guide.md", "tracking_status": "active"},
+            {"path": "docs/paused.md", "tracking_status": "paused"},
+        ],
+    )
+    body = _push_body(
+        commits=[
+            {
+                "added": ["docs/paused.md"],
+                "modified": ["docs/guide.md", "untracked.md"],
+                "removed": [],
+            }
+        ]
+    )
+    client = _RecordingDispatchClient()
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=client,
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+
+    assert result.status == "dispatched"
+    assert result.dispatched_count == 1
+    assert len(client.calls) == 1
+    event_type, payload = client.calls[0]
+    assert event_type == "upstream-source-updated"
+    assert payload["registry_path"] == "raw/github-sources/upstream.source-registry.json"
+    assert payload["owner"] == "upstream-owner"
+    assert payload["repo"] == "upstream-repo"
+    assert payload["changed_paths"] == ["docs/guide.md"]
+    assert payload["delivery_id"] == "delivery-123"
+    assert payload["event_name"] == "push"
+
+
+def test_relay_ignores_when_no_registry_path_intersection(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+    )
+    body = _push_body(
+        commits=[
+            {
+                "added": [],
+                "modified": ["docs/other.md"],
+                "removed": [],
+            }
+        ]
+    )
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+
+    assert result.status == "ignored"
+    assert result.reason == "no_registry_match_or_path_intersection"
+    assert result.dispatched_count == 0
+
+
+def test_relay_fails_closed_on_invalid_signature(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+    )
+    body = _push_body(
+        commits=[
+            {
+                "added": [],
+                "modified": ["docs/guide.md"],
+                "removed": [],
+            }
+        ]
+    )
+    headers = _headers(body, secret="secret-1")
+    headers["X-Hub-Signature-256"] = "sha256=bad"
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=headers,
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+
+    assert result.status == "rejected"
+    assert result.dispatched_count == 0
+
+
+def test_relay_dispatch_failure_returns_failed_result(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+    )
+    body = _push_body(
+        commits=[
+            {
+                "added": [],
+                "modified": ["docs/guide.md"],
+                "removed": [],
+            }
+        ]
+    )
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_FailingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+
+    assert result.status == "failed"
+    assert result.dispatched_count == 0
+
+
+def test_relay_dispatch_failure_does_not_consume_replay_key(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+    )
+    body = _push_body(
+        commits=[{"added": [], "modified": ["docs/guide.md"], "removed": []}]
+    )
+    replay_cache = GitHubDeliveryReplayCache()
+    failed = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1", delivery_id="delivery-retry"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_FailingDispatchClient(),
+        replay_cache=replay_cache,
+    )
+    successful_client = _RecordingDispatchClient()
+    retried = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1", delivery_id="delivery-retry"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=successful_client,
+        replay_cache=replay_cache,
+    )
+
+    assert failed.status == "failed"
+    assert retried.status == "dispatched"
+    assert len(successful_client.calls) == 1
+
+
+def test_validate_upstream_source_payload_requires_contract_fields() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_upstream_source_payload(
+            {
+                "registry_path": "raw/github-sources/a.source-registry.json",
+                "owner": "owner",
+                "repo": "repo",
+                "changed_paths": ["docs/guide.md"],
+                "delivery_id": "delivery-1",
+            }
+        )
+
+
+def test_validate_github_signature_rejects_missing_and_malformed_headers() -> None:
+    body = b'{"ok": true}'
+    assert not validate_github_signature(
+        webhook_secret="secret",
+        body=body,
+        signature_header=None,
+    )
+    assert not validate_github_signature(
+        webhook_secret="secret",
+        body=body,
+        signature_header="md5=abc",
+    )
+    assert not validate_github_signature(
+        webhook_secret="secret",
+        body=body,
+        signature_header="sha256=zzzz",
+    )
+
+
+def test_parse_push_event_requires_event_and_delivery_headers() -> None:
+    body = _push_body()
+    with pytest.raises(RelayValidationError):
+        parse_github_push_event(
+            headers={"X-GitHub-Delivery": "delivery-1"},
+            body=body,
+            webhook_secret="secret-1",
+        )
+    with pytest.raises(RelayValidationError):
+        parse_github_push_event(
+            headers={"X-GitHub-Event": "push"},
+            body=body,
+            webhook_secret="secret-1",
+        )
+
+
+def test_relay_ignores_non_push_events(tmp_path: Path) -> None:
+    body = _push_body()
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1", event_name="ping"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+    assert result.status == "ignored"
+    assert result.reason == "event_not_push"
+
+
+def test_relay_treats_uninitialized_registry_entries_as_monitored(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/new.md", "tracking_status": "uninitialized"}],
+    )
+    body = _push_body(
+        commits=[{"added": ["docs/new.md"], "modified": [], "removed": []}]
+    )
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+    assert result.status == "dispatched"
+    assert result.payloads[0]["changed_paths"] == ["docs/new.md"]
+
+
+def test_relay_rejects_when_registry_file_is_invalid(tmp_path: Path) -> None:
+    registry_dir = tmp_path / "raw" / "github-sources"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    (registry_dir / "broken.source-registry.json").write_text("not json", encoding="utf-8")
+    body = _push_body(
+        commits=[{"added": ["docs/new.md"], "modified": [], "removed": []}]
+    )
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "registry file is unreadable/invalid" in result.reason
+
+
+def test_relay_suppresses_replayed_delivery_ids(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+    )
+    body = _push_body(
+        commits=[{"added": [], "modified": ["docs/guide.md"], "removed": []}]
+    )
+    replay_cache = GitHubDeliveryReplayCache()
+    client = _RecordingDispatchClient()
+    first = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1", delivery_id="delivery-xyz"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=client,
+        replay_cache=replay_cache,
+    )
+    second = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1", delivery_id="delivery-xyz"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=client,
+        replay_cache=replay_cache,
+    )
+    assert first.status == "dispatched"
+    assert second.status == "ignored"
+    assert second.reason == "replay_suppressed"
+    assert len(client.calls) == 1
+
+
+def test_relay_reports_partial_dispatch_count_on_multi_registry_failure(tmp_path: Path) -> None:
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+        filename="first.source-registry.json",
+    )
+    _write_registry(
+        tmp_path,
+        entries=[{"path": "docs/guide.md", "tracking_status": "active"}],
+        filename="second.source-registry.json",
+    )
+    body = _push_body(
+        commits=[{"added": [], "modified": ["docs/guide.md"], "removed": []}]
+    )
+
+    class _FailsOnSecondDispatch:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def dispatch(
+            self, *, event_type: str, client_payload: Mapping[str, Any]
+        ) -> None:
+            self.calls += 1
+            if self.calls == 2:
+                raise RepositoryDispatchError("second dispatch failed")
+
+    client = _FailsOnSecondDispatch()
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=client,
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+    assert result.status == "failed"
+    assert result.dispatched_count == 1
+
+
+def test_validate_upstream_source_payload_rejects_invalid_registry_path() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_upstream_source_payload(
+            {
+                "registry_path": "../raw/github-sources/a.source-registry.json",
+                "owner": "owner",
+                "repo": "repo",
+                "changed_paths": ["docs/guide.md"],
+                "delivery_id": "delivery-1",
+                "event_name": "push",
+            }
+        )
+
+
+def test_validate_upstream_source_payload_rejects_unexpected_fields() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_upstream_source_payload(
+            {
+                "registry_path": "raw/github-sources/a.source-registry.json",
+                "owner": "owner",
+                "repo": "repo",
+                "changed_paths": ["docs/guide.md"],
+                "delivery_id": "delivery-1",
+                "event_name": "push",
+                "unexpected": "field",
+            }
+        )
+
+
+def test_validate_upstream_source_payload_rejects_too_many_changed_paths() -> None:
+    with pytest.raises(RelayValidationError):
+        validate_upstream_source_payload(
+            {
+                "registry_path": "raw/github-sources/a.source-registry.json",
+                "owner": "owner",
+                "repo": "repo",
+                "changed_paths": [f"docs/{i}.md" for i in range(201)],
+                "delivery_id": "delivery-1",
+                "event_name": "push",
+            }
+        )
+
+
+def test_relay_rejects_invalid_changed_paths_in_push_body(tmp_path: Path) -> None:
+    body = _push_body(
+        commits=[{"added": ["../escape.md"], "modified": [], "removed": []}]
+    )
+    result = relay_github_push_event(
+        repo_root=tmp_path,
+        headers=_headers(body, secret="secret-1"),
+        body=body,
+        webhook_secret="secret-1",
+        dispatch_client=_RecordingDispatchClient(),
+        replay_cache=GitHubDeliveryReplayCache(),
+    )
+    assert result.status == "rejected"
+    assert "invalid changed path" in result.reason


### PR DESCRIPTION
## Summary
- harden CI-5 and CI-6 workflows with strict dispatch input/path validation
- add GitHub and Drive relay helpers plus shared repository_dispatch client
- add targeted relay/workflow tests and context freshness updates for monitor modules

## Validation
- `python3 -m pre_commit run --files $(git diff --cached --name-only)`
- `python3 -m pytest tests/drive_monitor/test_relay.py tests/kb/test_ci5_workflow.py tests/kb/test_ci6_workflow.py tests/kb/test_dispatch_client.py tests/kb/test_github_monitor_relay.py -q`