### PR TITLE
feat: add mixed-scope pre-commit guard

### DIFF
--- a/.github/skills/CONTEXT.md
+++ b/.github/skills/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: directory
-last_updated: 2026-05-20
+last_updated: 2026-05-31
 ---
 
 # CONTEXT — .github/skills/
@@ -40,5 +40,5 @@ Vocabulary for the skill and agent persona layer. `AGENTS.md` takes precedence o
 | `.github/skills/<name>/logic/` | Optional executable logic implementing the skill contract. All logic files are read-only-only unless they declare a narrower write-surface row in AGENTS.md. |
 | `.github/agents/` | Persona definitions for custom agents used in the skill framework (e.g., `knowledgebase-orchestrator.md`, `source-intake-steward.md`). |
 | `.github/hooks/` | Agent lifecycle hooks for VS Code/Copilot integration. |
-| `scripts/hooks/` | Pre-commit hook scripts: `check_frontmatter.py`, `check_hooks_json.py`, `check_no_staged_locks.py`, `check_sourceref_format.py`, `check_context_md_format.py`, `check_matrix_coverage.py`. |
+| `scripts/hooks/` | Pre-commit hook scripts: `check_frontmatter.py`, `check_hooks_json.py`, `check_no_staged_locks.py`, `check_sourceref_format.py`, `check_context_md_format.py`, `check_matrix_coverage.py`, `check_mixed_scope.py`, `check_adr_cross_ref.py`, `check_stub_archive_path.py`. |
 | `.github/skills/references/` | Canonical shared checklists and reference docs used across multiple skills. |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         language: python
         entry: python -m scripts.hooks.check_mixed_scope
         types: [file]
-        pass_filenames: true
+        pass_filenames: false
 
       - id: frontmatter-validation
         name: Wiki, skill, and agent persona frontmatter validation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,13 @@ repos:
         exclude: "^tests/"
         pass_filenames: true
 
+      - id: mixed-scope-commit-guard
+        name: Block mixed-scope intake/control-plane commits
+        language: python
+        entry: python -m scripts.hooks.check_mixed_scope
+        types: [file]
+        pass_filenames: true
+
       - id: frontmatter-validation
         name: Wiki, skill, and agent persona frontmatter validation
         language: python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ This guide covers the setup, workflow, and governance rules every contributor ne
 ### Prerequisites
 
 - Python 3.10+
