### PR TITLE
feat: add repo-local semantic API lane in wiki search

### DIFF
--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -161,6 +161,62 @@ python3 scripts/reporting/coverage_report.py --mode persist --approval approved
 python3 -m pytest tests/ -q --cov=scripts/kb --cov=scripts.validation._runtime_budget --cov-fail-under=90
 ```
 
+## Wiki search semantic API contract (repo-local)
+
+Issue [#158](https://github.com/wryenmeek/knowledgebase/issues/158) covers the
+repo-local search-page integration only. Hosting/deployment/ownership decisions
+for a production semantic API endpoint remain in
+[#156](https://github.com/wryenmeek/knowledgebase/issues/156).
+
+### Configuration contract
+
+- `wiki/search.md` reads the endpoint from localStorage key
+  `kb-semantic-search-endpoint` (set with the in-page **Save endpoint** control).
+- Endpoint values must resolve to `http` or `https`.
+- Semantic requests always use `POST <base-endpoint>/query`.
+- Pagefind behavior remains active in all modes; semantic failures never disable
+  Pagefind.
+
+### Request contract (`POST <base-endpoint>/query`)
+
+```json
+{
+  "query": "search text",
+  "limit": 5
+}
+```
+
+### Response contract (`2xx application/json`)
+
+```json
+{
+  "results": [
+    {
+      "title": "Result title",
+      "url": "/knowledgebase/concepts/example/",
+      "snippet": "Short excerpt from the result.",
+      "score": 0.92
+    }
+  ]
+}
+```
+
+The `results` array is required. Items may include `title`, `url`, `snippet`,
+and `score`.
+
+### Error and fallback contract
+
+- Missing endpoint: semantic lane stays disabled and Pagefind results remain
+  available.
+- Network failure: semantic lane reports unavailable state and Pagefind results
+  remain available.
+- Non-2xx HTTP status: semantic lane reports HTTP fallback state and Pagefind
+  results remain available.
+- Non-JSON `Content-Type`, JSON parse errors, or missing `results` array:
+  semantic lane reports contract mismatch and Pagefind results remain available.
+- Semantic result rendering must use text nodes (`textContent`) and must not use
+  `innerHTML`.
+
 ## Framework verification entrypoints
 
 Use these repo-local checks when validating the landed framework artifacts

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -59,6 +59,28 @@ qmd query "your question here"
 This builds a local vector index and returns ranked results from the wiki
 content.
 
+### Optional semantic API results in wiki/search.md
+
+The published search page (`wiki/search.md`) supports a second semantic result
+lane in addition to Pagefind.
+
+1. Open `/knowledgebase/search/` on GitHub Pages.
+2. Enter an `http`/`https` endpoint and click **Save endpoint**.
+3. The page stores the endpoint in localStorage key
+   `kb-semantic-search-endpoint` for reuse.
+4. The search page sends semantic queries as `POST <base-endpoint>/query` with
+   JSON payload:
+
+```json
+{
+  "query": "your question here",
+  "limit": 5
+}
+```
+
+If the semantic endpoint is missing or unavailable, Pagefind results remain
+available and the page reports semantic fallback status.
+
 ### GitHub Pages
 
 The wiki is deployed as a browsable website at

--- a/tests/kb/test_pages_workflow.py
+++ b/tests/kb/test_pages_workflow.py
@@ -8,6 +8,9 @@ import unittest
 
 
 WORKFLOW_PATH = Path(".github/workflows/pages.yml")
+SEARCH_PAGE_PATH = Path("wiki/search.md")
+RUNBOOK_PATH = Path("docs/mvp-runbook.md")
+USER_GUIDE_PATH = Path("docs/user-guide.md")
 
 
 class PagesWorkflowContractTests(unittest.TestCase):
@@ -119,6 +122,73 @@ class PagesWorkflowContractTests(unittest.TestCase):
             self.workflow_text,
             r"(?ms)  deploy:\n\s+needs:\s+build\n.*?permissions:\n\s+pages:\s*write\n\s+id-token:\s*write",
         )
+
+
+class SearchPageSemanticContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.assertTrue(SEARCH_PAGE_PATH.exists(), f"Missing search page: {SEARCH_PAGE_PATH}")
+        self.assertTrue(RUNBOOK_PATH.exists(), f"Missing runbook: {RUNBOOK_PATH}")
+        self.assertTrue(USER_GUIDE_PATH.exists(), f"Missing user guide: {USER_GUIDE_PATH}")
+        self.search_page_text = SEARCH_PAGE_PATH.read_text(encoding="utf-8")
+        self.runbook_text = RUNBOOK_PATH.read_text(encoding="utf-8")
+        self.user_guide_text = USER_GUIDE_PATH.read_text(encoding="utf-8")
+
+    def test_search_page_keeps_pagefind_and_declares_semantic_api_markers(self) -> None:
+        expected_markers = (
+            "new PagefindUI(",
+            'element: "#pagefind-search"',
+            'const STORAGE_KEY = "kb-semantic-search-endpoint";',
+            'const SEARCH_PATH = "/query";',
+            '"Content-Type": "application/json"',
+            "query,",
+            "limit: RESULT_LIMIT",
+            "semantic_api_http_",
+            "semantic_api_content_type",
+            "semantic_api_json_parse",
+            "semantic_api_payload_shape",
+            "function sanitizeEndpoint(rawEndpoint)",
+            "function sanitizeResultUrl(rawUrl)",
+            'if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:")',
+            'id="semantic-search"',
+            'id="semantic-api-status"',
+            'id="semantic-results-list"',
+            "Pagefind results remain available.",
+        )
+        for marker in expected_markers:
+            self.assertIn(marker, self.search_page_text)
+        self.assertNotIn("innerHTML", self.search_page_text)
+
+    def test_runbook_documents_semantic_api_contract(self) -> None:
+        expected_markers = (
+            "## Wiki search semantic API contract (repo-local)",
+            "`kb-semantic-search-endpoint`",
+            "Endpoint values must resolve to `http` or `https`",
+            "`POST <base-endpoint>/query`",
+            "`results` array",
+            '"title": "Result title"',
+            '"url": "/knowledgebase/concepts/example/"',
+            '"snippet": "Short excerpt from the result."',
+            '"score": 0.92',
+            "Missing endpoint: semantic lane stays disabled",
+            "Network failure: semantic lane reports unavailable state",
+            "Non-2xx HTTP status: semantic lane reports HTTP fallback state",
+            "Non-JSON `Content-Type`, JSON parse errors, or missing `results` array",
+            "text nodes (`textContent`)",
+            "Pagefind results remain",
+        )
+        for marker in expected_markers:
+            self.assertIn(marker, self.runbook_text)
+
+    def test_user_guide_documents_semantic_api_configuration_and_fallback(self) -> None:
+        expected_markers = (
+            "### Optional semantic API results in wiki/search.md",
+            "Enter an `http`/`https` endpoint and click **Save endpoint**.",
+            "`kb-semantic-search-endpoint`",
+            "`POST <base-endpoint>/query`",
+            "Pagefind results remain",
+        )
+        for marker in expected_markers:
+            self.assertIn(marker, self.user_guide_text)
 
 
 if __name__ == "__main__":

--- a/wiki/search.md
+++ b/wiki/search.md
@@ -2,7 +2,7 @@
 type: process
 title: Semantic Search
 status: active
-updated_at: "2026-05-21T03:45:00Z"
+updated_at: "2026-05-25T21:06:37Z"
 hide:
   - navigation
   - toc
@@ -13,20 +13,458 @@ search:
 # Semantic Search
 
 Full-text search across all wiki pages, powered by [Pagefind](https://pagefind.app).
-Results include excerpts, page titles, and relevance ranking.
+The page also supports an optional semantic API result lane while keeping Pagefind
+available as a fallback.
 
 <link href="../pagefind/pagefind-ui.css" rel="stylesheet">
 <script src="../pagefind/pagefind-ui.js"></script>
 
-<div id="pagefind-search" style="margin-top:1.5rem;"></div>
+<div id="semantic-search-root">
+  <div id="pagefind-search" style="margin-top:1.5rem;"></div>
+
+  <section id="semantic-search" style="margin-top:1.5rem;">
+    <h2>Semantic API (optional)</h2>
+    <p>
+      Configure a semantic endpoint to show additional semantic matches for the
+      same query.
+    </p>
+    <label for="semantic-endpoint-input">Semantic API endpoint</label>
+    <div style="display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem;">
+      <input
+        id="semantic-endpoint-input"
+        type="url"
+        placeholder="https://example.com/semantic"
+        style="min-width:18rem;flex:1 1 18rem;"
+      >
+      <button id="semantic-endpoint-save" type="button">Save endpoint</button>
+    </div>
+    <p id="semantic-api-status" data-level="info" style="margin-top:0.75rem;"></p>
+    <ol id="semantic-results-list" style="margin-top:0.75rem;"></ol>
+  </section>
+</div>
 
 <script>
-  window.addEventListener('DOMContentLoaded', function() {
-    new PagefindUI({
-      element: "#pagefind-search",
-      showImages: false,
-      showEmptyFilters: false,
-      resetStyles: false
-    });
-  });
+  (function() {
+    const STORAGE_KEY = "kb-semantic-search-endpoint";
+    const SEARCH_PATH = "/query";
+    const MIN_QUERY_LENGTH = 2;
+    const SEARCH_DEBOUNCE_MS = 350;
+    const RESULT_LIMIT = 5;
+
+    function normalizeEndpoint(value) {
+      return String(value || "").trim().replace(/\/+$/, "");
+    }
+
+    function sanitizeEndpoint(rawEndpoint) {
+      const normalized = normalizeEndpoint(rawEndpoint);
+      if (!normalized) {
+        return "";
+      }
+      try {
+        const parsed = new URL(normalized, window.location.origin);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          return "";
+        }
+        return normalizeEndpoint(parsed.origin + parsed.pathname);
+      } catch (error) {
+        return "";
+      }
+    }
+
+    function sanitizeResultUrl(rawUrl) {
+      if (typeof rawUrl !== "string" || !rawUrl.trim()) {
+        return null;
+      }
+      try {
+        const parsedUrl = new URL(rawUrl, window.location.origin);
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+          return null;
+        }
+        return parsedUrl.href;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function isStorageAvailable() {
+      try {
+        const probe = "__kb_semantic_probe__";
+        window.localStorage.setItem(probe, "1");
+        window.localStorage.removeItem(probe);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    function statusText(level, message) {
+      return { level, message };
+    }
+
+    function setStatus(statusNode, status) {
+      statusNode.setAttribute("data-level", status.level);
+      statusNode.textContent = status.message;
+    }
+
+    function clearResults(resultsNode) {
+      resultsNode.replaceChildren();
+    }
+
+    function renderResults(resultsNode, results) {
+      clearResults(resultsNode);
+      if (!results.length) {
+        const emptyItem = document.createElement("li");
+        emptyItem.textContent = "No semantic API results for the current query.";
+        resultsNode.appendChild(emptyItem);
+        return;
+      }
+
+      for (const result of results) {
+        const item = document.createElement("li");
+        const titleText = typeof result.title === "string" && result.title.trim()
+          ? result.title.trim()
+          : "Untitled semantic result";
+        const safeUrl = sanitizeResultUrl(result.url);
+        if (safeUrl) {
+          const title = document.createElement("a");
+          title.href = safeUrl;
+          title.rel = "noopener noreferrer";
+          title.textContent = titleText;
+          item.appendChild(title);
+        } else {
+          const title = document.createElement("span");
+          title.textContent = titleText;
+          item.appendChild(title);
+        }
+
+        if (typeof result.snippet === "string" && result.snippet.trim()) {
+          const snippet = document.createElement("p");
+          snippet.style.margin = "0.25rem 0 0";
+          snippet.textContent = result.snippet.trim();
+          item.appendChild(snippet);
+        }
+
+        if (typeof result.score === "number" && Number.isFinite(result.score)) {
+          const score = document.createElement("small");
+          score.textContent = "Score: " + result.score.toFixed(3);
+          item.appendChild(score);
+        }
+
+        resultsNode.appendChild(item);
+      }
+    }
+
+    function resolveEndpoint(endpointInput, storageAvailable) {
+      if (!storageAvailable) {
+        endpointInput.value = "";
+        return "";
+      }
+
+      const storedValue = sanitizeEndpoint(window.localStorage.getItem(STORAGE_KEY));
+      if (!storedValue) {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+      endpointInput.value = storedValue;
+      return storedValue;
+    }
+
+    async function fetchSemanticResults(endpoint, query, signal) {
+      const response = await fetch(endpoint + SEARCH_PATH, {
+        method: "POST",
+        headers: {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          query,
+          limit: RESULT_LIMIT
+        }),
+        signal
+      });
+
+      if (!response.ok) {
+        throw new Error("semantic_api_http_" + response.status);
+      }
+
+      const contentType = String(response.headers.get("content-type") || "").toLowerCase();
+      if (!contentType.includes("application/json")) {
+        throw new Error("semantic_api_content_type");
+      }
+
+      let payload;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        throw new Error("semantic_api_json_parse");
+      }
+
+      if (!payload || !Array.isArray(payload.results)) {
+        throw new Error("semantic_api_payload_shape");
+      }
+
+      return payload.results;
+    }
+
+    function toFallbackStatus(error) {
+      if (error && typeof error.message === "string" && error.message.startsWith("semantic_api_http_")) {
+        return statusText(
+          "warning",
+          "Semantic API returned an HTTP error. Pagefind results remain available."
+        );
+      }
+      if (error && error.message === "semantic_api_content_type") {
+        return statusText(
+          "warning",
+          "Semantic API response was not JSON. Pagefind results remain available."
+        );
+      }
+      if (error && error.message === "semantic_api_json_parse") {
+        return statusText(
+          "warning",
+          "Semantic API response could not be parsed. Pagefind results remain available."
+        );
+      }
+      if (error && error.message === "semantic_api_payload_shape") {
+        return statusText(
+          "warning",
+          "Semantic API response was missing a results array. Pagefind results remain available."
+        );
+      }
+      return statusText(
+        "warning",
+        "Semantic API is unavailable. Pagefind results remain available."
+      );
+    }
+
+    function initializeSearchPage() {
+      const root = document.getElementById("semantic-search-root");
+      if (!root || root.getAttribute("data-initialized") === "true") {
+        return;
+      }
+      root.setAttribute("data-initialized", "true");
+
+      new PagefindUI({
+        element: "#pagefind-search",
+        showImages: false,
+        showEmptyFilters: false,
+        resetStyles: false
+      });
+
+      const endpointInput = document.getElementById("semantic-endpoint-input");
+      const endpointSaveButton = document.getElementById("semantic-endpoint-save");
+      const statusNode = document.getElementById("semantic-api-status");
+      const resultsNode = document.getElementById("semantic-results-list");
+      if (!endpointInput || !endpointSaveButton || !statusNode || !resultsNode) {
+        return;
+      }
+
+      const storageAvailable = isStorageAvailable();
+      let endpoint = resolveEndpoint(endpointInput, storageAvailable);
+      let debounceTimer = null;
+      let activeController = null;
+      let pagefindInputBound = false;
+
+      if (endpoint) {
+        setStatus(
+          statusNode,
+          statusText(
+            "info",
+            "Semantic API endpoint configured. Pagefind results remain available."
+          )
+        );
+      } else {
+        setStatus(
+          statusNode,
+          statusText(
+            "info",
+            "Semantic API endpoint is not configured. Pagefind results remain available."
+          )
+        );
+      }
+
+      async function runSemanticQuery(rawQuery) {
+        const query = String(rawQuery || "").trim();
+        if (query.length < MIN_QUERY_LENGTH) {
+          clearResults(resultsNode);
+          if (!endpoint) {
+            setStatus(
+              statusNode,
+              statusText(
+                "info",
+                "Semantic API endpoint is not configured. Pagefind results remain available."
+              )
+            );
+          } else {
+            setStatus(
+              statusNode,
+              statusText(
+                "info",
+                "Type at least 2 characters to query the semantic API."
+              )
+            );
+          }
+          return;
+        }
+
+        if (!endpoint) {
+          clearResults(resultsNode);
+          setStatus(
+            statusNode,
+            statusText(
+              "info",
+              "Semantic API endpoint is not configured. Pagefind results remain available."
+            )
+          );
+          return;
+        }
+
+        if (activeController) {
+          activeController.abort();
+        }
+        const controller = new AbortController();
+        activeController = controller;
+
+        setStatus(statusNode, statusText("info", "Querying semantic API..."));
+        try {
+          const results = await fetchSemanticResults(endpoint, query, controller.signal);
+          if (activeController !== controller) {
+            return;
+          }
+          renderResults(resultsNode, results);
+          setStatus(
+            statusNode,
+            statusText(
+              "info",
+              "Semantic API query complete. Pagefind results remain available."
+            )
+          );
+        } catch (error) {
+          if (error && error.name === "AbortError") {
+            return;
+          }
+          if (activeController !== controller) {
+            return;
+          }
+          clearResults(resultsNode);
+          setStatus(statusNode, toFallbackStatus(error));
+        } finally {
+          if (activeController === controller) {
+            activeController = null;
+          }
+        }
+      }
+
+      function scheduleSemanticQuery(rawQuery) {
+        if (debounceTimer) {
+          window.clearTimeout(debounceTimer);
+        }
+        debounceTimer = window.setTimeout(function() {
+          runSemanticQuery(rawQuery);
+        }, SEARCH_DEBOUNCE_MS);
+      }
+
+      function bindPagefindInput() {
+        if (pagefindInputBound) {
+          return true;
+        }
+        const pagefindInput = root.querySelector("input.pagefind-ui__search-input");
+        if (!pagefindInput) {
+          return false;
+        }
+        pagefindInput.addEventListener("input", function(event) {
+          scheduleSemanticQuery(event.target.value);
+        });
+        pagefindInput.addEventListener("search", function(event) {
+          scheduleSemanticQuery(event.target.value);
+        });
+        pagefindInputBound = true;
+        return true;
+      }
+
+      if (!bindPagefindInput()) {
+        let attempts = 0;
+        const maxAttempts = 40;
+        const bindingInterval = window.setInterval(function() {
+          attempts += 1;
+          if (bindPagefindInput() || attempts >= maxAttempts) {
+            window.clearInterval(bindingInterval);
+          }
+        }, 100);
+      }
+
+      function saveEndpoint() {
+        const rawEndpoint = endpointInput.value;
+        const nextEndpoint = sanitizeEndpoint(rawEndpoint);
+        if (String(rawEndpoint || "").trim() && !nextEndpoint) {
+          setStatus(
+            statusNode,
+            statusText(
+              "warning",
+              "Semantic API endpoint must use http or https."
+            )
+          );
+          return;
+        }
+
+        endpoint = nextEndpoint;
+        endpointInput.value = endpoint;
+        clearResults(resultsNode);
+        if (storageAvailable) {
+          if (endpoint) {
+            window.localStorage.setItem(STORAGE_KEY, endpoint);
+          } else {
+            window.localStorage.removeItem(STORAGE_KEY);
+          }
+        }
+
+        if (!endpoint) {
+          setStatus(
+            statusNode,
+            statusText(
+              "info",
+              "Semantic API endpoint cleared. Pagefind results remain available."
+            )
+          );
+          return;
+        }
+
+        if (storageAvailable) {
+          setStatus(
+            statusNode,
+            statusText(
+              "info",
+              "Semantic API endpoint saved. Pagefind results remain available."
+            )
+          );
+        } else {
+          setStatus(
+            statusNode,
+            statusText(
+              "info",
+              "Semantic API endpoint set for this page load only. Pagefind results remain available."
+            )
+          );
+        }
+      }
+
+      endpointSaveButton.addEventListener("click", saveEndpoint);
+      endpointInput.addEventListener("keydown", function(event) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          saveEndpoint();
+        }
+      });
+    }
+
+    function bootstrap() {
+      if (typeof window.PagefindUI === "function") {
+        initializeSearchPage();
+      }
+    }
+
+    if (window.document$ && typeof window.document$.subscribe === "function") {
+      window.document$.subscribe(bootstrap);
+    }
+    window.addEventListener("DOMContentLoaded", bootstrap);
+  })();
 </script>

--- a/wiki/search.md
+++ b/wiki/search.md
@@ -61,7 +61,7 @@ available as a fallback.
         return "";
       }
       try {
-        const parsed = new URL(normalized, window.location.origin);
+        const parsed = new URL(normalized);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
           return "";
         }


### PR DESCRIPTION
## Summary
Implements #158 by adding a repo-local semantic API lane to `wiki/search.md` while preserving existing Pagefind behavior.

## What changed
- `wiki/search.md`
  - Kept Pagefind UI and added optional semantic API results.
  - Added endpoint persistence via `kb-semantic-search-endpoint`.
  - Added HTTP/HTTPS endpoint validation, safe result-link sanitization, and stale-request protection.
  - Added explicit non-fatal fallback statuses so Pagefind remains available on semantic failures.
- `docs/mvp-runbook.md`
  - Added explicit semantic API contract documentation (configuration, request/response, fallback semantics).
- `docs/user-guide.md`
  - Added search-page semantic configuration and fallback usage guidance.
- `tests/kb/test_pages_workflow.py`
  - Added regression assertions for semantic lane markers and contract/fallback documentation markers.

## Validation
- `python3 -m pytest tests/` → `1551 passed`.
- Cross-functional review lane completed (`@code-reviewer`, `@test-engineer`, `@security-auditor`, `@documentation-engineer`), with all P0–P2 findings remediated.

## Follow-up
- Deferred behavior-level semantic runtime tests are tracked in #159.

Closes #158
