### PR TITLE
docs(checkpoint-registry): PR1 — ADR-026 amendment and documentation cascade

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,13 +254,15 @@ Operators can validate the landed framework with these repo-local entrypoints:
 - Raw immutability: `raw/processed/**` must not be mutated after ingest.
 - Ingest-time SourceRefs may use provisional placeholder git SHAs; only reconciled commit-bound SourceRefs whose `git_sha` resolves to a real revision containing the cited artifact bytes count as authoritative provenance.
 - Concurrency guard: workflow-level concurrency group plus local lock file (`wiki/.kb_write.lock`).
-- Checkpoint registry lock: `raw/.wiki-processing-checkpoint.lock` guards
-  writes to `raw/wiki-processing/wiki-processing-checkpoint-registry.json`
-  (ADR-026). Fails closed on contention or acquisition failure.
-- Checkpoint lock ordering: any run that updates both wiki content and
-  checkpoint state acquires `wiki/.kb_write.lock` first, then
-  `raw/.wiki-processing-checkpoint.lock`. Reverse order is a deadlock
-  hazard and is rejected by the deterministic execution surface.
+- Checkpoint registry lock (forward-looking — runtime lands with PR3):
+  `raw/.wiki-processing-checkpoint.lock` *will* guard writes to
+  `raw/wiki-processing/wiki-processing-checkpoint-registry.json` (ADR-026).
+  Failure mode is fail-closed on contention or acquisition failure.
+- Checkpoint lock ordering (forward-looking — runtime lands with PR3): any
+  run that updates both wiki content and checkpoint state *will* acquire
+  `wiki/.kb_write.lock` first, then `raw/.wiki-processing-checkpoint.lock`.
+  Reverse order is a deadlock hazard and *will be* rejected by the
+  deterministic execution surface.
 - **`wiki/log.md` append-only guardrail:** all governed surfaces must append-only; the sole declared exception is `scripts/init.py --fresh`, which performs a full overwrite as part of a clean-slate template reset. This exception is documented in `AGENTS.md` and is intentional.
 - Fail-closed behavior: missing prerequisites, permission mismatches, or lock contention stop writes.
 - Policy-gated query persistence: write only when `auto_persist_when_high_value` criteria pass.
@@ -281,9 +283,14 @@ require documented rationale.
 
 ## Wiki processing checkpoint registry
 
-The wiki processing pipeline maintains a governed checkpoint registry under
-`raw/` so partial fail-closed runs can resume and changed outputs can be
-re-evaluated without storing workflow state in topical wiki content. The
+> **Forward-looking.** The schema contract (PR2) and runtime (PR3) are not
+> yet on disk. The table below identifies which surfaces exist today and
+> which are deferred to PR2/PR3. Operators reading this section should
+> treat any present-tense description as the post-PR3 target state.
+
+The wiki processing pipeline *will* maintain a governed checkpoint registry
+under `raw/` so partial fail-closed runs can resume and changed outputs can
+be re-evaluated without storing workflow state in topical wiki content. The
 registry is observational — no checkpoint entry can authorize a write that
 governance would otherwise block.
 
@@ -294,7 +301,7 @@ governance would otherwise block.
 | Runtime entrypoint | `scripts/kb/checkpoint_registry.py` (authored in PR3) |
 | Dedicated lock | `raw/.wiki-processing-checkpoint.lock` |
 | Lock order with wiki writes | `wiki/.kb_write.lock` first, then the checkpoint lock |
