### PR TITLE
docs(mvp-runbook): document init --fresh customizations lock cleanup (#216)

### DIFF
--- a/docs/mvp-runbook.md
+++ b/docs/mvp-runbook.md
@@ -58,7 +58,7 @@ What `--fresh` does:
 - Verifies `REPO_ROOT` sentinel files (`pyproject.toml`, `.git`, `AGENTS.md`, `schema/`) are present
 - Checks that `wiki/.kb_write.lock` is not held (blocks if it is)
 - Wipes 10 content directories: `wiki/analyses/`, `wiki/concepts/`, `wiki/entities/`, `wiki/sources/`, `raw/inbox/`, `raw/processed/`, `raw/assets/`, `raw/rejected/`, `raw/github-sources/`, `raw/drive-sources/`
-- Removes stale lock files under `raw/` (but never touches `wiki/.kb_write.lock`)
+- Removes stale sibling lock files under `raw/` and `.github/`, including `.github/.customizations.lock` from #191's pending ADR-028 context (but never removes `wiki/.kb_write.lock`, which is checked-and-blocks above)
 - Regenerates `raw/processed/SPEC.md` skeleton, a sample inbox source, and stub wiki artifacts
 - Runs `pip install -e ".[dev]"` and `pytest tests/` to verify the clean state
 


### PR DESCRIPTION
Implements #216 — documents the init --fresh customizations-lock cleanup behavior added in #191.

## Acceptance status

- [x] Runbook init/fresh-init section mentions sibling lock cleanup under raw/ and .github/
- [x] wiki/.kb_write.lock distinction preserved (checked-and-blocks, not removed)
- [x] References issue #191 as originating change
- [x] ADR-028 referenced only as pending/forward-looking — no normative claims about an unauthored ADR

## Cross-functional review

Parent fleet runner will dispatch reviewers after merge.

Closes #216.