+- Node.js (current LTS) — required for semantic browser-behavior tests (`tests/kb/test_pages_workflow.py`)
 - [Bun](https://bun.sh) — only needed for `scripts/fleet/` TypeScript orchestration
 - `qmd` on your PATH — only needed for full index/query flow (not required for most framework contributions)
 
@@ -20,10 +21,18 @@ pre-commit install
 
 The pre-commit hooks (governed by ADR-016) enforce:
 - No staged governance lock files (`.kb_write.lock`, etc.)
+- Mixed-scope intake/control-plane separation:
+  - block staged commits that mix `raw/inbox/**` with sensitive non-inbox paths
+  - block staged commits that would make the current branch mixed-scope
 - Wiki page and `SKILL.md` frontmatter validation
 - `CONTEXT.md` structure (required sections, ≤200 lines)
 - SourceRef citation format in markdown files
-- Write-surface matrix coverage for any newly added scripts
+- Write-surface matrix coverage for newly added `scripts/**` and skill-local
+  `logic/*.py` files
+- ADR status-change cascade check (ADR amendment/extension requires staging
+  `docs/decisions/README.md`)
+- `docs/ideas/` archive-pointer check (`Archived to ...` target must exist in
+  `raw/inbox/` or `wiki/sources/`)
 
 Run all hooks manually with:
 
@@ -36,6 +45,8 @@ pre-commit run --all-files
 ```bash
 python3 -m pytest tests/ -q
 ```
+
+The semantic behavior checks in `tests/kb/test_pages_workflow.py` run through Node.js to execute a controlled JavaScript harness.
 
 Run the targeted framework suite after any `.github/agents/**`, `.github/skills/**`, or `AGENTS.md` write-surface matrix change:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,18 @@ pre-commit run --all-files
 
 Hooks enforce:
 - No staged governance lock files (`.kb_write.lock`, etc.)
+- Mixed-scope guard: blocks commits that mix `raw/inbox/**` with sensitive
+  control-plane paths, and blocks staged commits that would transition the
+  branch into mixed scope
 - Wiki page and SKILL.md frontmatter validation
 - SourceRef citation format in markdown files
 - `CONTEXT.md` structure (required sections, ≤200 lines)
-- Write-surface matrix coverage for newly added scripts
+- Write-surface matrix coverage for newly added `scripts/**` and skill-local
+  `logic/*.py` files
+- ADR status-change cascade check (ADR status amendment/extension requires
+  staged `docs/decisions/README.md` update)
+- `docs/ideas/` archive-pointer validation (`Archived to ...` target must exist
+  in `raw/inbox/` or `wiki/sources/`)
 
 For full operational flow (including qmd and query-persist behavior), see
 [`docs/mvp-runbook.md`](docs/mvp-runbook.md).

--- a/docs/decisions/ADR-016-pre-commit-hooks-governance.md
+++ b/docs/decisions/ADR-016-pre-commit-hooks-governance.md
@@ -142,6 +142,27 @@ in `AGENTS.md`.
 dispatch mechanism, the `scripts/hooks/` script location, and the CI-2
 enforcement gate.
 
+### Amendment 3 — Mixed-scope intake/control-plane hook (2026-05-31)
+
+**Date:** 2026-05-31
+
+**What changed:** A new hook was added to `.pre-commit-config.yaml`:
+
+1. **`check_mixed_scope.py` (id: `mixed-scope-commit-guard`)** — enforces intake/control-plane separation before commit by:
+   - rejecting staged commits that mix `raw/inbox/**` with sensitive non-inbox paths; and
+   - rejecting staged commits that would transition the current branch into mixed scope relative to the default-branch merge base.
+
+The hook is read-only and fail-closed for branch-baseline resolution errors on
+non-benign staged changes.
+
+**Why:** CI-1 already enforces trusted-trigger path segmentation, but mixed
+scope reached CI after push. This hook moves that separation check to local
+commit-time and reduces avoidable CI-1 handoff failures.
+
+**What didn't change:** CI-2 remains the authoritative gate, `--no-verify`
+still bypasses local hooks, and hooks remain read-only scripts under
+`scripts/hooks/`.
+
 ## References
 
 - `scripts/hooks/` — hook implementation scripts

--- a/scripts/hooks/check_mixed_scope.py
+++ b/scripts/hooks/check_mixed_scope.py
@@ -1,0 +1,203 @@
+"""Pre-commit hook: block mixed-scope intake/control-plane commits.
+
+This hook enforces two guards based on CI-1 gatekeeper path policy:
+1. Reject staged commits that mix ``raw/inbox/**`` with sensitive non-inbox paths.
+2. Reject staged commits that would transition the current branch into mixed scope
+   relative to the merge-base with the default branch.
+
+The benign LICENSE allowlist is intentionally strict (`LICENSE`, `LICENSE.md`,
+`LICENSE.txt`, `LICENSE.rst`) to avoid prefix-based bypasses like `LICENSE.py`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_INBOX_PREFIX = "raw/inbox/"
+_BENIGN_PREFIXES = ("docs/", "tests/", "wiki/pages/", "wiki/sources/")
+_BENIGN_EXACT = ("README.md",)
+_BENIGN_LICENSE_FILES = ("LICENSE", "LICENSE.md", "LICENSE.txt", "LICENSE.rst")
+
+
+def _normalize_paths(paths: list[str]) -> set[str]:
+    normalized: set[str] = set()
+    for path in paths:
+        norm = path.strip().replace("\\", "/")
+        if norm:
+            normalized.add(norm)
+    return normalized
+
+
+def _is_benign_non_inbox(path: str) -> bool:
+    if path.startswith(_BENIGN_PREFIXES):
+        return True
+    if path in _BENIGN_EXACT:
+        return True
+    return path in _BENIGN_LICENSE_FILES
+
+
+def _classify_paths(paths: set[str]) -> tuple[set[str], set[str], set[str]]:
+    inbox: set[str] = set()
+    benign_non_inbox: set[str] = set()
+    sensitive_non_inbox: set[str] = set()
+
+    for path in paths:
+        if path.startswith(_INBOX_PREFIX):
+            inbox.add(path)
+        elif _is_benign_non_inbox(path):
+            benign_non_inbox.add(path)
+        else:
+            sensitive_non_inbox.add(path)
+
+    return inbox, benign_non_inbox, sensitive_non_inbox
+
+
+def _is_mixed_scope(paths: set[str]) -> bool:
+    inbox, _, sensitive_non_inbox = _classify_paths(paths)
+    return bool(inbox and sensitive_non_inbox)
+
+
+def _git_stdout(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        cmd = " ".join(["git", *args])
+        raise RuntimeError(f"{cmd} failed: {stderr or f'exit {result.returncode}'}")
+    return result.stdout
+
+
+def _git_lines(args: list[str]) -> set[str]:
+    return _normalize_paths(_git_stdout(args).splitlines())
+
+
+def _has_head_commit() -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", "HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    return result.returncode == 0
+
+
+def _resolve_default_base_ref() -> str:
+    result = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    ref = result.stdout.strip()
+    if result.returncode == 0 and ref:
+        return ref
+
+    for candidate in ("origin/main", "origin/master", "main", "master"):
+        exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", candidate],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+        )
+        if exists.returncode == 0:
+            return candidate
+
+    raise RuntimeError("unable to resolve default-branch reference (origin/main or main)")
+
+
+def _current_branch_paths() -> set[str]:
+    if not _has_head_commit():
+        return set()
+
+    base_ref = _resolve_default_base_ref()
+    merge_base = _git_stdout(["merge-base", "HEAD", base_ref]).strip()
+    if not merge_base:
+        raise RuntimeError(f"git merge-base returned no output for HEAD and {base_ref}")
+    return _git_lines(["diff", "--name-only", merge_base, "HEAD"])
+
+
+def _format_paths(paths: set[str], *, limit: int = 8) -> str:
+    if not paths:
+        return "(none)"
+    items = sorted(paths)
+    if len(items) <= limit:
+        return ", ".join(items)
+    shown = ", ".join(items[:limit])
+    return f"{shown}, ... (+{len(items) - limit} more)"
+
+
+def main(argv: list[str] | None = None) -> int:
+    files = argv if argv is not None else sys.argv[1:]
+    staged_paths = _normalize_paths(files)
+    if not staged_paths:
+        staged_paths = _git_lines(["diff", "--cached", "--name-only"])
+    if not staged_paths:
+        return 0
+
+    staged_inbox, _, staged_sensitive = _classify_paths(staged_paths)
+    if staged_inbox and staged_sensitive:
+        print("ERROR: mixed-scope staged commit detected.", file=sys.stderr)
+        print(
+            f"  inbox paths: {_format_paths(staged_inbox)}",
+            file=sys.stderr,
+        )
+        print(
+            f"  sensitive non-inbox paths: {_format_paths(staged_sensitive)}",
+            file=sys.stderr,
+        )
+        print(
+            "Hint: split intake (`raw/inbox/**`) and control-plane changes into separate commits.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Benign-only staged changes (docs/tests/wiki pages/readme/license files)
+    # cannot create mixed scope and should not depend on branch baseline lookup.
+    if not staged_inbox and not staged_sensitive:
+        return 0
+
+    try:
+        branch_paths = _current_branch_paths()
+    except RuntimeError as exc:
+        print(
+            f"ERROR: could not evaluate branch mixed-scope status: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    mixed_before = _is_mixed_scope(branch_paths)
+    mixed_after = _is_mixed_scope(branch_paths | staged_paths)
+
+    if not mixed_before and mixed_after:
+        after_inbox, _, after_sensitive = _classify_paths(branch_paths | staged_paths)
+        print(
+            "ERROR: this commit would make the branch mixed-scope relative to default-branch merge-base.",
+            file=sys.stderr,
+        )
+        print(
+            f"  branch+staged inbox paths: {_format_paths(after_inbox)}",
+            file=sys.stderr,
+        )
+        print(
+            f"  branch+staged sensitive non-inbox paths: {_format_paths(after_sensitive)}",
+            file=sys.stderr,
+        )
+        print(
+            "Hint: keep intake work on an intake-only branch/commit series, and move control-plane edits to a separate branch.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hooks/test_check_mixed_scope.py
+++ b/tests/hooks/test_check_mixed_scope.py
@@ -1,0 +1,162 @@
+"""Tests for scripts.hooks.check_mixed_scope."""
+
+from contextlib import redirect_stderr
+import io
+import unittest
+from unittest.mock import patch
+
+from scripts.hooks import check_mixed_scope
+
+
+class CheckMixedScopeTests(unittest.TestCase):
+    def test_no_staged_files_exits_0(self) -> None:
+        with patch.object(check_mixed_scope, "_git_lines", return_value=set()):
+            self.assertEqual(check_mixed_scope.main([]), 0)
+
+    def test_staged_mixed_scope_fails(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(check_mixed_scope, "_current_branch_paths", return_value=set()),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["raw/inbox/source.md", "scripts/init.py"])
+        self.assertEqual(rc, 1)
+        self.assertIn("mixed-scope staged commit detected", stderr.getvalue())
+
+    def test_staged_path_normalization_fails_for_windows_paths(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(check_mixed_scope, "_current_branch_paths", return_value=set()),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["raw\\inbox\\source.md", "scripts\\init.py"])
+        self.assertEqual(rc, 1)
+        self.assertIn("mixed-scope staged commit detected", stderr.getvalue())
+
+    def test_inbox_plus_benign_non_inbox_passes(self) -> None:
+        with patch.object(check_mixed_scope, "_current_branch_paths", return_value=set()):
+            self.assertEqual(
+                check_mixed_scope.main(
+                    [
+                        "raw/inbox/source.md",
+                        "docs/notes.md",
+                        "tests/kb/test_ci1_workflow.py",
+                        "wiki/sources/README.md",
+                        "wiki/pages/home.md",
+                        "README.md",
+                        "LICENSE",
+                    ]
+                ),
+                0,
+            )
+
+    def test_benign_only_staged_changes_skip_branch_scope_lookup(self) -> None:
+        with patch.object(
+            check_mixed_scope,
+            "_current_branch_paths",
+            side_effect=RuntimeError("should not be called for benign-only staged files"),
+        ):
+            self.assertEqual(check_mixed_scope.main(["docs/notes.md", "README.md"]), 0)
+
+    def test_license_like_non_legal_file_is_treated_as_sensitive(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(check_mixed_scope, "_current_branch_paths", return_value=set()),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["raw/inbox/source.md", "LICENSE.py"])
+        self.assertEqual(rc, 1)
+        self.assertIn("mixed-scope staged commit detected", stderr.getvalue())
+
+    def test_branch_transition_to_mixed_scope_fails(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                check_mixed_scope,
+                "_current_branch_paths",
+                return_value={"raw/inbox/intake.md"},
+            ),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["scripts/init.py"])
+        self.assertEqual(rc, 1)
+        self.assertIn("would make the branch mixed-scope", stderr.getvalue())
+
+    def test_branch_transition_reverse_direction_fails(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                check_mixed_scope,
+                "_current_branch_paths",
+                return_value={"scripts/init.py"},
+            ),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["raw/inbox/intake.md"])
+        self.assertEqual(rc, 1)
+        self.assertIn("would make the branch mixed-scope", stderr.getvalue())
+
+    def test_already_mixed_branch_does_not_block_unrelated_staged_file(self) -> None:
+        with patch.object(
+            check_mixed_scope,
+            "_current_branch_paths",
+            return_value={"raw/inbox/intake.md", "scripts/init.py"},
+        ):
+            self.assertEqual(check_mixed_scope.main(["docs/notes.md"]), 0)
+
+    def test_already_mixed_branch_allows_non_benign_sensitive_staged_file(self) -> None:
+        with patch.object(
+            check_mixed_scope,
+            "_current_branch_paths",
+            return_value={"raw/inbox/intake.md", "scripts/init.py"},
+        ):
+            self.assertEqual(check_mixed_scope.main(["scripts/another_change.py"]), 0)
+
+    def test_inbox_only_branch_and_inbox_only_staged_pass(self) -> None:
+        with patch.object(
+            check_mixed_scope,
+            "_current_branch_paths",
+            return_value={"raw/inbox/existing.md"},
+        ):
+            self.assertEqual(check_mixed_scope.main(["raw/inbox/new_source.md"]), 0)
+
+    def test_sensitive_only_branch_and_sensitive_only_staged_pass(self) -> None:
+        with patch.object(
+            check_mixed_scope,
+            "_current_branch_paths",
+            return_value={"scripts/existing.py"},
+        ):
+            self.assertEqual(check_mixed_scope.main(["schema/new-contract.md"]), 0)
+
+    def test_argv_empty_mixed_cached_paths_fails(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                check_mixed_scope,
+                "_git_lines",
+                return_value={"raw/inbox/source.md", "scripts/init.py"},
+            ),
+            patch.object(check_mixed_scope, "_current_branch_paths", return_value=set()),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main([])
+        self.assertEqual(rc, 1)
+        self.assertIn("mixed-scope staged commit detected", stderr.getvalue())
+
+    def test_branch_scope_evaluation_error_fails_closed(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                check_mixed_scope,
+                "_current_branch_paths",
+                side_effect=RuntimeError("cannot resolve default branch"),
+            ),
+            redirect_stderr(stderr),
+        ):
+            rc = check_mixed_scope.main(["raw/inbox/source.md"])
+        self.assertEqual(rc, 1)
+        self.assertIn("could not evaluate branch mixed-scope status", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki/concepts/pre-commit-guardrails.md
+++ b/wiki/concepts/pre-commit-guardrails.md
@@ -7,7 +7,7 @@ sources:
 open_questions: []
 confidence: 5
 sensitivity: internal
-updated_at: "2026-05-12T06:00:00Z"
+updated_at: "2026-05-31T04:10:00Z"
 tags:
   - pre-commit
   - git-hooks
@@ -35,6 +35,9 @@ CI — they do not replace it; CI remains the authoritative gate.
 | `check_hooks_json.py` | Validate `.github/hooks/hooks.json` syntax, structure, and script paths | ~0.2s |
 | `check_context_md_format.py` | Validate `CONTEXT.md` files have required sections (`## Terms`, `## Invariants`, `## File Roles`) and ≤200 lines | ~0.3s |
 | `check_matrix_coverage.py` | Verify staged new `scripts/` or `logic/` files have a write-surface matrix row in `AGENTS.md` | ~0.5s |
+| `check_mixed_scope.py` | Block mixed intake/control-plane staged commits and branch-transition-to-mixed-scope commits | ~0.2s |
+| `check_adr_cross_ref.py` | Require `docs/decisions/README.md` to be staged when ADR status is amended/extended | ~0.1s |
+| `check_stub_archive_path.py` | Validate `docs/ideas/` archive pointer targets exist in `raw/inbox/` or `wiki/sources/` | ~0.1s |
 
 **Framework choice.** The design proposal recommended raw git hooks. The
 implementation adopted the `pre-commit` Python framework (ADR-016 amended


### PR DESCRIPTION
## Summary
- add `scripts/hooks/check_mixed_scope.py` to block mixed-scope staged commits and mixed-scope branch transitions
- wire the new hook into `.pre-commit-config.yaml`
- add regression coverage in `tests/hooks/test_check_mixed_scope.py`
- update contributor/governance docs for the new guardrail (`README.md`, `CONTRIBUTING.md`, ADR-016, skill/context docs, wiki concept page)

## Why
CI-1 trusted-trigger/path-policy failures were repeatedly caused by mixed intake/control-plane change ranges. This hook prevents those ranges before commit.

## Validation
- `python3 scripts/hooks/check_mixed_scope.py`
- `python3 -m pytest tests/hooks/test_check_mixed_scope.py`

## Mixed-scope safety
This PR intentionally excludes `raw/inbox/**` changes and contains only non-inbox scope updates.
