### PR TITLE
feat(locality): Mechanism A override block + trailer template + CONTEXT.md terms (slice 2, closes #192)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,28 +6,37 @@
 
 ## ⚠️ Slash-Command Override: /chronicle improve → audit-knowledgebase-workspace skill
 
-When the user runs `/chronicle improve` (Copilot CLI built-in), do not
-execute Steps 2-3 of the built-in prompt. Instead, invoke the
-`audit-knowledgebase-workspace` skill and follow its `improve` flow
-exclusively. That skill owns: session-store mining, locality-ladder
-classification (Locality 0..4), deletion-pairing for every Locality 4
-addition across BOTH `.github/copilot-instructions.md` AND `AGENTS.md`,
-and writes to the chosen locality — not necessarily either always-on
-file.
+When the user runs `/chronicle improve` (Copilot CLI built-in), prefer the
+`audit-knowledgebase-workspace` skill's `improve` flow over Steps 2-3 of the
+built-in prompt **when that flow is available in the current checkout**. The
+skill owns: session-store mining, locality-ladder classification (Locality
+0..4), deletion-pairing for every Locality 4 addition across BOTH
+`.github/copilot-instructions.md` AND `AGENTS.md`, and writes to the chosen
+locality — not necessarily either always-on file.
 
-ADR-028 (pending) owns the `Locality-4-Justification:` trailer escape
-and trailer soft budget for Locality 4 additions.
+ADR-028 (pending — tracked at issue #190) will normatively own the
+`Locality-4-Justification:` trailer escape and trailer soft budget for
+Locality 4 additions. Until ADR-028 lands, apply the rules captured in
+[`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`](.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md)
+and the [`docs/templates/locality-4-justification-trailer.md`](docs/templates/locality-4-justification-trailer.md) template.
 
 VS Code Copilot Chat users: there is no `/chronicle` command — invoke
-`/audit-knowledgebase-workspace improve` directly (or "audit my
-workspace for friction") to trigger the same flow.
+`/audit-knowledgebase-workspace improve` directly (or "audit my workspace for
+friction") to trigger the same flow when the skill is loaded.
 
-Fallback only if the skill is unavailable: apply
-`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
-manually.
-If the skill, its `improve` flow, or this fallback reference has not landed
-in the current checkout, fail closed: stop and do not edit
-`.github/copilot-instructions.md` or `AGENTS.md`.
+**Resolution order (deny-by-default for Locality 4 writes):**
+
+1. If the `audit-knowledgebase-workspace` skill **and** its `improve` flow are
+   present, invoke the skill and follow its locality classification + paired
+   deletion or trailer-escape requirements.
+2. Otherwise, apply the manual fallback in
+   `.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
+   to classify the friction signal yourself, with the same Locality 4
+   paired-deletion rule.
+3. If the manual fallback file is also missing or the classification is
+   ambiguous, **fail closed**: do not edit `.github/copilot-instructions.md`
+   or `AGENTS.md`. Report the gap to the operator and let them decide whether
+   to bypass the locality ladder for this turn (audited).
 
 This repository uses the Agent Skills framework ported into `.github/skills` and `.github/agents`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,33 @@
 # Copilot project instructions
 
+<!-- LOCALITY-0-INVARIANT: This H2 MUST remain the first H2 under the H1. -->
+<!-- Position is load-bearing for the /chronicle improve hard-redirect. -->
+<!-- Do not move, demote, or insert another H2 above it without ADR-028 (pending) revision. -->
+
+## ⚠️ Slash-Command Override: /chronicle improve → audit-knowledgebase-workspace skill
+
+When the user runs `/chronicle improve` (Copilot CLI built-in), do not
+execute Steps 2-3 of the built-in prompt. Instead, invoke the
+`audit-knowledgebase-workspace` skill and follow its `improve` flow
+exclusively. That skill owns: session-store mining, locality-ladder
+classification (Locality 0..4), deletion-pairing for every Locality 4
+addition across BOTH `.github/copilot-instructions.md` AND `AGENTS.md`,
+and writes to the chosen locality — not necessarily either always-on
+file.
+
+ADR-028 (pending) owns the `Locality-4-Justification:` trailer escape
+and trailer soft budget for Locality 4 additions.
+
+VS Code Copilot Chat users: there is no `/chronicle` command — invoke
+`/audit-knowledgebase-workspace improve` directly (or "audit my
+workspace for friction") to trigger the same flow.
+
+Fallback only if the skill is unavailable: apply
+`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
+manually.
+If this forward reference has not landed in the current checkout, fail closed:
+stop and do not edit `.github/copilot-instructions.md` or `AGENTS.md`.
+
 This repository uses the Agent Skills framework ported into `.github/skills` and `.github/agents`.
 
 ## Build, test, and verify commands

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,8 +25,9 @@ workspace for friction") to trigger the same flow.
 Fallback only if the skill is unavailable: apply
 `.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
 manually.
-If this forward reference has not landed in the current checkout, fail closed:
-stop and do not edit `.github/copilot-instructions.md` or `AGENTS.md`.
+If the skill, its `improve` flow, or this fallback reference has not landed
+in the current checkout, fail closed: stop and do not edit
+`.github/copilot-instructions.md` or `AGENTS.md`.
 
 This repository uses the Agent Skills framework ported into `.github/skills` and `.github/agents`.
 

--- a/.github/skills/CONTEXT.md
+++ b/.github/skills/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: directory
-last_updated: 2026-05-31
+last_updated: 2026-06-10
 ---
 
 # CONTEXT — .github/skills/
@@ -21,6 +21,10 @@ Vocabulary for the skill and agent persona layer. `AGENTS.md` takes precedence o
 | synthesis combined entrypoint | `.github/skills/synthesize-entity-page/logic/synthesize_combined.py` — CI-3 entrypoint that synthesizes entity + concept pages in one critical section under a single `wiki/.kb_write.lock` acquisition. |
 | `parents[4]` import pattern | The canonical way to import from `scripts.kb` inside skill logic files: `sys.path.insert(0, str(Path(__file__).resolve().parents[4]))`. Resolves 4 levels up from `logic/<file>.py` to the repo root. |
 | skill-first execution | When a task matches a skill, invoke and follow that skill workflow. Do not quick-implement around an applicable skill. |
+| instruction ratchet | The pattern where always-on instruction files such as `.github/copilot-instructions.md` grow monotonically add-only, decoupled from customization-surface growth. Measured by net line change in a window where skill count is flat. |
+| Locality | A trigger-frequency ordinal for instruction destinations (Locality 0–4); frequency increases monotonically. Locality 4 = every turn (always-on); Locality 0 = only when a single file is read. See ADR-028 (pending). |
+| trailer soft budget | The rolling-window cap on `Locality-4-Justification:` git trailers (default 1 per 10 commits to global rules sections) that prevents the escape hatch from normalizing into bypass. ADR-028 (pending) owns the final enforcement details. |
+| customizations lock | The planned file `.github/.customizations.lock` — concurrency guard for approved `--apply` mode writes to `.github/**` introduced by ADR-028 (pending). Sibling to `wiki/.kb_write.lock` and `raw/.rejection-registry.lock`; never held simultaneously with either once implemented. |
 
 ## Invariants
 

--- a/.github/skills/audit-knowledgebase-workspace/SKILL.md
+++ b/.github/skills/audit-knowledgebase-workspace/SKILL.md
@@ -101,5 +101,6 @@ python3 -m pytest tests/kb/test_doc_cascade_completeness.py tests/kb/test_docs_i
 - [`docs/architecture.md`](../../../docs/architecture.md)
 - [`docs/decisions/ADR-007-control-plane-layering-and-packaging.md`](../../../docs/decisions/ADR-007-control-plane-layering-and-packaging.md)
 - [`docs/ideas/wiki-curation-agent-framework.md`](../../../docs/ideas/wiki-curation-agent-framework.md)
+- [`references/locality-ladder.md`](references/locality-ladder.md)
 - [`tests/kb/test_framework_references.py`](../../../tests/kb/test_framework_references.py)
 - [`tests/kb/test_skill_wrappers.py`](../../../tests/kb/test_skill_wrappers.py)

--- a/.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md
+++ b/.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md
@@ -1,0 +1,106 @@
+---
+type: reference
+title: "Locality Ladder — Manual Fallback Cheat Sheet"
+status: active
+updated_at: "2026-06-10"
+owner: ".github/skills/audit-knowledgebase-workspace"
+---
+
+# Locality Ladder — Manual Fallback Cheat Sheet
+
+Concise operator reference invoked from the `## ⚠️ Slash-Command Override` block
+in `.github/copilot-instructions.md` and `AGENTS.md`. Use this only when the
+`audit-knowledgebase-workspace` skill's `improve` flow is unavailable (skill not
+installed, logic not yet implemented, or runtime gated).
+
+The full design rationale lives in `docs/ideas/audit-workspace-improve-flow.md`
+(PR #215) and the future `ADR-028: Instruction Locality Ladder` (pending, issue
+#190). This file is the minimum operator-actionable subset.
+
+## The Locality Ladder (Locality 0 → Locality 4)
+
+Each Locality names **when** the agent pays the context cost. Lower tiers defer
+context delivery (progressive disclosure / JIT). Reading top-to-bottom: per-turn
+cost grows from 0 to full-file body.
+
+| Locality | Trigger | Mechanism | Per-turn cost |
+|---|---|---|---|
+| **0** | File read | Code comment, `# noqa` rationale, docstring | **0** (body cost only when file is read) |
+| **1** | File matches glob | `.github/instructions/<scope>.instructions.md` with required `applyTo:` frontmatter | **~1 metadata row** (file body on `view` when matched) |
+| **2** | User invocation | `.github/skills/<name>/SKILL.md` | **0** (full skill body when invoked) |
+| **3a** | Tool call (inject) | `PreToolUse` hook → returns context | **0** |
+| **3b** | Tool call (block) | `PreToolUse` hook → non-zero exit | **0** |
+| **3c** | After file edited | `PostToolUse` hook on edit + path glob | **0** |
+| **3d** | Pre-commit | `.pre-commit-config.yaml` hook | **0** (block/warn at `git commit`) |
+| **3e** | Prompt submit | `UserPromptSubmit` hook | **0** |
+| **4** | Always-on | `.github/copilot-instructions.md` AND `AGENTS.md` | **Full file body, every turn** |
+
+> Instruction files **without** `applyTo:` frontmatter behave as Locality 4
+> (always loaded). `scripts/hooks/check_instructions_applyto_present.py`
+> enforces the invariant at commit time.
+
+## The 5-step efficiency check
+
+Goal: find the tier that delivers a rule with **minimum expected token waste**
+across its actual trigger pattern. A rule stays at Locality 4 only if all five
+lower tiers produce worse expected token efficiency.
+
+1. **Locality 0** — Can it live as a code comment / docstring / `# noqa`
+   rationale at a single point in the codebase? If yes, **always pick this**
+   (cheapest deterministic tier).
+2. **Locality 1** — Can a plausible `applyTo:` glob be authored? Bar is "no
+   glob *could* be authored," not "no glob exists today." Author a new
+   `.github/instructions/<scope>.instructions.md` file if a glob would scope
+   correctly. Consider per-package globs for friction concentrated in
+   `scripts/kb/**`, `scripts/fleet/**`, `scripts/github_monitor/**`,
+   `scripts/drive_monitor/**`, `scripts/ingest/**`, `scripts/validation/**`,
+   `scripts/reporting/**`, `scripts/maintenance/**`, `scripts/context/**`,
+   `scripts/hooks/**`, `.github/skills/**`, `.github/agents/**`, `wiki/**`,
+   `schema/**`, `docs/decisions/**`, `tests/kb/**`.
+3. **Locality 2** — Is it a discrete multi-step workflow? Could it live as a
+   new skill or as a `references/` checklist under an existing skill?
+4. **Locality 3a–3e** — Can a hook event fire it (PreToolUse, PostToolUse,
+   pre-commit, UserPromptSubmit)?
+5. **Locality 4** — Only after the above are exhausted. Requires a paired
+   deletion candidate **or** a `Locality-4-Justification:` git trailer
+   (see "Paired-deletion rule" below).
+
+## Paired-deletion rule (Locality 4 additions)
+
+Every Locality 4 addition to `.github/copilot-instructions.md` or `AGENTS.md`
+must satisfy one of:
+
+1. **Paired deletion** — accompany the addition with a deletion candidate of
+   roughly equivalent token weight from the same file. The deletion must be a
+   real removal, not a reformatting. Identify and execute in the same commit.
+2. **Trailer escape** — include a `Locality-4-Justification:` git trailer on
+   the commit explaining why no deletion candidate exists. Use the template at
+   `docs/templates/locality-4-justification-trailer.md`. Trailer usage is
+   audited and rate-limited (soft budget: 1 per 10 commits to either file).
+
+The override block in both always-on files codifies this rule. Until ADR-028
+lands, enforcement is by reviewer convention plus the `audit-knowledgebase-
+workspace` skill when available.
+
+## Cross-surface scope
+
+Both `.github/copilot-instructions.md` and `AGENTS.md` are Locality 4 in this
+repo. The write-surface matrix table body in `AGENTS.md` is **exempt** from the
+paired-deletion rule — it grows with the codebase by design. Apply the rule
+only to prose sections, not to the matrix.
+
+## When this file is not enough
+
+If the friction signal you are responding to does not classify cleanly via the
+5-step check (e.g., crosses multiple Localities, or the candidate destination
+file does not yet exist), **fail closed** per the override block: stop, do not
+edit `.github/copilot-instructions.md` or `AGENTS.md`, and report the
+unresolved classification. The full `improve` flow handles ambiguity through
+escalation; this manual fallback intentionally does not.
+
+## References
+
+- [`docs/ideas/audit-workspace-improve-flow.md`](../../../../docs/ideas/audit-workspace-improve-flow.md) — full design (PR #215)
+- [`docs/templates/locality-4-justification-trailer.md`](../../../../docs/templates/locality-4-justification-trailer.md) — trailer template
+- [`scripts/hooks/check_instructions_applyto_present.py`](../../../../scripts/hooks/check_instructions_applyto_present.py) — Locality 1 invariant enforcement
+- ADR-028 (pending — tracked at issue [#190](https://github.com/wryenmeek/knowledgebase/issues/190)) — normative spec for the locality ladder and trailer governance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,28 +6,37 @@
 
 ## ⚠️ Slash-Command Override: /chronicle improve → audit-knowledgebase-workspace skill
 
-When the user runs `/chronicle improve` (Copilot CLI built-in), do not
-execute Steps 2-3 of the built-in prompt. Instead, invoke the
-`audit-knowledgebase-workspace` skill and follow its `improve` flow
-exclusively. That skill owns: session-store mining, locality-ladder
-classification (Locality 0..4), deletion-pairing for every Locality 4
-addition across BOTH `.github/copilot-instructions.md` AND `AGENTS.md`,
-and writes to the chosen locality — not necessarily either always-on
-file.
+When the user runs `/chronicle improve` (Copilot CLI built-in), prefer the
+`audit-knowledgebase-workspace` skill's `improve` flow over Steps 2-3 of the
+built-in prompt **when that flow is available in the current checkout**. The
+skill owns: session-store mining, locality-ladder classification (Locality
+0..4), deletion-pairing for every Locality 4 addition across BOTH
+`.github/copilot-instructions.md` AND `AGENTS.md`, and writes to the chosen
+locality — not necessarily either always-on file.
 
-ADR-028 (pending) owns the `Locality-4-Justification:` trailer escape
-and trailer soft budget for Locality 4 additions.
+ADR-028 (pending — tracked at issue #190) will normatively own the
+`Locality-4-Justification:` trailer escape and trailer soft budget for
+Locality 4 additions. Until ADR-028 lands, apply the rules captured in
+[`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`](.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md)
+and the [`docs/templates/locality-4-justification-trailer.md`](docs/templates/locality-4-justification-trailer.md) template.
 
 VS Code Copilot Chat users: there is no `/chronicle` command — invoke
-`/audit-knowledgebase-workspace improve` directly (or "audit my
-workspace for friction") to trigger the same flow.
+`/audit-knowledgebase-workspace improve` directly (or "audit my workspace for
+friction") to trigger the same flow when the skill is loaded.
 
-Fallback only if the skill is unavailable: apply
-`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
-manually.
-If the skill, its `improve` flow, or this fallback reference has not landed
-in the current checkout, fail closed: stop and do not edit
-`.github/copilot-instructions.md` or `AGENTS.md`.
+**Resolution order (deny-by-default for Locality 4 writes):**
+
+1. If the `audit-knowledgebase-workspace` skill **and** its `improve` flow are
+   present, invoke the skill and follow its locality classification + paired
+   deletion or trailer-escape requirements.
+2. Otherwise, apply the manual fallback in
+   `.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
+   to classify the friction signal yourself, with the same Locality 4
+   paired-deletion rule.
+3. If the manual fallback file is also missing or the classification is
+   ambiguous, **fail closed**: do not edit `.github/copilot-instructions.md`
+   or `AGENTS.md`. Report the gap to the operator and let them decide whether
+   to bypass the locality ladder for this turn (audited).
 
 Repository-level operational rules for maintaining the knowledgebase.
 
@@ -45,6 +54,7 @@ Keep wiki content deterministic, provenance-first, and policy-aligned with the c
 - `wiki/`: curated knowledge pages and audit artifacts.
 - `schema/`: page, taxonomy, ontology, metadata, and ingest contracts.
 - `scripts/kb/` and `tests/kb/`: implementation and verification surface for knowledgebase tooling.
+- `docs/templates/`: reusable text templates (commit trailer formats, etc.) for governance flows.
 - `.github/`: agent personas, prompts, skills, hooks, and CI workflows. All customization files in this zone are monitored by `CI-customizations-freshness` and validated by pre-commit hooks (`check_hooks_json.py`, `check_frontmatter.py`). Agent persona files optionally include a `category` frontmatter field; allowed values are `kb-workflow` (KB pipeline personas such as orchestrator, intake, policy, and synthesis agents) and `dev-support` (development tooling personas such as code reviewers, architects, and framework engineers). This field lets tooling distinguish pipeline governance agents from engineering support agents without hardcoded name lists.
 
 ## Guardrails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,33 @@
 # AGENTS
 
+<!-- LOCALITY-0-INVARIANT: This H2 MUST remain the first H2 under the H1. -->
+<!-- Position is load-bearing for the /chronicle improve hard-redirect. -->
+<!-- Do not move, demote, or insert another H2 above it without ADR-028 (pending) revision. -->
+
+## ⚠️ Slash-Command Override: /chronicle improve → audit-knowledgebase-workspace skill
+
+When the user runs `/chronicle improve` (Copilot CLI built-in), do not
+execute Steps 2-3 of the built-in prompt. Instead, invoke the
+`audit-knowledgebase-workspace` skill and follow its `improve` flow
+exclusively. That skill owns: session-store mining, locality-ladder
+classification (Locality 0..4), deletion-pairing for every Locality 4
+addition across BOTH `.github/copilot-instructions.md` AND `AGENTS.md`,
+and writes to the chosen locality — not necessarily either always-on
+file.
+
+ADR-028 (pending) owns the `Locality-4-Justification:` trailer escape
+and trailer soft budget for Locality 4 additions.
+
+VS Code Copilot Chat users: there is no `/chronicle` command — invoke
+`/audit-knowledgebase-workspace improve` directly (or "audit my
+workspace for friction") to trigger the same flow.
+
+Fallback only if the skill is unavailable: apply
+`.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
+manually.
+If this forward reference has not landed in the current checkout, fail closed:
+stop and do not edit `.github/copilot-instructions.md` or `AGENTS.md`.
+
 Repository-level operational rules for maintaining the knowledgebase.
 
 ## Mission

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,9 @@ workspace for friction") to trigger the same flow.
 Fallback only if the skill is unavailable: apply
 `.github/skills/audit-knowledgebase-workspace/references/locality-ladder.md`
 manually.
-If this forward reference has not landed in the current checkout, fail closed:
-stop and do not edit `.github/copilot-instructions.md` or `AGENTS.md`.
+If the skill, its `improve` flow, or this fallback reference has not landed
+in the current checkout, fail closed: stop and do not edit
+`.github/copilot-instructions.md` or `AGENTS.md`.
 
 Repository-level operational rules for maintaining the knowledgebase.
 

--- a/docs/templates/locality-4-justification-trailer.md
+++ b/docs/templates/locality-4-justification-trailer.md
@@ -1,3 +1,11 @@
+---
+type: template
+title: "Locality 4 Justification Trailer"
+status: active
+updated_at: "2026-06-10"
+owner: ".github/skills/audit-knowledgebase-workspace"
+---
+
 # Locality 4 Justification Trailer Template
 
 Use this commit trailer only when an instruction must remain Locality 4

--- a/docs/templates/locality-4-justification-trailer.md
+++ b/docs/templates/locality-4-justification-trailer.md
@@ -1,0 +1,21 @@
+# Locality 4 Justification Trailer Template
+
+Use this commit trailer only when an instruction must remain Locality 4
+(always-on) and no paired deletion candidate exists.
+
+## Format
+
+```text
+Locality-4-Justification: <one-line reason explaining why this rule must be Locality 4>
+```
+
+The reason must fit on one line and explain why a lower-locality destination
+cannot carry the rule. Trailer use counts against the soft budget defined by
+ADR-028 (pending): by default, one trailer per ten commits touching global
+rules sections, until a paired deletion lands.
+
+## Example
+
+```text
+Locality-4-Justification: keep this rule always-on because it prevents unsafe cross-worktree edits before any skill can load
+```

--- a/tests/kb/test_locality_override_presence.py
+++ b/tests/kb/test_locality_override_presence.py
@@ -11,6 +11,9 @@ OVERRIDE_HEADING = (
 LOCALITY_INVARIANT_BLOCK = """<!-- LOCALITY-0-INVARIANT: This H2 MUST remain the first H2 under the H1. -->
 <!-- Position is load-bearing for the /chronicle improve hard-redirect. -->
 <!-- Do not move, demote, or insert another H2 above it without ADR-028 (pending) revision. -->"""
+OVERRIDE_BLOCK_END = (
+    "bypass the locality ladder for this turn (audited)."
+)
 TRAILER_TEMPLATE = (
     "Locality-4-Justification: <one-line reason explaining why this rule must be "
     "Locality 4>"
@@ -20,6 +23,13 @@ CONTEXT_TERMS = (
     "Locality",
     "trailer soft budget",
     "customizations lock",
+)
+FALLBACK_REF_PATH = (
+    ".github/skills/audit-knowledgebase-workspace/references/locality-ladder.md"
+)
+OVERRIDE_TWIN_FILES = (
+    ".github/copilot-instructions.md",
+    "AGENTS.md",
 )
 
 
@@ -34,6 +44,14 @@ def _first_h2_after_h1(text: str) -> str:
     raise AssertionError("No H2 heading found after H1")
 
 
+def _extract_override_block(text: str) -> str:
+    """Extract the override block as the substring from the invariant comment
+    block through the documented OVERRIDE_BLOCK_END marker, inclusive."""
+    start_idx = text.index(LOCALITY_INVARIANT_BLOCK)
+    end_idx = text.index(OVERRIDE_BLOCK_END, start_idx) + len(OVERRIDE_BLOCK_END)
+    return text[start_idx:end_idx]
+
+
 class TestLocalityOverridePresence(unittest.TestCase):
     def assert_override_block_first_h2(self, relative_path: str) -> None:
         text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
@@ -41,12 +59,8 @@ class TestLocalityOverridePresence(unittest.TestCase):
         self.assertIn(f"{LOCALITY_INVARIANT_BLOCK}\n\n{OVERRIDE_HEADING}", text)
         self.assertEqual(OVERRIDE_HEADING, _first_h2_after_h1(text))
 
-        block = text[
-            text.index(LOCALITY_INVARIANT_BLOCK) : text.index(OVERRIDE_HEADING)
-            + len(OVERRIDE_HEADING)
-            + 1200
-        ]
-        self.assertIn("ADR-028 (pending)", block)
+        block = _extract_override_block(text)
+        self.assertIn("ADR-028 (pending", block)
         self.assertIn("Locality-4-Justification:", block)
         self.assertIn("fail closed", block)
 
@@ -71,3 +85,50 @@ class TestLocalityOverridePresence(unittest.TestCase):
         for term in CONTEXT_TERMS:
             with self.subTest(term=term):
                 self.assertIn(f"| {term} |", text)
+
+    def test_fallback_reference_path_present_in_both_files(self) -> None:
+        """Override block must cite the manual fallback reference path verbatim."""
+        for rel in OVERRIDE_TWIN_FILES:
+            with self.subTest(file=rel):
+                text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+                self.assertIn(FALLBACK_REF_PATH, text)
+
+    def test_fallback_reference_file_exists_with_required_sections(self) -> None:
+        """Manual fallback reference must be present and operator-actionable."""
+        fallback = REPO_ROOT / FALLBACK_REF_PATH
+        self.assertTrue(
+            fallback.is_file(),
+            f"Override block cites {FALLBACK_REF_PATH} which must exist on disk",
+        )
+        text = fallback.read_text(encoding="utf-8")
+        for required in (
+            "# Locality Ladder",
+            "Locality 0",
+            "Locality 4",
+            "Paired-deletion",
+            "Locality-4-Justification:",
+            "audit-knowledgebase-workspace",
+        ):
+            with self.subTest(section=required):
+                self.assertIn(required, text)
+
+    def test_override_block_is_byte_identical_across_both_files(self) -> None:
+        """Both override blocks must stay byte-identical to prevent silent drift.
+
+        The block spans from LOCALITY_INVARIANT_BLOCK through OVERRIDE_BLOCK_END.
+        Trailing prose between the block end and the next H2 is file-specific
+        (each always-on file has its own H1 intro) and is intentionally outside
+        the symmetry contract.
+        """
+        copilot_block = _extract_override_block(
+            (REPO_ROOT / ".github/copilot-instructions.md").read_text(encoding="utf-8")
+        )
+        agents_block = _extract_override_block(
+            (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            copilot_block,
+            agents_block,
+            "Override block in .github/copilot-instructions.md and AGENTS.md "
+            "must stay byte-identical. If you intended to update one, update both.",
+        )

--- a/tests/kb/test_locality_override_presence.py
+++ b/tests/kb/test_locality_override_presence.py
@@ -68,7 +68,6 @@ class TestLocalityOverridePresence(unittest.TestCase):
 
     def test_context_terms_present(self) -> None:
         text = (REPO_ROOT / ".github/skills/CONTEXT.md").read_text(encoding="utf-8")
-        self.assertIn("last_updated: 2026-06-10", text)
         for term in CONTEXT_TERMS:
             with self.subTest(term=term):
                 self.assertIn(f"| {term} |", text)

--- a/tests/kb/test_locality_override_presence.py
+++ b/tests/kb/test_locality_override_presence.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+OVERRIDE_HEADING = (
+    "## ⚠️ Slash-Command Override: /chronicle improve → "
+    "audit-knowledgebase-workspace skill"
+)
+LOCALITY_INVARIANT_BLOCK = """<!-- LOCALITY-0-INVARIANT: This H2 MUST remain the first H2 under the H1. -->
+<!-- Position is load-bearing for the /chronicle improve hard-redirect. -->
+<!-- Do not move, demote, or insert another H2 above it without ADR-028 (pending) revision. -->"""
+TRAILER_TEMPLATE = (
+    "Locality-4-Justification: <one-line reason explaining why this rule must be "
+    "Locality 4>"
+)
+CONTEXT_TERMS = (
+    "instruction ratchet",
+    "Locality",
+    "trailer soft budget",
+    "customizations lock",
+)
+
+
+def _first_h2_after_h1(text: str) -> str:
+    seen_h1 = False
+    for line in text.splitlines():
+        if not seen_h1 and line.startswith("# "):
+            seen_h1 = True
+            continue
+        if seen_h1 and line.startswith("## "):
+            return line
+    raise AssertionError("No H2 heading found after H1")
+
+
+class TestLocalityOverridePresence(unittest.TestCase):
+    def assert_override_block_first_h2(self, relative_path: str) -> None:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        self.assertIn(LOCALITY_INVARIANT_BLOCK, text)
+        self.assertIn(f"{LOCALITY_INVARIANT_BLOCK}\n\n{OVERRIDE_HEADING}", text)
+        self.assertEqual(OVERRIDE_HEADING, _first_h2_after_h1(text))
+
+        block = text[
+            text.index(LOCALITY_INVARIANT_BLOCK) : text.index(OVERRIDE_HEADING)
+            + len(OVERRIDE_HEADING)
+            + 1200
+        ]
+        self.assertIn("ADR-028 (pending)", block)
+        self.assertIn("Locality-4-Justification:", block)
+        self.assertIn("fail closed", block)
+
+    def test_copilot_instructions_override_block_is_first_h2(self) -> None:
+        self.assert_override_block_first_h2(".github/copilot-instructions.md")
+
+    def test_agents_override_block_is_first_h2(self) -> None:
+        self.assert_override_block_first_h2("AGENTS.md")
+
+    def test_locality_4_justification_trailer_template_documented(self) -> None:
+        text = (REPO_ROOT / "docs/templates/locality-4-justification-trailer.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("# Locality 4 Justification Trailer Template", text)
+        self.assertIn(TRAILER_TEMPLATE, text)
+        self.assertIn("Locality-4-Justification: keep this rule always-on", text)
+        self.assertIn("ADR-028 (pending)", text)
+        self.assertIn("soft budget", text)
+
+    def test_context_terms_present(self) -> None:
+        text = (REPO_ROOT / ".github/skills/CONTEXT.md").read_text(encoding="utf-8")
+        self.assertIn("last_updated: 2026-06-10", text)
+        for term in CONTEXT_TERMS:
+            with self.subTest(term=term):
+                self.assertIn(f"| {term} |", text)


### PR DESCRIPTION
## Summary

- Adds the Mechanism A `/chronicle improve` override block as the first H2 under the H1 in both `.github/copilot-instructions.md` and `AGENTS.md`.
- Documents the `Locality-4-Justification:` trailer template in `docs/templates/locality-4-justification-trailer.md`.
- Adds the four `.github/skills/CONTEXT.md` terms: `instruction ratchet`, `Locality`, `trailer soft budget`, and `customizations lock`; bumps `last_updated` to `2026-06-10`.
- Adds presence tests for override placement, trailer template format, and CONTEXT.md terms.

## Forward references

- ADR-028 is referenced as `ADR-028 (pending)` per the slice instructions and issue #190 dependency.
- The override block points at the audit skill/locality ladder expected from PR #218 (`feat/issue-197-audit-skill-scaffold`). If that forward reference has not landed in the current checkout, the block now explicitly says to fail closed and not edit `.github/copilot-instructions.md` or `AGENTS.md`.
- The Phase 5 pre-commit hook (`check_override_block_position.py`) is intentionally not included in this PR; the inline `LOCALITY-0-INVARIANT` comment marks the load-bearing placement until that future slice lands.

## Validation

- `python3 -m pytest tests/kb/test_context_md_freshness.py tests/kb/test_locality_override_presence.py tests/kb/test_framework_skills.py -q` — 16 passed, 384 subtests passed.
- `python3 .github/skills/documentation-and-adrs/logic/validate_doc_batch.py --path docs/templates/locality-4-justification-trailer.md` — passed.
- `python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents` — 42 passed.
- `python3 -m pytest tests/kb/test_doc_cascade_completeness.py tests/kb/test_docs_ideas_archival.py -v` — 7 passed, 77 subtests passed.
- Full-suite local check: `python3 -m pytest tests/ -x 2>&1 | tail -30` reached 1249 passed, then failed in `tests/kb/test_skill_wrappers.py` because this required isolated worktree is named `issue-192` while the existing wrapper test expects repo name `knowledgebase`. The failure is path-sensitive to the required worktree location and unrelated to this change.

## AI generation note

Implemented with GitHub Copilot CLI in the required isolated worktree. Cross-functional review agents checked code/tests/security/docs; P0-P2 findings were remediated before pushing.

Closes #192
