### PR TITLE
ci: pin pip>=26.1.2 in CI-2 to fix PYSEC-2026-196 (fixes #185)

### DIFF
--- a/.github/workflows/ci-2-analyst-diagnostics.yml
+++ b/.github/workflows/ci-2-analyst-diagnostics.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Dependency vulnerability audit (pip-audit)
         run: |
           set -euo pipefail
-          python -m pip install --quiet 'pip>=26.1' pip-audit
+          python -m pip install --quiet 'pip>=26.1.2' pip-audit
           # CVE-2026-3219 affects pip 26.x — no upstream fix version published.
           # TODO(2026-12): re-evaluate once upstream releases a fix for CVE-2026-3219.
           pip-audit --desc on --ignore-vuln CVE-2026-3219


### PR DESCRIPTION
## Summary

Bumps the CI-2 diagnostics workflow's pip pin from `>=26.1` to `>=26.1.2` to remediate PYSEC-2026-196 (pip console_scripts/gui_scripts path-vs-filename vulnerability). This unblocks PR #184 whose only failing required check is CI-2.

## What changed

- `.github/workflows/ci-2-analyst-diagnostics.yml` line 73: `'pip>=26.1'` → `'pip>=26.1.2'`. No other changes.

## Why this approach

Issue #185 documented two remediation options: (1) pin to `>=26.1.2`, (2) add `--ignore-vuln PYSEC-2026-196`. Option 1 is lower-risk because it removes the vulnerable pip from the resolution set rather than suppressing the advisory. The fix is already published upstream.

## Verification

- Local YAML parse passes.
- Existing `--ignore-vuln CVE-2026-3219` flag on line 76 left untouched.
- No cascade required: change does not touch cron, contracts, or any surface in the test cascade tables.

## Acceptance evidence (post-merge)

- `gh run list --workflow=ci-2-analyst-diagnostics.yml --json conclusion -L 5` shows green.
- `pip-audit` step exits 0.

Fixes #185
Unblocks #184