-| Operator snapshot | `wiki/status.md` via `sync-knowledgebase-state` |
+| Operator snapshot | `wiki/status.md` via `sync-knowledgebase-state` (publisher exists; checkpoint payload lands PR3) |
 | Trigger model | `intake_driven`, `infrastructure_revalidation`, `manual_rescan` (ADR-027) |
 
 The registry tracks both batch-level state (`batch_id`, `trigger`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,18 +291,18 @@ require documented rationale.
 The wiki processing pipeline *will* maintain a governed checkpoint registry
 under `raw/` so partial fail-closed runs can resume and changed outputs can
 be re-evaluated without storing workflow state in topical wiki content. The
-registry is observational — no checkpoint entry can authorize a write that
-governance would otherwise block.
+registry will be observational — no checkpoint entry will be able to
+authorize a write that governance would otherwise block.
 
 | Aspect | Value |
 |---|---|
 | Registry artifact | `raw/wiki-processing/wiki-processing-checkpoint-registry.json` |
 | Schema contract | `schema/wiki-processing-checkpoint-registry-contract.md` (authored in PR2) |
 | Runtime entrypoint | `scripts/kb/checkpoint_registry.py` (authored in PR3) |
-| Dedicated lock | `raw/.wiki-processing-checkpoint.lock` |
-| Lock order with wiki writes | `wiki/.kb_write.lock` first, then the checkpoint lock |
+| Dedicated lock | `raw/.wiki-processing-checkpoint.lock` (lands PR3) |
+| Lock order with wiki writes | `wiki/.kb_write.lock` first, then the checkpoint lock (enforced in PR3 runtime) |
 | Operator snapshot | `wiki/status.md` via `sync-knowledgebase-state` (publisher exists; checkpoint payload lands PR3) |
-| Trigger model | `intake_driven`, `infrastructure_revalidation`, `manual_rescan` (ADR-027) |
+| Trigger model | `intake_driven`, `infrastructure_revalidation`, `manual_rescan` (declared in ADR-027; runtime PR3) |
 
 The registry tracks both batch-level state (`batch_id`, `trigger`,
 `started_at`, `finished_at`, `status`, `input_fingerprint`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,6 +254,13 @@ Operators can validate the landed framework with these repo-local entrypoints:
 - Raw immutability: `raw/processed/**` must not be mutated after ingest.
 - Ingest-time SourceRefs may use provisional placeholder git SHAs; only reconciled commit-bound SourceRefs whose `git_sha` resolves to a real revision containing the cited artifact bytes count as authoritative provenance.
 - Concurrency guard: workflow-level concurrency group plus local lock file (`wiki/.kb_write.lock`).
+- Checkpoint registry lock: `raw/.wiki-processing-checkpoint.lock` guards
+  writes to `raw/wiki-processing/wiki-processing-checkpoint-registry.json`
+  (ADR-026). Fails closed on contention or acquisition failure.
+- Checkpoint lock ordering: any run that updates both wiki content and
+  checkpoint state acquires `wiki/.kb_write.lock` first, then
+  `raw/.wiki-processing-checkpoint.lock`. Reverse order is a deadlock
+  hazard and is rejected by the deterministic execution surface.
 - **`wiki/log.md` append-only guardrail:** all governed surfaces must append-only; the sole declared exception is `scripts/init.py --fresh`, which performs a full overwrite as part of a clean-slate template reset. This exception is documented in `AGENTS.md` and is intentional.
 - Fail-closed behavior: missing prerequisites, permission mismatches, or lock contention stop writes.
 - Policy-gated query persistence: write only when `auto_persist_when_high_value` criteria pass.
@@ -271,6 +278,39 @@ require documented rationale.
 | `freshness_stale_days` | 90 | `check_doc_freshness.py --max-age-days`, `wiki-freshness.yml` | Pages not updated in 90+ days are flagged for review. Aligns with quarterly review cadence. |
 | `freshness_afk_threshold_days` | 180 | `classify_stale.py --afk-threshold-days`, `wiki-freshness.yml` | Pages stale 90–179 days likely need only metadata refresh (AFK-candidate). Pages ≥180 days may need content review and re-sourcing (HITL). The gap between 90 and 180 catches pages that are stale enough to notice but may still need editorial judgment. |
 | `missing_data_default_days` | 999 | `classify_stale.py` | Pages with missing `last_updated` frontmatter default to 999 days stale, classifying as HITL (deny-by-default). |
+
+## Wiki processing checkpoint registry
+
+The wiki processing pipeline maintains a governed checkpoint registry under
+`raw/` so partial fail-closed runs can resume and changed outputs can be
+re-evaluated without storing workflow state in topical wiki content. The
+registry is observational — no checkpoint entry can authorize a write that
+governance would otherwise block.
+
+| Aspect | Value |
+|---|---|
+| Registry artifact | `raw/wiki-processing/wiki-processing-checkpoint-registry.json` |
+| Schema contract | `schema/wiki-processing-checkpoint-registry-contract.md` (authored in PR2) |
+| Runtime entrypoint | `scripts/kb/checkpoint_registry.py` (authored in PR3) |
+| Dedicated lock | `raw/.wiki-processing-checkpoint.lock` |
+| Lock order with wiki writes | `wiki/.kb_write.lock` first, then the checkpoint lock |
+| Operator snapshot | `wiki/status.md` via `sync-knowledgebase-state` |
+| Trigger model | `intake_driven`, `infrastructure_revalidation`, `manual_rescan` (ADR-027) |
+
+The registry tracks both batch-level state (`batch_id`, `trigger`,
+`started_at`, `finished_at`, `status`, `input_fingerprint`,
+`error_summary`) and item-level state (`item_key`, `output_path`,
+`path_aliases`, `artifact_type`, `source_fingerprint`,
+`dependency_fingerprint`, `status`, `last_attempted_at`,
+`last_succeeded_at`, `last_error`, `last_successful_batch_id`). Identity
+keys follow the repository's canonical-identity rules (ADR-009); paths
+are mutable projections recorded in `path_aliases` on rename or move.
+
+Bootstrap is an explicit mode (never auto-on-first-write) and emits a
+reconciliation report before any registry write. See
+[`docs/ideas/wiki-processing-checkpoint-registry.md`](ideas/wiki-processing-checkpoint-registry.md)
+for the full Path C-prime implementation plan and ADR-026/ADR-027 for
+the canonical decisions.
 
 ## Decision records
 
@@ -301,3 +341,5 @@ Key architecture decisions are captured in ADRs:
 - [`ADR-023`](decisions/ADR-023-batch-query-persistence-design.md): batch query persistence design (single lock, partial failure, and size limits)
 - [`ADR-024`](decisions/ADR-024-synthesis-curator-stage-design.md): CI-3 synthesis curator stage design for entity/concept draft generation
 - [`ADR-025`](decisions/ADR-025-runtime-budget-contract-scope.md): runtime-budget contract scope and schema/workflow parity requirements
+- [`ADR-026`](decisions/ADR-026-wiki-processing-checkpoint-registry.md): wiki processing checkpoint registry for resumed and revalidated synthesis
+- [`ADR-027`](decisions/ADR-027-infrastructure-validation-trigger-model.md): infrastructure validation trigger model for CI-3

--- a/docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md
+++ b/docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md
@@ -61,7 +61,7 @@ The registry tracks both batch-level and item-level recovery state.
 Batch fields:
 
 - `batch_id`
-- `trigger` (`automatic` or `manual_rescan`)
+- `trigger` (`automatic` or `manual_rescan`) — superseded; see § Amendment for the authoritative three-value enum
 - `started_at`
 - `finished_at`
 - `status` (`running`, `completed`, `failed`, `partial`)
@@ -230,7 +230,10 @@ Item fields:
   Python per the precedent in `scripts/kb/contracts.py`.
 - What did not change: the rest of the State model, including batch and item
   fields, item-level state transitions, identity rules, locking decisions, the
-  retention rule, and the operator snapshot via `wiki/status.md`.
+  retention rule, and the operator snapshot via `wiki/status.md`. In
+  `### State transitions`, the descriptor "automatic run" now refers to any
+  non-manual trigger (`intake_driven` or `infrastructure_revalidation`); the
+  transition graph itself is unchanged.
 - Cross-reference: see ADR-027 for the trigger model rationale and CI-3 trigger
   paths.
 

--- a/docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md
+++ b/docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted — extended by ADR-027
 
 ## Date
 
@@ -217,6 +217,50 @@ Item fields:
   canonical identity rules.
 - Batch records are retained indefinitely unless a later ADR defines a separate
   archival policy.
+
+## Amendment
+
+- Date: 2026-06-07.
+- What changed: the original Decision `### State model` lists `trigger`
+  values as `(automatic or manual_rescan)`. ADR-027 introduced a third
+  trigger value, `infrastructure_revalidation`, and renamed `automatic` to
+  `intake_driven`. The authoritative trigger enum is now the three-value set:
+  `intake_driven`, `infrastructure_revalidation`, and `manual_rescan`, written
+  as lowercase snake_case strings in JSON and represented as a `StrEnum` in
+  Python per the precedent in `scripts/kb/contracts.py`.
+- What did not change: the rest of the State model, including batch and item
+  fields, item-level state transitions, identity rules, locking decisions, the
+  retention rule, and the operator snapshot via `wiki/status.md`.
+- Cross-reference: see ADR-027 for the trigger model rationale and CI-3 trigger
+  paths.
+
+## Migration
+
+- New batch records written by `scripts/kb/checkpoint_registry.py` in PR3 use
+  the three-value enum from initial bootstrap.
+- No legacy registry records exist today because the registry artifact has not
+  been written yet, so no rewrite of historical batch JSON is required.
+- If any pre-amendment batch records ever appear, for example from a vendored
+  snapshot, bootstrap performs a one-shot rewrite from `trigger: automatic` to
+  `trigger: intake_driven`. The bootstrap reconciliation report must list every
+  normalized record before any registry write.
+- The CI-3 workflow's path-filter allowlist for `infrastructure_revalidation`
+  runs is the authoritative dependency set. ADR-027 documents these paths, and
+  the schema contract in PR2 cross-references the same allowlist via
+  `DEPENDENCY_FINGERPRINT_SOURCES`.
+
+## Rollback
+
+- Remove the `infrastructure_revalidation` value from `scripts/kb/contracts.py`
+  `TriggerType`, then rename `intake_driven` back to `automatic` in code and in
+  the schema contract.
+- Revert the CI-3 `push:` trigger added by ADR-027, specifically the `push:`
+  section in `.github/workflows/ci-3-pr-producer.yml`.
+- Rewrite registry records with `trigger: intake_driven` to
+  `trigger: automatic`. Reject records with `trigger: infrastructure_revalidation`
+  for manual triage because the two-value enum has no equivalent.
+- Rollback impact: infrastructure changes lose end-to-end auto-validation;
+  manual `workflow_dispatch` remains the recovery path.
 
 ## References
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,5 +32,5 @@ This directory captures durable architecture and governance decisions derived fr
 | [ADR-023](ADR-023-batch-query-persistence-design.md) | Batch query persistence — single-lock, partial-failure, and size-limit design | Accepted — extends ADR-003 |
 | [ADR-024](ADR-024-synthesis-curator-stage-design.md) | Synthesis Curator stage design — LLM entity/concept extraction in CI-3 | Accepted — amended in-place |
 | [ADR-025](ADR-025-runtime-budget-contract-scope.md) | Runtime-budget contract scope and CI parity | Accepted — amended in-place |
-| [ADR-026](ADR-026-wiki-processing-checkpoint-registry.md) | Wiki processing checkpoint registry for resumed and revalidated synthesis | Accepted |
+| [ADR-026](ADR-026-wiki-processing-checkpoint-registry.md) | Wiki processing checkpoint registry for resumed and revalidated synthesis | Accepted — extended by ADR-027 |
 | [ADR-027](ADR-027-infrastructure-validation-trigger-model.md) | Infrastructure validation trigger model for CI-3 | Accepted |

--- a/docs/ideas/wiki-processing-checkpoint-registry.md
+++ b/docs/ideas/wiki-processing-checkpoint-registry.md
@@ -150,14 +150,14 @@ ADR work (PR1):
 - [x] ADR-026 published (2026-05-31).
 - [x] ADR-027 published (2026-06-02) — documents `infrastructure_revalidation` trigger model.
 - [x] `docs/decisions/README.md` indexes both ADRs.
-- [ ] ADR-026 amended in place: `Status: Accepted — extended by ADR-027` plus `## Amendment` section codifying the three-value trigger enum (`intake_driven`, `infrastructure_revalidation`, `manual_rescan` — lowercase snake_case JSON strings; `StrEnum` Python representation per `scripts/kb/contracts.py` precedent).
-- [ ] ADR-026 gains `## Migration` and `## Rollback` headings to match ADR-027 structure and the original Phase 1 ADR requirement.
-- [ ] `docs/decisions/README.md` row for ADR-026 updated to match new status (enforced by pre-commit hook `check_adr_cross_ref.py`).
+- [x] ADR-026 amended in place: `Status: Accepted — extended by ADR-027` plus `## Amendment` section codifying the three-value trigger enum (`intake_driven`, `infrastructure_revalidation`, `manual_rescan` — lowercase snake_case JSON strings; `StrEnum` Python representation per `scripts/kb/contracts.py` precedent).
+- [x] ADR-026 gains `## Migration` and `## Rollback` headings to match ADR-027 structure and the original Phase 1 ADR requirement.
+- [x] `docs/decisions/README.md` row for ADR-026 updated to match new status (enforced by pre-commit hook `check_adr_cross_ref.py`).
 
 Architecture and runbook cascade items (PR1, identified by the research validation report as missing):
 
-- [ ] `docs/architecture.md` updated to document checkpoint lifecycle and lock ordering.
-- [ ] `docs/mvp-runbook.md` updated with: manual rescan procedure, checkpoint recovery procedure (per the rollback-scenarios decision), required bootstrap dry-run-then-apply sequence, and `gh run list --workflow=ci-3-pr-producer.yml --status in_progress` reference for the lock-unavailable case.
+- [x] `docs/architecture.md` updated to document checkpoint lifecycle and lock ordering (forward-looking until PR2/PR3 land).
+- [x] `docs/mvp-runbook.md` updated with: manual rescan procedure, checkpoint recovery procedure (per the rollback-scenarios decision), required bootstrap dry-run-then-apply sequence, and `gh run list --workflow=ci-3-pr-producer.yml --status in_progress` reference for the lock-unavailable case (all sub-procedures marked forward-looking until PR3/PR4 land).
 
 Schema and surface cascade (PR2-PR3):
 

--- a/docs/ideas/wiki-processing-checkpoint-registry.md
+++ b/docs/ideas/wiki-processing-checkpoint-registry.md
@@ -59,7 +59,7 @@ If a run updates both wiki artifacts and checkpoint state, lock ordering is dete
 
 ## Registry model
 
-> The fields below are the operative contract surface. The canonical, normative schema is authored in `schema/wiki-processing-checkpoint-registry-contract.md` (PR3 of the implementation plan), which also defines the top-level `source_fingerprints` map (path → sha256) referenced by `item.source_fingerprint`.
+> The fields below are the operative contract surface. The canonical, normative schema is authored in `schema/wiki-processing-checkpoint-registry-contract.md` (PR2 of the implementation plan), which also defines the top-level `source_fingerprints` map (path → sha256) referenced by `item.source_fingerprint`.
 
 ### Batch-level fields
 

--- a/docs/ideas/wiki-processing-checkpoint-registry.md
+++ b/docs/ideas/wiki-processing-checkpoint-registry.md
@@ -1,8 +1,26 @@
 # Wiki processing checkpoint registry
 
-**Status:** In Progress — ADR-026 is published and tracked in docs/decisions/README.md; registry implementation remains pending (2026-06-04)
+**Status:** In Progress — Design decisions resolved via grilling session 2026-06-07; ADR-026 and ADR-027 published; canonical 6-PR implementation plan defined; runtime implementation, schema contract, and remaining documentation cascade items pending.
 
 This proposal adds a governed checkpoint registry under `raw/` for wiki processing. The registry tracks generated wiki artifacts/pages at item and batch granularity so partial fail-closed runs can resume and changed outputs can be re-evaluated without storing workflow state in topical wiki content.
+
+## Design status
+
+Design decisions for this feature were resolved in a `grill-with-docs` session on 2026-06-07. The session walked 16 decision branches across 58 sub-decisions, grounded in primary-source evidence from the codebase, ADR history, and empirical CI-3 run telemetry. Validation findings are recorded in `docs/research/wiki-processing-checkpoint-registry-implementation-status.md`.
+
+Key resolved decisions:
+
+- **Trigger enum reconciled.** ADR-026 was published before ADR-027 introduced the three-value trigger split; PR1 of the implementation plan amends ADR-026 in place per the repo's ADR-evolution rule (`Status: Accepted — extended by ADR-027` plus an `## Amendment` section codifying the lowercase snake_case spelling).
+- **Schema contract structure.** Fresh skeleton (not a 1:1 mirror of `schema/drive-source-registry-contract.md`) because the checkpoint registry's two-scope state model (batch + item), `source_fingerprints` map, and trigger-typed transitions don't fit the per-source-entry shape of the existing registry contracts.
+- **Trigger × transition matrix.** Three triggers (`intake_driven`, `infrastructure_revalidation`, `manual_rescan`) crossed against the six item states. `infrastructure_revalidation` reacts to `dependency_fingerprint` changes; `intake_driven` reacts to `source_fingerprint` changes; only `manual_rescan` can retire (`skipped`) or un-retire items.
+- **Lock strategy: lock-once, hold-long.** Matches `synthesize_combined.py` (PR #115) precedent. Empirical CI-3 data (5 successful runs) shows wiki-lock-held duration is ~1 second per batch today; projected ~1.2-1.5 seconds under the checkpoint orchestrator.
+- **Six-PR implementation layout.** Each PR on its own branch off `main` (named `checkpoint/0N-<slug>`); strict linear merge order; full pre-commit, post-commit, and pre-merge validation per PR.
+
+Three repo-wide backlog issues were filed during the session as side-effect findings (none block the checkpoint feature):
+
+- [#181](https://github.com/wryenmeek/knowledgebase/issues/181) — Formalize pytest as canonical test framework + CI ratchet for unittest→pytest migration.
+- [#182](https://github.com/wryenmeek/knowledgebase/issues/182) — Reconsider `--approval` flag pattern (codify, rename, or replace).
+- [#183](https://github.com/wryenmeek/knowledgebase/issues/183) — Add holder-PID tracking to write lock files for better lock-unavailable UX.
 
 ## Goals
 
@@ -39,7 +57,9 @@ This proposal adds a governed checkpoint registry under `raw/` for wiki processi
 
 If a run updates both wiki artifacts and checkpoint state, lock ordering is deterministic: acquire `wiki/.kb_write.lock` first, then `raw/.wiki-processing-checkpoint.lock`.
 
-## Registry model (draft)
+## Registry model
+
+> The fields below are the operative contract surface. The canonical, normative schema is authored in `schema/wiki-processing-checkpoint-registry-contract.md` (PR3 of the implementation plan), which also defines the top-level `source_fingerprints` map (path → sha256) referenced by `item.source_fingerprint`.
 
 ### Batch-level fields
 
@@ -72,12 +92,15 @@ If a run updates both wiki artifacts and checkpoint state, lock ordering is dete
 - `failed` is reserved for hard processing errors.
 - `skipped` is reserved for intentionally retired or out-of-scope items.
 
-## Identity and collision rules (draft)
+## Identity and collision rules
+
+> Per-artifact-type derivation rules and excluded-artifact-type rationale are codified in the schema contract. The summary below captures the design intent.
 
 - Canonical identity is `item_key`; paths are mutable projections.
-- For wiki entity/concept pages, derive `item_key` from the repository's canonical identity contract (`entity_id` when present, otherwise normalized canonical slug).
-- For analysis/index-derived artifacts, derive `item_key` from a stable tuple of artifact type plus source/query fingerprint.
-- Rename/move: keep `item_key`, update `output_path`, append previous path to `path_aliases`.
+- For wiki entity pages, derive `item_key` from `entity_id` when present in frontmatter, otherwise the normalized canonical slug per `schema/ontology-entity-contract.md`. Concept pages use the normalized canonical slug (concepts do not carry `entity_id`).
+- For analysis pages (`wiki/analyses/<slug>-<fp16>.md`), `item_key` is the filename stem; the fingerprint is already computed by `persist_query._analysis_relative_path` and is extracted into a public `analysis_fingerprint()` helper in PR2.
+- `wiki/sources/**`, governed fixed-path artifacts (`wiki/index.md`, `wiki/log.md`, `wiki/status.md`, `wiki/open-questions.md`, `wiki/backlog.md`), and `wiki/reports/**` are explicit-excluded from registry items. Sources' content hashes still appear in the top-level `source_fingerprints` map so downstream items can detect source-change-driven staleness; the other excluded surfaces have their own governance.
+- Rename/move: keep `item_key`, update `output_path`, append previous path to `path_aliases`. Meaningful only for entities and concepts; analyses cannot be renamed without changing identity (filename includes the fingerprint).
 - One-source-to-many-output and many-source-to-one-output cases must be represented explicitly through dependency fingerprints.
 - On key collision or ambiguous mapping, fail closed and require manual resolution before advancing state.
 
@@ -88,34 +111,67 @@ If a run updates both wiki artifacts and checkpoint state, lock ordering is dete
 - Leave ambiguous or contradictory cases out of the bootstrap set and flag them for manual resolution.
 - This keeps the registry trustworthy while still letting the next run resume from the latest proven stage.
 
-## Phases
+## Implementation plan
 
-1. Draft ADR and contract together: decision, alternatives, migration, rollback, and operational consequences. Document infrastructure_revalidation trigger model and its interaction with checkpoint state.
-2. Define checkpoint schema, identity model, lock ordering, and legal state transitions. Account for runs triggered by different sources (intake_driven vs. infrastructure_revalidation) and their fingerprint contexts.
-3. Add write-surface matrix entries and runtime guardrails for checkpoint read/write paths. Define allowed writers per trigger type and phase.
-4. Bootstrap current generated artifacts into the registry (dry-run + apply) with explicit reconciliation reporting.
-5. Wire resume and revalidation logic (intake_driven automatic run + infrastructure_revalidation trigger + manual_rescan). Ensure each trigger type correctly classifies stale items and skips non-applicable recovery steps.
-6. Add operator-facing progress summary in governed status/report artifacts only.
-7. Land tests and docs before enabling checkpoint writes in CI.
+The canonical implementation plan is six PRs in strict linear merge order, each on its own branch off `main`. Every PR must pass pre-commit hooks, post-commit CI checks (including the `--cov-fail-under=90` gate), and pre-merge cross-functional review before merge.
 
-## Verification plan (required for implementation)
+1. **PR1 — `checkpoint/01-adr-reconciliation`.** Amend ADR-026 in place to reflect the three-value trigger enum and reference ADR-027 (Status → `Accepted — extended by ADR-027`; new `## Amendment`, `## Migration`, and `## Rollback` sections); update `docs/decisions/README.md` row; land the previously-missing `docs/architecture.md` and `docs/mvp-runbook.md` cascade items called out by the research validation report.
+2. **PR2 — `checkpoint/02-extract-analysis-fingerprint`.** Refactor `scripts/kb/persist_query._analysis_relative_path` to call a new public `analysis_fingerprint()` helper. Pure extraction; no behavior change. Provides the canonical identifier formula the checkpoint code reuses for `wiki/analyses/` items.
+3. **PR3 — `checkpoint/03-schema-contract`.** Author `schema/wiki-processing-checkpoint-registry-contract.md` with the full normative schema (per-artifact-type identity table, `source_fingerprints` map, batch + item state machines, trigger × transition matrix, bootstrap classification rules, retention thresholds, embedded operator-snapshot rendering section).
+4. **PR4 — `checkpoint/04-contracts-and-enums`.** Add `CHECKPOINT_REGISTRY_LOCK_PATH`, `wiki-processing-checkpoint-registry` `GovernedArtifactContract` entry, `TriggerType`/`ArtifactType` enums, `DEPENDENCY_FINGERPRINT_SOURCES` map, and `CheckpointRetentionThresholds` dataclass to `scripts/kb/contracts.py`. Triggers the contract-test cascades in `tests/kb/test_contracts.py` and a new partial `test_checkpoint_contract_alignment.py`.
+5. **PR5 — `checkpoint/05-runtime-and-governance`.** Implement `scripts/kb/checkpoint_registry.py` (bootstrap + mutate + verify modes) and `scripts/kb/checkpoint_status_render.py`; refactor `synthesize_combined.run()` to accept `lock_already_held: bool = False`; add 4 new test files (`test_checkpoint_registry.py`, `test_checkpoint_bootstrap.py`, `test_checkpoint_status_render.py`, `test_checkpoint_contract_alignment.py`); add 3 write-surface matrix rows + amend `sync-knowledgebase-state` row in `AGENTS.md`; update `docs/ideas/wiki-curation-agent-framework.md` FRAMEWORK_BOUNDARY_DOCS entrypoint list verbatim; add `scripts/hooks/check_checkpoint_registry_json.py` pre-commit hook.
+6. **PR6 — `checkpoint/06-ci-wiring-and-bootstrap`.** Wire CI-3 to invoke `checkpoint_registry.py --mutate` and `checkpoint_status_render.py` per batch; required runbook sequence: dry-run bootstrap → review reconciliation report → operator confirmation → `--bootstrap --apply --approval approved`; commit initial registry JSON.
+
+PR1-PR2 are doc/refactor PRs (low risk, single reviewer + `documentation-engineer`). PR3 requires `documentation-engineer` review. PR4 requires `code-reviewer` + `test-engineer` + `documentation-engineer` review. PR5 and PR6 additionally require `security-auditor` review per the repo's post-implementation rule.
+
+## Verification plan
+
+Per-PR baseline (runs unchanged from existing CI):
 
 - `python3 .github/skills/validate-wiki-governance/logic/validate_wiki_governance.py`
-- `python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents tests.kb.test_framework_references tests.kb.test_skill_wrappers`
-- `python3 -m pytest tests/kb/`
+- `python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents tests.kb.test_framework_references tests.kb.test_framework_write_surface_matrix tests.kb.test_skill_wrappers`
+- `python3 -m pytest tests/kb/ -q --cov=scripts/kb --cov-fail-under=90`
 
-Implementation acceptance must include explicit tests for:
+Test files added in PR5 (pytest style per adjacent `tests/drive_monitor/` and `tests/github_monitor/` precedent):
 
-- interrupted-run resume behavior
-- stage-by-stage bootstrap classification against expected outputs/fingerprints
-- stale-item revalidation detection
-- lock contention/failure fail-closed behavior
-- rename/move continuity via `item_key` + `path_aliases`
-- bootstrap idempotency and replay safety
+- `tests/kb/test_checkpoint_registry.py` — interrupted-run resume; stale-item revalidation; lock contention/fail-closed; rename/move continuity via `item_key` + `path_aliases`; 1-hour stale timeout; atomic-replace rollback; legal/illegal transitions per the trigger × transition matrix.
+- `tests/kb/test_checkpoint_bootstrap.py` — per-artifact-type classification; bootstrap idempotency and replay safety; canonical JSON output; collision detection; `--force-rebootstrap` lock guard; reconciliation report shape; `--dry-run-report` drift detection.
+- `tests/kb/test_checkpoint_status_render.py` — renderer determinism (snapshot tests); frontmatter machine-fields; rollup table correctness; bounded recent-batches list; empty-registry rendering; threshold-breach annotations.
+- `tests/kb/test_checkpoint_contract_alignment.py` — governed-artifact entry present; lock in `GOVERNANCE_LOCK_FILES`; matrix rows declared; `DEPENDENCY_FINGERPRINT_SOURCES` symmetric with CI-3 push-trigger allowlist; trigger and artifact-type enum completeness; retention-threshold sync between contract doc and code.
+
+Test files amended in PR4/PR5 (contract-test cascades):
+
+- `tests/kb/test_contracts.py` — `GOVERNED_ARTIFACT_IDS` and `GOVERNED_ARTIFACT_PATHS` expected tuples must include the checkpoint registry entry.
+- `tests/kb/test_framework_write_surface_matrix.py` — `EXPECTED_WRITE_SURFACE_MATRIX_ROWS` dict must include three new rows (bootstrap, mutate, status renderer).
+- `tests/kb/test_framework_contracts.py` — `test_boundary_docs_list_same_execution_surface` must include the new `scripts/kb/checkpoint_*.py` entrypoints verbatim in `docs/ideas/wiki-curation-agent-framework.md`.
 
 ## Documentation cascade (implementation checklist)
 
-- Add/update the relevant row(s) in `AGENTS.md` write-surface matrix.
-- Add ADR in `docs/decisions/ADR-*.md` and update `docs/decisions/README.md`.
-- Update `docs/architecture.md` for checkpoint lifecycle and lock ordering.
-- Update `docs/mvp-runbook.md` operator runbooks for manual rescan and checkpoint recovery.
+ADR work (PR1):
+
+- [x] ADR-026 published (2026-05-31).
+- [x] ADR-027 published (2026-06-02) — documents `infrastructure_revalidation` trigger model.
+- [x] `docs/decisions/README.md` indexes both ADRs.
+- [ ] ADR-026 amended in place: `Status: Accepted — extended by ADR-027` plus `## Amendment` section codifying the three-value trigger enum (`intake_driven`, `infrastructure_revalidation`, `manual_rescan` — lowercase snake_case JSON strings; `StrEnum` Python representation per `scripts/kb/contracts.py` precedent).
+- [ ] ADR-026 gains `## Migration` and `## Rollback` headings to match ADR-027 structure and the original Phase 1 ADR requirement.
+- [ ] `docs/decisions/README.md` row for ADR-026 updated to match new status (enforced by pre-commit hook `check_adr_cross_ref.py`).
+
+Architecture and runbook cascade items (PR1, identified by the research validation report as missing):
+
+- [ ] `docs/architecture.md` updated to document checkpoint lifecycle and lock ordering.
+- [ ] `docs/mvp-runbook.md` updated with: manual rescan procedure, checkpoint recovery procedure (per the rollback-scenarios decision), required bootstrap dry-run-then-apply sequence, and `gh run list --workflow=ci-3-pr-producer.yml --status in_progress` reference for the lock-unavailable case.
+
+Schema and surface cascade (PR3-PR5):
+
+- [ ] `schema/wiki-processing-checkpoint-registry-contract.md` authored (PR3).
+- [ ] `schema/CONTEXT.md` File Roles list adds the new contract; `last_updated` bumped.
+- [ ] `scripts/kb/CONTEXT.md` `last_updated` bumped when checkpoint modules land in `scripts/kb/`.
+- [ ] 3 new rows added to `AGENTS.md` write-surface matrix: `scripts/kb/checkpoint_registry.py` bootstrap mode, mutate mode, and `scripts/kb/checkpoint_status_render.py` (PR5).
+- [ ] `sync-knowledgebase-state` matrix row's Schema/artifact owners column extended to cite the new contract (PR5).
+- [ ] `docs/ideas/wiki-curation-agent-framework.md` FRAMEWORK_BOUNDARY_DOCS entrypoint list extended verbatim with the new `scripts/kb/checkpoint_*.py` entrypoints — required by `tests/kb/test_framework_contracts.py::test_boundary_docs_list_same_execution_surface` (literal `assertIn`).
+
+Related repo-wide backlog (not blocking this feature):
+
+- [#181](https://github.com/wryenmeek/knowledgebase/issues/181) — pytest framework formalization + CI ratchet.
+- [#182](https://github.com/wryenmeek/knowledgebase/issues/182) — `--approval` flag pattern reconsideration.
+- [#183](https://github.com/wryenmeek/knowledgebase/issues/183) — lock holder-PID tracking for better lock-unavailable UX.

--- a/docs/ideas/wiki-processing-checkpoint-registry.md
+++ b/docs/ideas/wiki-processing-checkpoint-registry.md
@@ -1,6 +1,6 @@
 # Wiki processing checkpoint registry
 
-**Status:** In Progress — Design decisions resolved via grilling session 2026-06-07; ADR-026 and ADR-027 published; canonical 6-PR implementation plan defined; runtime implementation, schema contract, and remaining documentation cascade items pending.
+**Status:** In Progress — Design decisions resolved via grilling session 2026-06-07 and simplified via `improve-codebase-architecture` review on 2026-06-07 (Path C-prime, 4 PRs); ADR-026 and ADR-027 published; runtime implementation, schema contract, and remaining documentation cascade items pending.
 
 This proposal adds a governed checkpoint registry under `raw/` for wiki processing. The registry tracks generated wiki artifacts/pages at item and batch granularity so partial fail-closed runs can resume and changed outputs can be re-evaluated without storing workflow state in topical wiki content.
 
@@ -14,7 +14,7 @@ Key resolved decisions:
 - **Schema contract structure.** Fresh skeleton (not a 1:1 mirror of `schema/drive-source-registry-contract.md`) because the checkpoint registry's two-scope state model (batch + item), `source_fingerprints` map, and trigger-typed transitions don't fit the per-source-entry shape of the existing registry contracts.
 - **Trigger × transition matrix.** Three triggers (`intake_driven`, `infrastructure_revalidation`, `manual_rescan`) crossed against the six item states. `infrastructure_revalidation` reacts to `dependency_fingerprint` changes; `intake_driven` reacts to `source_fingerprint` changes; only `manual_rescan` can retire (`skipped`) or un-retire items.
 - **Lock strategy: lock-once, hold-long.** Matches `synthesize_combined.py` (PR #115) precedent. Empirical CI-3 data (5 successful runs) shows wiki-lock-held duration is ~1 second per batch today; projected ~1.2-1.5 seconds under the checkpoint orchestrator.
-- **Six-PR implementation layout.** Each PR on its own branch off `main` (named `checkpoint/0N-<slug>`); strict linear merge order; full pre-commit, post-commit, and pre-merge validation per PR.
+- **Four-PR implementation layout (Path C-prime).** An `improve-codebase-architecture` review on 2026-06-07 simplified the earlier six-PR plan: dedicated runtime module preserved; separate render module folded into the existing `sync-knowledgebase-state` skill; `--force-*` operator commands deferred (observable via the monitors below); retention thresholds collapsed to two module-level constants; pre-commit hook deferred (covered by runtime `--verify` mode); separate bootstrap PR folded into the runtime PR. Each PR on its own branch off `main` (named `checkpoint/0N-<slug>`); strict linear merge order; full pre-commit, post-commit, and pre-merge validation per PR.
 
 Three repo-wide backlog issues were filed during the session as side-effect findings (none block the checkpoint feature):
 
@@ -106,23 +106,23 @@ If a run updates both wiki artifacts and checkpoint state, lock ordering is dete
 
 ## Bootstrap and recovery rule
 
+- Bootstrap is an **explicit mode** of `checkpoint_registry.py` (not auto-on-first-write); the architecture review on 2026-06-07 rejected auto-bootstrap to preserve ADR-026's trust model.
 - Bootstrap validates expected outputs at each stage before seeding state.
 - Seed every item whose current state can be classified unambiguously from expected outputs/fingerprints.
 - Leave ambiguous or contradictory cases out of the bootstrap set and flag them for manual resolution.
+- Bootstrap emits a reconciliation report (item-by-item classification plus any ambiguous cases) before any write; the required runbook sequence is dry-run bootstrap -> review reconciliation report -> operator confirmation -> `--bootstrap --apply --approval approved`.
 - This keeps the registry trustworthy while still letting the next run resume from the latest proven stage.
 
 ## Implementation plan
 
-The canonical implementation plan is six PRs in strict linear merge order, each on its own branch off `main`. Every PR must pass pre-commit hooks, post-commit CI checks (including the `--cov-fail-under=90` gate), and pre-merge cross-functional review before merge.
+The canonical implementation plan is **four PRs (Path C-prime)** in strict linear merge order, each on its own branch off `main`. Every PR must pass pre-commit hooks, post-commit CI checks (including the `--cov-fail-under=90` gate), and pre-merge cross-functional review before merge.
 
-1. **PR1 — `checkpoint/01-adr-reconciliation`.** Amend ADR-026 in place to reflect the three-value trigger enum and reference ADR-027 (Status → `Accepted — extended by ADR-027`; new `## Amendment`, `## Migration`, and `## Rollback` sections); update `docs/decisions/README.md` row; land the previously-missing `docs/architecture.md` and `docs/mvp-runbook.md` cascade items called out by the research validation report.
-2. **PR2 — `checkpoint/02-extract-analysis-fingerprint`.** Refactor `scripts/kb/persist_query._analysis_relative_path` to call a new public `analysis_fingerprint()` helper. Pure extraction; no behavior change. Provides the canonical identifier formula the checkpoint code reuses for `wiki/analyses/` items.
-3. **PR3 — `checkpoint/03-schema-contract`.** Author `schema/wiki-processing-checkpoint-registry-contract.md` with the full normative schema (per-artifact-type identity table, `source_fingerprints` map, batch + item state machines, trigger × transition matrix, bootstrap classification rules, retention thresholds, embedded operator-snapshot rendering section).
-4. **PR4 — `checkpoint/04-contracts-and-enums`.** Add `CHECKPOINT_REGISTRY_LOCK_PATH`, `wiki-processing-checkpoint-registry` `GovernedArtifactContract` entry, `TriggerType`/`ArtifactType` enums, `DEPENDENCY_FINGERPRINT_SOURCES` map, and `CheckpointRetentionThresholds` dataclass to `scripts/kb/contracts.py`. Triggers the contract-test cascades in `tests/kb/test_contracts.py` and a new partial `test_checkpoint_contract_alignment.py`.
-5. **PR5 — `checkpoint/05-runtime-and-governance`.** Implement `scripts/kb/checkpoint_registry.py` (bootstrap + mutate + verify modes) and `scripts/kb/checkpoint_status_render.py`; refactor `synthesize_combined.run()` to accept `lock_already_held: bool = False`; add 4 new test files (`test_checkpoint_registry.py`, `test_checkpoint_bootstrap.py`, `test_checkpoint_status_render.py`, `test_checkpoint_contract_alignment.py`); add 3 write-surface matrix rows + amend `sync-knowledgebase-state` row in `AGENTS.md`; update `docs/ideas/wiki-curation-agent-framework.md` FRAMEWORK_BOUNDARY_DOCS entrypoint list verbatim; add `scripts/hooks/check_checkpoint_registry_json.py` pre-commit hook.
-6. **PR6 — `checkpoint/06-ci-wiring-and-bootstrap`.** Wire CI-3 to invoke `checkpoint_registry.py --mutate` and `checkpoint_status_render.py` per batch; required runbook sequence: dry-run bootstrap → review reconciliation report → operator confirmation → `--bootstrap --apply --approval approved`; commit initial registry JSON.
+1. **PR1 — `checkpoint/01-adr-and-doc-reconciliation`.** Amend ADR-026 in place to reflect the three-value trigger enum and reference ADR-027 (Status → `Accepted — extended by ADR-027`; new `## Amendment`, `## Migration`, and `## Rollback` sections); update `docs/decisions/README.md` row; land the previously-missing `docs/architecture.md` and `docs/mvp-runbook.md` cascade items called out by the research validation report. Also includes this idea-doc and the validation research report (`docs/research/wiki-processing-checkpoint-registry-implementation-status.md`) as planning artifacts of PR1.
+2. **PR2 — `checkpoint/02-schema-and-contracts`.** Author `schema/wiki-processing-checkpoint-registry-contract.md` with the full normative schema (per-artifact-type identity table, `source_fingerprints` map, batch + item state machines, trigger × transition matrix, bootstrap classification rules, retention constants). Add to `scripts/kb/contracts.py`: `CHECKPOINT_REGISTRY_LOCK_PATH`, `wiki-processing-checkpoint-registry` `GovernedArtifactContract` entry, `TriggerType`/`ArtifactType` enums, `DEPENDENCY_FINGERPRINT_SOURCES` map, and two module-level retention constants (`CHECKPOINT_REGISTRY_SIZE_WARN_BYTES`, `CHECKPOINT_REGISTRY_SIZE_FAIL_BYTES`) in place of the original `CheckpointRetentionThresholds` dataclass. Extract `analysis_fingerprint()` from `scripts/kb/persist_query._analysis_relative_path` as a pure refactor (pure extraction; no behavior change). Triggers contract-test cascades in `tests/kb/test_contracts.py` and a new partial `test_checkpoint_contract_alignment.py`.
+3. **PR3 — `checkpoint/03-runtime`.** Implement `scripts/kb/checkpoint_registry.py` as a **single module** with three CLI modes: `--bootstrap`, `--mutate`, `--verify`. No `--force-*` family (deferred — see "Deferred items and monitoring" below). Status snapshot is rendered inline by the existing `sync-knowledgebase-state` skill (no new render module). Refactor `synthesize_combined.run()` to accept `lock_already_held: bool = False`. Add 2 new test files (`test_checkpoint_registry.py` covering all three modes, `test_checkpoint_contract_alignment.py`). Add 1 write-surface matrix row to `AGENTS.md` (single entrypoint with all three modes documented in the row) + amend the `sync-knowledgebase-state` row to cite the new contract. Update `docs/ideas/wiki-curation-agent-framework.md` `FRAMEWORK_BOUNDARY_DOCS` entry list verbatim with `scripts/kb/checkpoint_registry.py`. `--verify` mode emits the file-size, item-count, schema-validation, and JSON-parse signals that feed the deferred-item monitors (see "Deferred items and monitoring" below).
+4. **PR4 — `checkpoint/04-ci-wiring-and-bootstrap`.** Wire CI-3 to invoke `checkpoint_registry.py --mutate` per batch, followed by `--verify --warn-only` whose output is surfaced to the GitHub Actions job summary. Execute the bootstrap runbook sequence (dry-run bootstrap -> review reconciliation report -> operator confirmation -> `--bootstrap --apply --approval approved`) and commit the initial registry JSON.
 
-PR1-PR2 are doc/refactor PRs (low risk, single reviewer + `documentation-engineer`). PR3 requires `documentation-engineer` review. PR4 requires `code-reviewer` + `test-engineer` + `documentation-engineer` review. PR5 and PR6 additionally require `security-auditor` review per the repo's post-implementation rule.
+PR1 is a doc-only PR (low risk, single reviewer + `documentation-engineer`). PR2 requires `documentation-engineer` + `test-engineer` review. PR3 requires `code-reviewer` + `test-engineer` + `documentation-engineer` + `security-auditor` review per the repo's post-implementation rule. PR4 additionally requires `security-auditor` review for the CI wiring.
 
 ## Verification plan
 
@@ -132,18 +132,16 @@ Per-PR baseline (runs unchanged from existing CI):
 - `python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents tests.kb.test_framework_references tests.kb.test_framework_write_surface_matrix tests.kb.test_skill_wrappers`
 - `python3 -m pytest tests/kb/ -q --cov=scripts/kb --cov-fail-under=90`
 
-Test files added in PR5 (pytest style per adjacent `tests/drive_monitor/` and `tests/github_monitor/` precedent):
+Test files added in PR3 (pytest style per adjacent `tests/drive_monitor/` and `tests/github_monitor/` precedent):
 
-- `tests/kb/test_checkpoint_registry.py` — interrupted-run resume; stale-item revalidation; lock contention/fail-closed; rename/move continuity via `item_key` + `path_aliases`; 1-hour stale timeout; atomic-replace rollback; legal/illegal transitions per the trigger × transition matrix.
-- `tests/kb/test_checkpoint_bootstrap.py` — per-artifact-type classification; bootstrap idempotency and replay safety; canonical JSON output; collision detection; `--force-rebootstrap` lock guard; reconciliation report shape; `--dry-run-report` drift detection.
-- `tests/kb/test_checkpoint_status_render.py` — renderer determinism (snapshot tests); frontmatter machine-fields; rollup table correctness; bounded recent-batches list; empty-registry rendering; threshold-breach annotations.
-- `tests/kb/test_checkpoint_contract_alignment.py` — governed-artifact entry present; lock in `GOVERNANCE_LOCK_FILES`; matrix rows declared; `DEPENDENCY_FINGERPRINT_SOURCES` symmetric with CI-3 push-trigger allowlist; trigger and artifact-type enum completeness; retention-threshold sync between contract doc and code.
+- `tests/kb/test_checkpoint_registry.py` — covers all three modes. Bootstrap: per-artifact-type classification, idempotency and replay safety, canonical JSON output, collision detection, reconciliation-report shape. Mutate: interrupted-run resume, stale-item revalidation, lock contention/fail-closed, rename/move continuity via `item_key` + `path_aliases`, 1-hour stale timeout, atomic-replace rollback, legal/illegal transitions per the trigger × transition matrix. Verify: read-only schema validation, file-size and item-count reporting, JSON-parse failure detection, exit-code semantics for `--warn-only` vs strict.
+- `tests/kb/test_checkpoint_contract_alignment.py` — governed-artifact entry present; lock in `GOVERNANCE_LOCK_FILES`; matrix row declared; `DEPENDENCY_FINGERPRINT_SOURCES` symmetric with CI-3 push-trigger allowlist; trigger and artifact-type enum completeness; retention-constant sync between contract doc and code.
 
-Test files amended in PR4/PR5 (contract-test cascades):
+Test files amended in PR2/PR3 (contract-test cascades):
 
-- `tests/kb/test_contracts.py` — `GOVERNED_ARTIFACT_IDS` and `GOVERNED_ARTIFACT_PATHS` expected tuples must include the checkpoint registry entry.
-- `tests/kb/test_framework_write_surface_matrix.py` — `EXPECTED_WRITE_SURFACE_MATRIX_ROWS` dict must include three new rows (bootstrap, mutate, status renderer).
-- `tests/kb/test_framework_contracts.py` — `test_boundary_docs_list_same_execution_surface` must include the new `scripts/kb/checkpoint_*.py` entrypoints verbatim in `docs/ideas/wiki-curation-agent-framework.md`.
+- `tests/kb/test_contracts.py` — `GOVERNED_ARTIFACT_IDS` and `GOVERNED_ARTIFACT_PATHS` expected tuples must include the checkpoint registry entry (amended in PR2).
+- `tests/kb/test_framework_write_surface_matrix.py` — `EXPECTED_WRITE_SURFACE_MATRIX_ROWS` dict must include one new row for `scripts/kb/checkpoint_registry.py` (single entrypoint, three modes documented in the row text) (amended in PR3).
+- `tests/kb/test_framework_contracts.py` — `test_boundary_docs_list_same_execution_surface` must include `scripts/kb/checkpoint_registry.py` verbatim in `docs/ideas/wiki-curation-agent-framework.md` (amended in PR3).
 
 ## Documentation cascade (implementation checklist)
 
@@ -161,17 +159,35 @@ Architecture and runbook cascade items (PR1, identified by the research validati
 - [ ] `docs/architecture.md` updated to document checkpoint lifecycle and lock ordering.
 - [ ] `docs/mvp-runbook.md` updated with: manual rescan procedure, checkpoint recovery procedure (per the rollback-scenarios decision), required bootstrap dry-run-then-apply sequence, and `gh run list --workflow=ci-3-pr-producer.yml --status in_progress` reference for the lock-unavailable case.
 
-Schema and surface cascade (PR3-PR5):
+Schema and surface cascade (PR2-PR3):
 
-- [ ] `schema/wiki-processing-checkpoint-registry-contract.md` authored (PR3).
-- [ ] `schema/CONTEXT.md` File Roles list adds the new contract; `last_updated` bumped.
-- [ ] `scripts/kb/CONTEXT.md` `last_updated` bumped when checkpoint modules land in `scripts/kb/`.
-- [ ] 3 new rows added to `AGENTS.md` write-surface matrix: `scripts/kb/checkpoint_registry.py` bootstrap mode, mutate mode, and `scripts/kb/checkpoint_status_render.py` (PR5).
-- [ ] `sync-knowledgebase-state` matrix row's Schema/artifact owners column extended to cite the new contract (PR5).
-- [ ] `docs/ideas/wiki-curation-agent-framework.md` FRAMEWORK_BOUNDARY_DOCS entrypoint list extended verbatim with the new `scripts/kb/checkpoint_*.py` entrypoints — required by `tests/kb/test_framework_contracts.py::test_boundary_docs_list_same_execution_surface` (literal `assertIn`).
+- [ ] `schema/wiki-processing-checkpoint-registry-contract.md` authored (PR2).
+- [ ] `schema/CONTEXT.md` File Roles list adds the new contract; `last_updated` bumped (PR2).
+- [ ] `scripts/kb/CONTEXT.md` `last_updated` bumped when `checkpoint_registry.py` lands (PR3).
+- [ ] 1 new row added to `AGENTS.md` write-surface matrix: `scripts/kb/checkpoint_registry.py` (single entrypoint with all three modes documented in the row) (PR3).
+- [ ] `sync-knowledgebase-state` matrix row's Schema/artifact owners column extended to cite the new contract (PR3).
+- [ ] `docs/ideas/wiki-curation-agent-framework.md` `FRAMEWORK_BOUNDARY_DOCS` entrypoint list extended verbatim with `scripts/kb/checkpoint_registry.py` — required by `tests/kb/test_framework_contracts.py::test_boundary_docs_list_same_execution_surface` (literal `assertIn`).
 
 Related repo-wide backlog (not blocking this feature):
 
 - [#181](https://github.com/wryenmeek/knowledgebase/issues/181) — pytest framework formalization + CI ratchet.
 - [#182](https://github.com/wryenmeek/knowledgebase/issues/182) — `--approval` flag pattern reconsideration.
 - [#183](https://github.com/wryenmeek/knowledgebase/issues/183) — lock holder-PID tracking for better lock-unavailable UX.
+
+## Deferred items and monitoring
+
+The `improve-codebase-architecture` review on 2026-06-07 deferred several surfaces that were in the original six-PR plan. Each is observable via cheap, mostly-free signals so a re-evaluation issue can be filed with concrete evidence rather than speculation.
+
+| Deferred item | Failure signal to watch | Where to read it | Trigger threshold to file backlog issue |
+|---|---|---|---|
+| `--force-*` operator recovery commands (`--force-transition`, `--mark-stale-by-key`, `--force-rebootstrap`, `--dry-run-report`) | Operator manually edits `raw/wiki-processing/wiki-processing-checkpoint-registry.json` to repair state | `git log --oneline -- raw/wiki-processing/wiki-processing-checkpoint-registry.json` (count non-CI-bot commits) | ≥2 manual repair commits in a 90-day window |
+| `--force-*` operator recovery commands | `--verify` mode failures in CI-3 | `gh run list --workflow=ci-3-pr-producer.yml --json conclusion,createdAt` plus the `--verify --warn-only` job-summary output | ≥3 verify-mode failures in 30 days |
+| Retention dataclass with soft/hard threshold pairs | Registry file size growth | `--verify` mode prints `file_size_bytes` and compares against `CHECKPOINT_REGISTRY_SIZE_WARN_BYTES` / `CHECKPOINT_REGISTRY_SIZE_FAIL_BYTES` constants | File >5 MB warning / >10 MB hard fail |
+| Retention dataclass with soft/hard threshold pairs | Item count growth | `--verify` mode prints `item_count` | >5,000 items |
+| Pre-commit hook for registry JSON | Invalid JSON discovered at runtime | `--verify` mode JSON-parse failure events appended to `wiki/log.md` under event type `checkpoint_registry.verify_warning` | ≥1 corruption incident logged |
+| Pre-commit hook for registry JSON | Schema validation failures | `--verify` mode schema-check failure events appended to `wiki/log.md` under event type `checkpoint_registry.verify_warning` | ≥2 schema failures from hand-edits in 90 days |
+| Standalone status render module | Inline render code in `sync-knowledgebase-state` growing unwieldy | Code-review observation; LOC count of the inline render function | >50 LOC inline render |
+
+Monitoring instrumentation lives in PR3 (`--verify` mode reports + `wiki/log.md` event taxonomy) and PR4 (CI-3 job-summary surfacing). Net cost: ~15 LOC in PR3, ~5 lines of YAML in PR4. No new GitHub Actions workflow, no per-PR size assertion, no separate monitoring schema — everything piggybacks on existing telemetry (`git log`, `gh run list`, append-only `wiki/log.md`).
+
+Issue filing protocol: do not pre-emptively file backlog issues for deferred items. File one issue per signal only when its trigger threshold is exceeded, with the supporting evidence (git log output, CI run IDs, or log events) attached. This keeps the backlog free of speculative items and ensures any new surface added later is justified by observed failure data.

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -317,8 +317,11 @@ python3 scripts/kb/checkpoint_registry.py --mutate \
 After a CI-3 partial-failure or fail-closed run, recover with this
 sequence:
 
-1. Inspect the operator snapshot at `wiki/status.md` for the most
-   recent batch's `status` and `error_summary`.
+1. (PR3+) Inspect the operator snapshot at `wiki/status.md` for the
+   most recent batch's `status` and `error_summary`. The
+   `sync-knowledgebase-state` publisher gains checkpoint fields
+   (`batch_id`, `status`, `trigger`, `error_summary`) in PR3; today's
+   `wiki/status.md` does not carry them yet.
 2. Inspect the raw registry at
    `raw/wiki-processing/wiki-processing-checkpoint-registry.json` for
    the failing item's `last_error`, `status`, and `last_attempted_at`

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -378,9 +378,9 @@ CI-3 run. First, list active CI-3 runs:
 gh run list --workflow=ci-3-pr-producer.yml --status in_progress
 ```
 
-If no run is active and the lock is stale (no in-progress CI-3 job),
-remove the lock file and retry. If a run is active, wait for it to
-complete (lock is typically held for ~1 second per batch under the
+Once PR4 lands: if no run is active and the lock is stale (no in-progress
+CI-3 job), remove the lock file and retry. If a run is active, wait for it
+to complete (lock is typically held for ~1 second per batch under the
 single-lock-hold-long pattern; see `synthesize_combined.py` precedent).
 The repo-wide convention for holder-PID tracking is filed as backlog
 issue [#183](https://github.com/wryenmeek/knowledgebase/issues/183).

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -288,6 +288,91 @@ approved, keep these existing MVP suites green:
 - Broad regression suite:
   `python3 -m pytest tests/ -q`
 
+## Wiki processing checkpoint registry (forward-looking)
+
+The wiki processing checkpoint registry (ADR-026, ADR-027) lands across
+four PRs per the Path C-prime plan in
+[`docs/ideas/wiki-processing-checkpoint-registry.md`](ideas/wiki-processing-checkpoint-registry.md).
+The runtime script `scripts/kb/checkpoint_registry.py` lands in PR3 and
+CI-3 wiring lands in PR4. The procedures below document the operator
+path that those PRs enable; they are not yet executable today.
+
+### Manual rescan
+
+A manual rescan recomputes item state and reruns failed/stale entries
+under operator control. Run from the repo root:
+
+```bash
+# PR3 entrypoint (forward-looking)
+python3 scripts/kb/checkpoint_registry.py --mutate \
+  --trigger manual_rescan \
+  --approval approved
+```
+
+`manual_rescan` is the only trigger that can move items between
+`skipped` and `pending`. See ADR-026 § State transitions.
+
+### Checkpoint recovery procedure
+
+After a CI-3 partial-failure or fail-closed run, recover with this
+sequence:
+
+1. Inspect the operator snapshot at `wiki/status.md` for the most
+   recent batch's `status` and `error_summary`.
+2. Inspect the raw registry at
+   `raw/wiki-processing/wiki-processing-checkpoint-registry.json` for
+   the failing item's `last_error`, `status`, and `last_attempted_at`
+   fields.
+3. Resolve the underlying cause (validator failure, write denial, schema
+   mismatch, lock contention).
+4. Run a manual rescan (above) — `stale` and `failed` items are
+   re-claimed by the next batch under deterministic transition rules.
+
+The registry is the source of truth; `wiki/status.md` is a derived
+snapshot.
+
+### Bootstrap dry-run-then-apply sequence
+
+Bootstrap is an explicit mode (never auto-on-first-write). The required
+sequence is dry-run, review the reconciliation report, operator
+confirmation, then apply:
+
+```bash
+# 1. Dry-run bootstrap — emits the reconciliation report without writing
+python3 scripts/kb/checkpoint_registry.py --bootstrap --dry-run
+
+# 2. Review the reconciliation report (item-by-item classification plus
+#    any ambiguous cases) printed to stdout.
+
+# 3. Operator confirms the report is correct.
+
+# 4. Apply bootstrap with explicit approval
+python3 scripts/kb/checkpoint_registry.py --bootstrap --apply \
+  --approval approved
+```
+
+Ambiguous or contradictory items are left out of the bootstrap set and
+require manual resolution before they can be tracked. See ADR-026 §
+Bootstrap and recovery.
+
+### Lock-unavailable: `raw/.wiki-processing-checkpoint.lock`
+
+If the checkpoint script reports
+`reason_code=lock_unavailable` for `raw/.wiki-processing-checkpoint.lock`,
+do **not** remove the lock blindly. The lock may be held by an active
+CI-3 run. First, list active CI-3 runs:
+
+```bash
+gh run list --workflow=ci-3-pr-producer.yml --status in_progress
+```
+
+If no run is active and the lock is stale (no in-progress CI-3 job),
+remove the lock file and retry. If a run is active, wait for it to
+complete (lock is typically held for ~1 second per batch under the
+single-lock-hold-long pattern; see `synthesize_combined.py` precedent).
+The repo-wide convention for holder-PID tracking is filed as backlog
+issue [#183](https://github.com/wryenmeek/knowledgebase/issues/183).
+
 ## Exit semantics and failure handling
 
 - **Fail-closed default:** any non-zero exit from preflight/index/lint/tests is a stop signal.

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -322,14 +322,15 @@ sequence:
    `sync-knowledgebase-state` publisher gains checkpoint fields
    (`batch_id`, `status`, `trigger`, `error_summary`) in PR3; today's
    `wiki/status.md` does not carry them yet.
-2. Inspect the raw registry at
+2. (PR3+) Inspect the raw registry at
    `raw/wiki-processing/wiki-processing-checkpoint-registry.json` for
    the failing item's `last_error`, `status`, and `last_attempted_at`
-   fields.
+   fields. The registry file does not exist until PR3 lands.
 3. Resolve the underlying cause (validator failure, write denial, schema
    mismatch, lock contention).
-4. Run a manual rescan (above) — `stale` and `failed` items are
+4. (PR3+) Run a manual rescan (above) — `stale` and `failed` items are
    re-claimed by the next batch under deterministic transition rules.
+   Requires `scripts/kb/checkpoint_registry.py` (PR3).
 
 The registry is the source of truth; `wiki/status.md` is a derived
 snapshot.
@@ -341,6 +342,9 @@ sequence is dry-run, review the reconciliation report, operator
 confirmation, then apply:
 
 ```bash
+# PR3 entrypoint (forward-looking) — scripts/kb/checkpoint_registry.py
+# does not yet exist; bootstrap is exercisable only after PR3 lands.
+
 # 1. Dry-run bootstrap — emits the reconciliation report without writing
 python3 scripts/kb/checkpoint_registry.py --bootstrap --dry-run
 
@@ -358,7 +362,11 @@ Ambiguous or contradictory items are left out of the bootstrap set and
 require manual resolution before they can be tracked. See ADR-026 §
 Bootstrap and recovery.
 
-### Lock-unavailable: `raw/.wiki-processing-checkpoint.lock`
+### Lock-unavailable: `raw/.wiki-processing-checkpoint.lock` (PR4+)
+
+> **Forward-looking.** The lock first becomes observable when CI-3 wiring
+> lands in PR4. Today the lock file does not exist and no script attempts
+> to acquire it.
 
 If the checkpoint script reports
 `reason_code=lock_unavailable` for `raw/.wiki-processing-checkpoint.lock`,
@@ -366,6 +374,7 @@ do **not** remove the lock blindly. The lock may be held by an active
 CI-3 run. First, list active CI-3 runs:
 
 ```bash
+# PR4+ runbook step — CI-3 invokes the checkpoint runtime starting in PR4.
 gh run list --workflow=ci-3-pr-producer.yml --status in_progress
 ```
 

--- a/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
+++ b/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
@@ -1,0 +1,192 @@
+# Wiki processing checkpoint registry — implementation status verification
+
+**Date:** 2026-06-04
+**Mode:** verified-research (read-only)
+**Subject:** `docs/ideas/wiki-processing-checkpoint-registry.md`
+**Method:** primary-source verification with four parallel explore subagents (ADR/doc cascade, runtime/code, schema/matrix, tests/CI) plus direct inspection of ADR-026, ADR-027, README, and the CI-3 workflow.
+
+---
+
+## Headline
+
+The idea doc's own status line — **"In Progress — ADR-026 is published and tracked in `docs/decisions/README.md`; registry implementation remains pending (2026-06-04)"** — is **substantially accurate** but **understates two pieces of drift**:
+
+1. **Trigger-model drift between ADR-026 and the idea doc** (the doc has evolved past the ADR without amending it).
+2. **Documentation cascade items the doc itself prescribes were never landed** (`docs/architecture.md` and `docs/mvp-runbook.md` updates).
+
+Implementation of the registry, schema, lock, runtime code, write-surface row, and tests is **0% landed**. Only ADRs (decision artifacts) and one upstream CI workflow gate (the push-trigger preflight in CI-3) are present.
+
+---
+
+## Lineage
+
+- **Idea doc** `docs/ideas/wiki-processing-checkpoint-registry.md` — proposal (`Status: In Progress`).
+- **ADR-026** `docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md` — Accepted 2026-05-31, codifies the registry decision.
+- **ADR-027** `docs/decisions/ADR-027-infrastructure-validation-trigger-model.md` — Accepted 2026-06-02, introduces the `intake_driven` / `infrastructure_revalidation` trigger naming and lists ADR-026 in "Related decisions" (but ADR-026's `## Status` was **not** updated to "extended by ADR-027" per the repo's ADR evolution rule).
+
+The idea doc was last updated **2026-06-04** to record the ADR-027 trigger naming; ADR-026 still uses the older `automatic | manual_rescan` field values.
+
+This is **convergence with drift**: the idea doc, ADR-027, and CI-3 workflow agree on the trigger model; ADR-026 lags behind.
+
+---
+
+## Confirmation table (per major claim)
+
+| # | Claim from idea doc | Verdict | Confidence | Primary evidence |
+|---|---|---|---|---|
+| 1 | ADR-026 exists and is `Accepted` | **Confirmed** | Very High | `docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md:3-5` |
+| 2 | ADR-026 tracked in `docs/decisions/README.md` with matching status | **Confirmed** | Very High | `docs/decisions/README.md:35` |
+| 3 | ADR documents the `infrastructure_revalidation` trigger model | **Drift** | High | `ADR-026:64` lists triggers as `automatic` and `manual_rescan` only; the model is in ADR-027 instead, and ADR-026's status was not amended |
+| 4 | Registry artifact `raw/wiki-processing/wiki-processing-checkpoint-registry.json` exists | **Not Implemented** | Very High | Directory `raw/wiki-processing/` does not exist |
+| 5 | Schema contract `schema/wiki-processing-checkpoint-registry-contract.md` exists | **Not Implemented** | Very High | Not in `schema/` listing; precedent files would be `schema/github-source-registry-contract.md`, `schema/drive-source-registry-contract.md` |
+| 6 | Checkpoint lock `raw/.wiki-processing-checkpoint.lock` declared in code | **Not Implemented** | Very High | `scripts/kb/contracts.py:74-88` defines `GOVERNANCE_LOCK_FILES` from `WRITE_LOCK_PATH`, `GITHUB_SOURCES_LOCK_PATH`, `REJECTION_REGISTRY_LOCK_PATH`, `DRIVE_SOURCES_LOCK_PATH` only |
+| 7 | Write-surface matrix row added in `AGENTS.md` | **Not Implemented** | Very High | No matrix row mentions `wiki-processing`, `checkpoint`, or the proposed lock path |
+| 8 | Runtime helpers exist under `scripts/kb/**` | **Not Implemented** | Very High | No `scripts/kb/**` source contains the registry/checkpoint/bootstrap symbols listed in the idea doc |
+| 9 | Bootstrap dry-run + apply implemented | **Not Implemented** | Very High | No `bootstrap_checkpoint*` module, no `--bootstrap` flag against `raw/wiki-processing` |
+| 10 | Resume / revalidation logic wired (intake_driven + infrastructure_revalidation + manual_rescan) | **Partially Implemented (gate-only)** | High | CI-3 push-trigger gate exists at `.github/workflows/ci-3-pr-producer.yml:112-157` (path filter for CI-3 infrastructure changes); no checkpoint write-back, no trigger-type label propagation |
+| 11 | Operator snapshot via `sync-knowledgebase-state` -> `wiki/status.md` | **Partially Implemented (publisher exists; no checkpoint summary)** | Very High | `.github/skills/sync-knowledgebase-state/logic/sync_knowledgebase_state.py:24-29` defines `STATUS_ARTIFACT = "wiki/status.md"` and supports `--write-status-from`, but no `checkpoint`, `batch_id`, or trigger-type fields are written |
+| 12 | `docs/architecture.md` updated for checkpoint lifecycle and lock ordering | **Not Implemented** | Very High | No matches for `checkpoint`, `infrastructure_revalidation`, `manual_rescan`, `wiki-processing`, or `wiki-processing-checkpoint.lock` in `docs/architecture.md` |
+| 13 | `docs/mvp-runbook.md` updated for manual rescan and checkpoint recovery | **Not Implemented** | Very High | No matches for the same terms in `docs/mvp-runbook.md` |
+| 14 | Tests cover all required acceptance categories (resume, bootstrap classification, stale revalidation, lock fail-closed, rename continuity, replay safety) | **Not Implemented** | Very High | Exhaustive `tests/` grep returned zero matches for the required symbols/terms; framework-level test files exist but contain no checkpoint coverage |
+| 15 | CI workflow runs checkpoint registry tooling | **Not Implemented** | Very High | `.github/workflows/*.yml` has no matches for `wiki-processing`, `checkpoint`, or `manual_rescan` |
+| 16 | `GovernedArtifactContract` enumerates the registry | **Not Implemented** | Very High | `scripts/kb/contracts.py:138-206` enumerates `wiki-index`, `wiki-log`, `wiki-open-questions`, `wiki-backlog`, `wiki-status`, `github-source-registry`, `external-asset`, `rejection-record` — no checkpoint entry |
+
+---
+
+## Material findings (ordered by severity)
+
+### F1 — Trigger-name drift between ADR-026 and idea doc (must reconcile)
+
+**Severity:** High — this affects the contract surface a future implementer will build to.
+
+- **Idea doc** `docs/ideas/wiki-processing-checkpoint-registry.md:48` says `trigger` ∈ `{intake_driven, infrastructure_revalidation, manual_rescan}`.
+- **ADR-026** `docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md:64` says `trigger` ∈ `{automatic, manual_rescan}` — only two values.
+- **ADR-027** `docs/decisions/ADR-027-infrastructure-validation-trigger-model.md:27-33` introduces `intake_driven` and `infrastructure_revalidation` as separate trigger paths and explicitly says: *"Update the checkpoint registry (when implemented) with `trigger: infrastructure_revalidation`"* — implying ADR-026's `automatic` value is now subdivided.
+- **ADR-027 lists ADR-026 in "Related decisions"** (lines 76-77) but ADR-026's `## Status` (line 5) is still bare `Accepted` — per the repo's ADR-evolution rule in `.github/copilot-instructions.md`, ADR-026 should be updated to `Accepted — extended by ADR-027` and a `## Amendment` section added.
+
+**Concrete remediation needed before implementation lands:**
+- Either amend ADR-026 in place to enumerate the three-value trigger field and reference ADR-027, or move the canonical trigger enumeration entirely into ADR-027 and have ADR-026 defer to it. The current state forces a future implementer to choose between two contradictory specs.
+
+### F2 — ADR-026 lacks the `Migration` / `Rollback` headings the idea doc requires
+
+**Severity:** Medium.
+
+- Idea doc §Phases.1 says: *"Draft ADR and contract together: decision, alternatives, migration, rollback, and operational consequences."*
+- ADR-026 has `## Decision`, `## Alternatives considered`, `## Consequences`, `## References` but **no `## Migration`, `## Rollback`, or `## Operational consequences` headings**.
+- The substance partially exists inside `## Consequences` (lines 207-219) and `## Retention` (lines 136-142), but does not satisfy the structured headings the idea doc itself prescribed.
+- (Counter-example: ADR-027 does include `## Migration and rollback` at line 79 — so the precedent in this codebase is to have these as explicit headings.)
+
+### F3 — Documentation cascade prescribed by the idea doc is not landed
+
+**Severity:** Medium.
+
+The idea doc §"Documentation cascade (implementation checklist)" lists four required updates. Three are absent and one is partially done:
+
+| Required cascade | State |
+|---|---|
+| AGENTS.md write-surface matrix row(s) | **Absent** (deferred until writes are enabled — acceptable) |
+| ADR in `docs/decisions/ADR-*.md` + README update | **Done** for ADR-026; README aligned |
+| `docs/architecture.md` updated for checkpoint lifecycle and lock ordering | **Absent** |
+| `docs/mvp-runbook.md` operator runbooks for manual rescan and checkpoint recovery | **Absent** |
+
+The matrix-row deferral is defensible (no writes yet), but `docs/architecture.md` should at minimum reference ADR-026/ADR-027 so the layering picture matches the accepted decisions. The runbook gap is operationally riskier — when the registry lands, the runbook will need both manual_rescan and recovery procedures.
+
+### F4 — CI-3 push-trigger preflight is the only piece of "trigger logic" that exists
+
+**Severity:** Informational (positive partial progress).
+
+ADR-027 lines 70-72 claim the preflight is *"implemented in `.github/workflows/ci-3-pr-producer.yml`, lines 109–147"*. **Verified:** the gate is at lines **112-157** (slight line drift from the ADR's stated range, immaterial). The gate:
+
+- Allows `push` events only when changed paths match: `.github/workflows/ci-3-*`, `.github/skills/extract-entities-and-claims/**`, `.github/skills/validate-wiki-governance/**`, `.github/skills/synthesize-entity-page/**`, `.github/skills/synthesize-concept-page/**`.
+- Rejects mixed scopes (any non-matching path fails the preflight).
+- Uses the generic `prereq_trusted_trigger_model` indicator — **no literal `infrastructure_revalidation` / `intake_driven` / `manual_rescan` string appears in any workflow YAML or downstream code.** The trigger-type label propagation that ADR-026/ADR-027 envision (so a checkpoint row can record `trigger: infrastructure_revalidation`) is not yet wired.
+
+### F5 — `wiki/status.md` publisher exists but emits no checkpoint summary
+
+**Severity:** Informational.
+
+- Idea doc says: *"Primary operator snapshot: `wiki/status.md` via `sync-knowledgebase-state`."*
+- ADR-026 lines 128-133 reinforce this.
+- `.github/skills/sync-knowledgebase-state/logic/sync_knowledgebase_state.py:24-29` defines `STATUS_ARTIFACT = "wiki/status.md"` and supports `--write-status-from`.
+- No `checkpoint`, `batch_id`, `infrastructure_revalidation`, or `manual_rescan` references in the skill logic file. The publisher is ready; the schema/payload for the checkpoint summary is not.
+
+### F6 — FRAMEWORK_BOUNDARY_DOCS rule will trip when a new `scripts/kb/**` entrypoint lands
+
+**Severity:** Procedural (must-handle-on-implementation).
+
+Per `.github/copilot-instructions.md`, `docs/ideas/wiki-curation-agent-framework.md` is monitored by `tests/kb/test_framework_contracts.py::test_boundary_docs_list_same_execution_surface` with literal `assertIn` against the entrypoint list. Today that doc lists only: `scripts/kb/ingest.py`, `scripts/kb/update_index.py`, `scripts/kb/lint_wiki.py`, `scripts/kb/qmd_preflight.py`, `scripts/kb/persist_query.py`. **Adding any new `scripts/kb/<checkpoint>.py` entrypoint will require updating this monitored doc verbatim, or the boundary-contract test will fail in CI.** Flag for the implementation phase.
+
+### F7 — Contract-test cascades a future implementer will hit
+
+**Severity:** Procedural (must-handle-on-implementation).
+
+Per AGENTS.md "Contract test cascades" and copilot-instructions.md, three tests use exhaustive expected-tuple/dict assertions:
+- `tests/kb/test_contracts.py:12-40` — `GOVERNED_ARTIFACT_IDS` / `GOVERNED_ARTIFACT_PATHS` expected tuples (must add checkpoint registry entry)
+- `tests/kb/test_framework_write_surface_matrix.py:12-124` — `EXPECTED_WRITE_SURFACE_MATRIX_ROWS` dict (must add matrix-row entry)
+- Plus the boundary-docs test above
+
+None reference checkpoint today — they will block any partial implementation that adds the artifact contract or matrix row without simultaneously updating expected sets.
+
+### F8 — Sibling idea doc for ADR-027 not authored
+
+**Severity:** Low.
+
+ADR-027 stands alone in `docs/decisions/` with no companion `docs/ideas/infrastructure-validation-trigger-model.md`. Of 10 idea docs in `docs/ideas/`, 9 are `Implemented` (or `Implemented (Phase 1)`) and only this one is `In Progress`. The repo pattern is to back each ADR with an idea doc; ADR-027 is the only Accepted ADR in the recent set without one. Not blocking but worth noting for the documentation-cascade audit.
+
+---
+
+## Counter-examples checked
+
+For each "nothing exists" claim above I searched for the actual artifact (not just the term) before reporting. Specifically:
+
+- **"No registry artifact"** — verified `raw/wiki-processing/` does not exist on disk (not just absent from grep).
+- **"No runtime helpers"** — searched all of `scripts/**` (not just `scripts/kb/**`); the only `bootstrap` hits were in `scripts/fleet/**` (unrelated TypeScript fleet tooling).
+- **"No tests"** — adjacent precedent tests for `github_monitor/` and `drive_monitor/` registries were located and confirmed structurally analogous; their absence for `wiki-processing` is therefore a genuine gap, not a naming/path mismatch.
+- **"No matrix row"** — searched the matrix for all four candidate substrings (`wiki-processing`, `checkpoint`, the writable path, the lock path) — none match.
+
+No counter-examples found to overturn the "not implemented" verdicts in items 4-16.
+
+---
+
+## What IS in place (positive baseline)
+
+1. **ADR-026 published and indexed** with substantive Decision, Alternatives, Consequences sections.
+2. **ADR-027 published and indexed** with the trigger model and CI-3 preflight gate cross-reference.
+3. **CI-3 infrastructure-revalidation push gate** working at `.github/workflows/ci-3-pr-producer.yml:112-157`.
+4. **`wiki/status.md` publisher** ready to receive a checkpoint summary payload once the writer side exists.
+5. **Adjacent contract templates** (`schema/github-source-registry-contract.md`, `schema/drive-source-registry-contract.md`) provide a clean precedent the new contract can mirror.
+6. **Adjacent test patterns** (`tests/github_monitor/test_check_drift.py`, `tests/drive_monitor/test_registry.py`) provide a clean precedent for the new test suite.
+
+---
+
+## Recommended next actions (ordered)
+
+These come from the verification, not from the implementer's plan. They mirror the idea doc's Phase ordering with the gaps filled in.
+
+1. **Reconcile ADR-026 with ADR-027** — amend ADR-026's `## Status` to `Accepted — extended by ADR-027`, add a `## Amendment` section noting the three-value trigger field, and update the README row's status to match. This unblocks every subsequent step by removing the spec ambiguity.
+2. **Add `## Migration` and `## Rollback` headings to ADR-026** to match ADR-027's structure and the idea doc's Phase 1 requirement.
+3. **Land `schema/wiki-processing-checkpoint-registry-contract.md`** mirroring the structure of `schema/drive-source-registry-contract.md` (the more recent of the two precedents).
+4. **Update `schema/CONTEXT.md`** File Roles list with the new contract; bump `last_updated`.
+5. **Update `docs/architecture.md`** to document checkpoint lifecycle and lock ordering; cite ADR-026 and ADR-027.
+6. **Update `docs/mvp-runbook.md`** with `manual_rescan` and recovery procedures.
+7. **Only then** open the runtime work: add `scripts/kb/<checkpoint>.py`, the matrix row, the lock declaration in `contracts.py`, and the test suite — in lockstep with the boundary-docs and expected-tuple cascades (F6, F7).
+
+---
+
+## Analytical framing labels (for transparency)
+
+- *"Drift" verdicts* are this report's characterization based on comparing the idea doc, ADR-026, and ADR-027 line-by-line. The repo's own ADR-evolution rule (in `.github/copilot-instructions.md`) is the cited authority.
+- *"Partially Implemented"* is reserved for surfaces where part of the proposed wiring is live and verified (CI-3 push gate; `wiki/status.md` publisher) but the checkpoint payload is absent. Calling these "Implemented" would be misleading; calling them "Not Implemented" would obscure the real partial progress.
+- *"Not Implemented"* is binary: no file, no symbol, no reference found by exhaustive grep. Each such verdict is backed by either a directory listing or a grep result with the patterns documented inline above.
+
+---
+
+## Verification trail
+
+- **Subagent A** (verify-adr-doc-cascade): confirmed ADR-026/027 + README rows + architecture/runbook absence + idea-doc `Status` field.
+- **Subagent B** (verify-runtime-implementation): confirmed absence of `raw/wiki-processing/`, lock file references, runtime helpers, bootstrap, and `wiki/status.md` checkpoint payload.
+- **Subagent C** (verify-schema-and-matrix): confirmed absence of contract, matrix row, governed-artifact contract entry, and lock-file-registry entry; located precedent templates.
+- **Subagent D** (verify-tests-and-validation): confirmed absence of acceptance tests, located contract-test cascade locations, and located adjacent test templates.
+- **Direct primary-source reads** by the orchestrator: ADR-026 (full file), ADR-027 (full file), `docs/decisions/README.md` (relevant lines), `.github/workflows/ci-3-pr-producer.yml` (lines 100-160 + grep over trigger-term variants).
+
+All factual statements above trace to either a file:line citation, a directory-listing result, or a documented grep pattern that returned zero matches.

--- a/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
+++ b/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
@@ -7,9 +7,9 @@
 
 > **Baseline report — point-in-time snapshot (2026-06-04).** This
 > document captures the codebase state **before PR1 of the C-prime 4-PR
-> plan landed**. Items 1 and 2 in the Headline ("Documentation cascade
-> items never landed" and "Trigger-model drift between ADR-026 and the
-> idea doc") were resolved by PR #184 (this PR). The findings below
+> plan landed**. Items 1 and 2 in the Headline ("Trigger-model drift
+> between ADR-026 and the idea doc" and "Documentation cascade items
+> never landed") were resolved by PR #184 (this PR). The findings below
 > remain accurate as historical evidence for *why* the cascade work was
 > scoped; they should not be read as a description of current state.
 > See `docs/ideas/wiki-processing-checkpoint-registry.md` § Implementation

--- a/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
+++ b/docs/research/wiki-processing-checkpoint-registry-implementation-status.md
@@ -5,6 +5,16 @@
 **Subject:** `docs/ideas/wiki-processing-checkpoint-registry.md`
 **Method:** primary-source verification with four parallel explore subagents (ADR/doc cascade, runtime/code, schema/matrix, tests/CI) plus direct inspection of ADR-026, ADR-027, README, and the CI-3 workflow.
 
+> **Baseline report — point-in-time snapshot (2026-06-04).** This
+> document captures the codebase state **before PR1 of the C-prime 4-PR
+> plan landed**. Items 1 and 2 in the Headline ("Documentation cascade
+> items never landed" and "Trigger-model drift between ADR-026 and the
+> idea doc") were resolved by PR #184 (this PR). The findings below
+> remain accurate as historical evidence for *why* the cascade work was
+> scoped; they should not be read as a description of current state.
+> See `docs/ideas/wiki-processing-checkpoint-registry.md` § Implementation
+> plan for what PR1 closed and what PR2/PR3/PR4 still address.
+
 ---
 
 ## Headline

--- a/tests/kb/test_framework_references.py
+++ b/tests/kb/test_framework_references.py
@@ -87,6 +87,23 @@ OPTIONAL_GOVERNED_ARTIFACT_TARGETS = {
     "wiki/backlog.md",
     "wiki/status.md",
 }
+# Narrow allowlist of paths that audited docs intentionally reference forward
+# during a multi-PR rollout. Each entry MUST be removed once the PR that lands
+# the file is merged; the self-cleanup guard test below fails as soon as the
+# allowlisted path appears on disk, forcing the entry to be removed in the same
+# PR that creates the file.
+FORWARD_REFERENCED_PATHS: frozenset[str] = frozenset(
+    {
+        # Lands in PR2 of the wiki-processing checkpoint registry rollout
+        # (issue #186). docs/architecture.md cites this contract path in PR1.
+        "schema/wiki-processing-checkpoint-registry-contract.md",
+        # Lands in PR3 of the wiki-processing checkpoint registry rollout
+        # (issue #187). docs/architecture.md and docs/mvp-runbook.md cite this
+        # runtime entrypoint (both as a backticked path and in example
+        # python3 commands) in PR1.
+        "scripts/kb/checkpoint_registry.py",
+    }
+)
 
 
 class FrameworkReferenceAuditTests(unittest.TestCase):
@@ -109,6 +126,8 @@ class FrameworkReferenceAuditTests(unittest.TestCase):
                     continue
                 if target in OPTIONAL_GOVERNED_ARTIFACT_TARGETS:
                     continue
+                if target in FORWARD_REFERENCED_PATHS:
+                    continue
                 if target not in {"AGENTS.md", "README.md"} and Path(target).suffix not in {
                     ".md",
                     ".py",
@@ -121,6 +140,8 @@ class FrameworkReferenceAuditTests(unittest.TestCase):
         for path in MARKDOWN_FILES:
             text = path.read_text(encoding="utf-8")
             for command_target in PYTHON_COMMAND_RE.findall(text):
+                if command_target in FORWARD_REFERENCED_PATHS:
+                    continue
                 resolved = self._resolve_command_target(command_target)
                 with self.subTest(
                     file=path.relative_to(REPO_ROOT).as_posix(),
@@ -166,6 +187,26 @@ class FrameworkReferenceAuditTests(unittest.TestCase):
                 self.assertNotIn("raw/inbox/SPEC.md", text)
                 if "SPEC.md" in text:
                     self.assertIn("raw/processed/SPEC.md", text)
+
+    def test_forward_referenced_paths_have_not_landed_yet(self) -> None:
+        """Force cleanup of FORWARD_REFERENCED_PATHS entries once their files land.
+
+        Each entry in FORWARD_REFERENCED_PATHS exists to skip the resolution
+        checks above for paths that are documented in PR1 but authored in a
+        later PR. When the later PR lands the file, the allowlist entry must
+        be removed in the same PR — otherwise the entry becomes dead code that
+        silently hides future broken references at the same path.
+        """
+        for forward_path in FORWARD_REFERENCED_PATHS:
+            with self.subTest(forward_path=forward_path):
+                self.assertFalse(
+                    (REPO_ROOT / forward_path).exists(),
+                    msg=(
+                        f"{forward_path} now exists on disk. Remove it from "
+                        "FORWARD_REFERENCED_PATHS in tests/kb/test_framework_references.py "
+                        "so the normal resolution checks audit it like any other path."
+                    ),
+                )
 
     def _resolve_doc_target(self, source_path: Path, target: str) -> Path:
         if target.startswith("/"):


### PR DESCRIPTION
## PR1 of the wiki processing checkpoint registry feature

This is **PR1 (doc-only) of 4** for the wiki processing checkpoint registry feature. Per the [Path C-prime plan](https://github.com/wryenmeek/knowledgebase/blob/checkpoint/01-adr-and-doc-reconciliation/docs/ideas/wiki-processing-checkpoint-registry.md#implementation-plan):

| PR | Branch | Scope |
|---|---|---|
| **PR1 (this PR)** | `checkpoint/01-adr-and-doc-reconciliation` | ADR amendment + documentation cascade |
| PR2 | `checkpoint/02-schema-and-contracts` | Schema contract + `scripts/kb/contracts.py` additions |
| PR3 | `checkpoint/03-runtime` | `scripts/kb/checkpoint_registry.py` (single module, 3 modes) |
| PR4 | `checkpoint/04-ci-wiring-and-bootstrap` | CI-3 wiring + bootstrap |

## What changed

Eight commits land six files (all under `docs/`):

| File | Change |
|---|---|
| `docs/decisions/ADR-026-…md` | Status → `Accepted — extended by ADR-027`; new `## Amendment`, `## Migration`, `## Rollback` sections codifying the three-value trigger enum (`intake_driven`, `infrastructure_revalidation`, `manual_rescan`); inline pointer added to the superseded two-value enumeration in the Decision body. |
| `docs/decisions/README.md` | ADR-026 row status updated to match (same-commit-cascade rule enforced by `check_adr_cross_ref.py`). |
| `docs/architecture.md` | New `## Wiki processing checkpoint registry` section (with forward-looking preamble); checkpoint-lock and lock-ordering bullets added to Write & safety controls (marked forward-looking until PR3 runtime lands); ADR-026/ADR-027 added to the Decision-records list. |
| `docs/mvp-runbook.md` | New forward-looking section with four operator procedures: manual rescan (PR3+), checkpoint recovery (PR3+), bootstrap dry-run-then-apply sequence (PR3+), and lock-unavailable diagnostics for `raw/.wiki-processing-checkpoint.lock` (PR4+). Every sub-procedure carries an explicit `(forward-looking)` marker so operators cannot copy-paste a not-yet-implemented entrypoint. |
| `docs/ideas/wiki-processing-checkpoint-registry.md` | C-prime 4-PR plan (down from 6), deferred-items monitor table, design-status reconciliation, PR1 cascade checklist fully ticked. |
| `docs/research/wiki-processing-checkpoint-registry-implementation-status.md` (new) | Research validation report (evidence base for what is implemented vs not). |

**Diffstat:** 6 files, ~+508 / -51.

## Process

1. **`/verified-research`** — 4 parallel explore subagents validated `docs/ideas/wiki-processing-checkpoint-registry.md` against the codebase. Produced the research report. Found 2/16 surfaces implemented, 12 not.
2. **`/grill-with-docs`** — 16 decision branches, 58 sub-decisions resolved. Filed 3 unrelated backlog issues (#181, #182, #183).
3. **`/improve-codebase-architecture`** — Simplified the original 6-PR plan to 4 PRs (Path C-prime). Cut a separate render module, the `--force-*` command family, the retention dataclass (replaced with 2 module constants), the pre-commit hook (covered by runtime `--verify`), and a separate bootstrap PR. Each cut has a cheap monitor that piggybacks on existing telemetry (`git log`, `gh run list`, `wiki/log.md`).
4. **Rubber-duck pushback** — Preserved governance ceremony (matrix row, contract entry, lock declaration), dedicated module (rejected inlining), and bootstrap as an explicit mode (rejected auto-bootstrap).
5. **@documentation-engineer review** — Returned 1 P1 (PR number off-by-one in idea-doc) + 4 P2 (F4 confirmation-only, F1/F2/F3/F5 actionable). All remediated in commit `2fa9c6f`.
6. **Second-pass review — @change-patrol + audit-knowledgebase-workspace + shipping-and-launch** — All three independently flagged inconsistent forward-looking markers in the new architecture.md safety-controls bullets and the runbook sub-procedures. Idea-doc PR1 checklist was still showing unticked items now that PR1 lands. All P1/P2 findings remediated in commit `9c47419`.

## Validation

```bash
python3 -m pytest \
  tests/kb/test_adr_readme_status_sync.py \
  tests/kb/test_doc_cascade_completeness.py \
  tests/kb/test_workflow_schedule_docs_sync.py \
  tests/kb/test_docs_ideas_archival.py \
  tests/kb/test_framework_contracts.py \
  -q
# 19 passed, 166 subtests passed

PYTHONPATH=. python3 scripts/hooks/check_adr_cross_ref.py \
  docs/decisions/ADR-026-wiki-processing-checkpoint-registry.md
# ok
```

## Out of scope (deferred to later PRs)

- `schema/wiki-processing-checkpoint-registry-contract.md` → PR2
- `schema/CONTEXT.md` File Roles list addition + `last_updated` bump → PR2
- `scripts/kb/contracts.py` additions (TriggerType, ArtifactType, GovernedArtifactContract entry, lock-path constant, retention constants) → PR2
- `tests/kb/test_contracts.py` GOVERNED_ARTIFACT_IDS/PATHS expected-tuple updates + new `tests/kb/test_checkpoint_contract_alignment.py` → PR2
- `scripts/kb/checkpoint_registry.py` runtime → PR3
- `scripts/kb/CONTEXT.md` `last_updated` bump → PR3
- `AGENTS.md` write-surface matrix row → PR3
- `sync-knowledgebase-state` matrix-row Schema/artifact-owners column extension → PR3
- `docs/ideas/wiki-curation-agent-framework.md` `FRAMEWORK_BOUNDARY_DOCS` literal-string entrypoint list extension — required by `tests/kb/test_framework_contracts.py::test_boundary_docs_list_same_execution_surface` (literal `assertIn`) → PR3
- CI-3 wiring + bootstrap execution → PR4

## Related ADRs

- ADR-026 (amended in this PR): wiki processing checkpoint registry
- ADR-027 (published 2026-06-02): infrastructure validation trigger model for CI-3

## Related issues / known external concerns

- **#185** — `CI-2 diagnostics` is failing on this PR (and on `main`) due to a brand-new pip 26.1.1 vulnerability PYSEC-2026-196. Unrelated to this PR — filed for separate workflow remediation.
- #181 — pytest framework formalization (raised during grill review; unrelated to this PR).
- #182 — `--approval` flag pattern reconsideration (raised during grill review; unrelated to this PR).
- #183 — lock holder-PID tracking (raised during grill review; relevant to PR3 lock-unavailable UX).

## Risk

Low — doc-only PR. No code, no schema, no CI changes, no write-surface changes. Every reference to forward-looking surfaces (`scripts/kb/checkpoint_registry.py`, `raw/.wiki-processing-checkpoint.lock`, `raw/wiki-processing/wiki-processing-checkpoint-registry.json`) is now marked `(forward-looking)`, `(PR3+)`, or `(PR4+)` so operators cannot mistake the docs for live operator surfaces.

## Rollback

Revert this doc-only PR. No data, schema, contracts, or workflow state is changed; revert leaves the codebase in the pre-PR1 state. Downstream runtime rollback follows ADR-026 `## Rollback`.
