### PR TITLE
docs: refresh post-PR213 forward-looking disclaimers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -292,10 +292,15 @@ require documented rationale.
 
 ## Wiki processing checkpoint registry
 
-> **Forward-looking.** The PR2 schema contract and PR3 runtime are not
-> yet on disk. The table below identifies which surfaces exist today and
-> which are deferred to PR2/PR3. Operators reading this section should
-> treat any present-tense description as the post-PR3 target state.
+> **Runtime forward-looking; schema landed.** The PR2 schema contract,
+> `scripts/kb/contracts.py` constants (lock path, trigger and artifact
+> enums, dependency-fingerprint dict, retention thresholds), and the
+> `analysis_fingerprint()` helper landed in PR #213. The PR3 runtime
+> (`scripts/kb/checkpoint_registry.py`) and PR4 CI-3 wiring are not yet
+> on disk. The table below identifies which surfaces exist today and
+> which are deferred to PR3/PR4. Operators reading this section should
+> treat any present-tense description of the runtime entrypoint as the
+> post-PR3 target state.
 
 The wiki processing pipeline *will* maintain a governed checkpoint registry
 under `raw/` so partial fail-closed runs can resume and changed outputs can

--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -288,8 +288,11 @@ approved, keep these existing MVP suites green:
 - Broad regression suite:
   `python3 -m pytest tests/ -q`
 
-## Wiki processing checkpoint registry (forward-looking)
+## Wiki processing checkpoint registry (runtime forward-looking; schema landed)
 
+Schema contract, `scripts/kb/contracts.py` constants, and the
+`analysis_fingerprint()` helper are on disk as of PR2 (PR #213,
+2026-06-11).
 The wiki processing checkpoint registry (ADR-026, ADR-027) lands across
 four PRs per the Path C-prime plan in
 [`docs/ideas/wiki-processing-checkpoint-registry.md`](ideas/wiki-processing-checkpoint-registry.md).


### PR DESCRIPTION
## Summary

Address the **1 P1 + 1 P2** findings from the `@documentation-engineer` cascade audit run after PR #213 (checkpoint-registry schema contract) merged at commit `3a964a2`. Pure docs change — 2 files, +13/-5.

## Findings remediated

| Severity | File | Fix |
|---|---|---|
| P1 | `docs/architecture.md` L295-298 | Forward-looking disclaimer said "PR2 schema contract and PR3 runtime are not yet on disk" — false post-merge for the schema half. Rescoped to runtime only; cited PR #213; enumerated what landed (schema, contracts.py constants, `analysis_fingerprint()`). |
| P2 | `docs/mvp-runbook.md` L291 | Section heading `## Wiki processing checkpoint registry (forward-looking)` over-broad. Renamed to `(runtime forward-looking; schema landed)` and added a one-line lede confirming PR #213. |

## Boundary discipline

- No claim that the PR3 runtime, registry JSON file, AGENTS.md write-surface row, or CI-3 wiring exist — those remain correctly forward-looking.
- `FORWARD_REFERENCED_PATHS` in `tests/kb/test_framework_references.py` still exempts `scripts/kb/checkpoint_registry.py` (PR3 entry) — verified.
- Tracked follow-ups: PR3 (#187), PR4 (#188).

## Verification

```sh
python3 -m pytest tests/kb/test_framework_references.py tests/kb/test_doc_cascade_completeness.py tests/kb/test_context_md_freshness.py
# → 11 passed, 654 subtests passed
```

## Deferred (P3, not in this PR)

The cascade audit surfaced 4 P3 items (ADR-026 amendment heading inconsistency, self-referential "this PR2 schema" phrase, `5 MB` cell formatting, and a no-action note). Routed to PR3 (#187) for opportunistic addressal during runtime authoring; none are blocking.

Closes (none — no issue tracker for forward-looking disclaimer cleanup; this is a same-day fix surfaced by the post-merge docs-cascade audit).
