### PR TITLE
feat(audit-workspace): 10-bin classifier finding schema (slice 8b, #203)

### DIFF
--- a/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
+++ b/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "repo://wryenmeek/knowledgebase/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json",
+  "title": "Audit workspace improve classifier finding",
+  "description": "JSON Schema for a single audit-knowledgebase-workspace improve dry-run classifier finding. Implements the ADR-028 instruction-locality ladder contract tracked by issue #190 and slice 8b issue #203. The destination enum is the 10-bin output contract: Delete, Locality 0, Locality 1, Locality 2, Locality 3a, Locality 3b, Locality 3c, Locality 3d, Locality 3e, and Locality 4. compliance_risk is required on every finding: deterministic applies to Locality 0 and mechanically enforced Locality 3a/3b/3c/3d destinations; agent-dependent applies to Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A. Delete findings may use the risk class appropriate to their proof path. The schema intentionally documents but does not enforce the destination-to-compliance_risk mapping; classifier logic owns that cross-field validation. expected_token_efficiency_rank is the integer rank derived from ADR-028's token-efficiency rule: estimated trigger frequency multiplied by per-fire cost, with lower ranks being cheaper. cache_strategy identifies the skill-corpus indexing strategy that generated the finding; mtime_first_para is the slice 8a baseline and hybrid_signature is the documented upgrade path, so the field remains an open string with non-empty content rather than an enum.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "source_file",
+    "source_section",
+    "destination",
+    "rationale",
+    "compliance_risk",
+    "expected_token_efficiency_rank",
+    "cache_strategy",
+    "suggested_artifact_path"
+  ],
+  "properties": {
+    "source_file": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!.*[\\s\\x00-\\x1F\\x7F])(?!/)(?![A-Za-z]:)(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\\.\\.?($|/))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$",
+      "description": "Repo-relative source file that produced the friction signal, for Phase 7 set-equivalence checks."
+    },
+    "source_section": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Heading, subsection, or signal identifier within source_file."
+    },
+    "destination": {
+      "type": "string",
+      "enum": [
+        "Delete",
+        "Locality 0",
+        "Locality 1",
+        "Locality 2",
+        "Locality 3a",
+        "Locality 3b",
+        "Locality 3c",
+        "Locality 3d",
+        "Locality 3e",
+        "Locality 4"
+      ],
+      "description": "One of the 10 approved destination bins for slice 8b. OutOfBand is intentionally excluded from this finding schema."
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Evidence-backed explanation for the proposed destination."
+    },
+    "compliance_risk": {
+      "type": "string",
+      "enum": [
+        "deterministic",
+        "agent-dependent"
+      ],
+      "description": "Risk class surfaced for reviewer judgment. ADR-028 maps Locality 0 and Locality 3a/3b/3c/3d to deterministic; Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A to agent-dependent. This schema does not enforce that cross-field mapping."
+    },
+    "expected_token_efficiency_rank": {
+      "type": "integer",
+      "description": "Relative integer rank of estimated trigger frequency multiplied by per-fire cost across candidate destinations; lower ranks are cheaper."
+    },
+    "cache_strategy": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Skill-corpus cache strategy that generated the finding. Known values include mtime_first_para and the documented future hybrid_signature upgrade path; future strategies remain schema-compatible."
+    },
+    "suggested_artifact_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!.*[\\s\\x00-\\x1F\\x7F])(?!/)(?![A-Za-z]:)(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\\.\\.?($|/))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$",
+      "description": "Repo-relative target artifact path for the proposed destination. Absolute paths, URI schemes, parent-directory segments, empty path segments, whitespace, shell metacharacters, and control characters are rejected."
+    },
+    "deletion_candidate": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optional path plus snippet for Delete findings or Locality 4 paired-deletion candidates."
+    },
+    "citation": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optional artifact path plus snippet citation for redundancy claims."
+    }
+  }
+}

--- a/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
+++ b/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
@@ -2,13 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "repo://wryenmeek/knowledgebase/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json",
   "title": "Audit workspace improve classifier finding",
-  "description": "JSON Schema for a single audit-knowledgebase-workspace improve dry-run classifier finding. Implements the ADR-028 instruction-locality ladder contract tracked by issue #190 and slice 8b issue #203. The destination enum is the 10-bin output contract: Delete, Locality 0, Locality 1, Locality 2, Locality 3a, Locality 3b, Locality 3c, Locality 3d, Locality 3e, and Locality 4. compliance_risk is required on every finding: deterministic applies to Locality 0 and mechanically enforced Locality 3a/3b/3c/3d destinations; agent-dependent applies to Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A. Delete findings may use the risk class appropriate to their proof path. The schema intentionally documents but does not enforce the destination-to-compliance_risk mapping; classifier logic owns that cross-field validation. expected_token_efficiency_rank is the integer rank derived from ADR-028's token-efficiency rule: estimated trigger frequency multiplied by per-fire cost, with lower ranks being cheaper. cache_strategy identifies the skill-corpus indexing strategy that generated the finding; mtime_first_para is the slice 8a baseline and hybrid_signature is the documented upgrade path, so the field remains an open string with non-empty content rather than an enum.",
+  "description": "JSON Schema for a single audit-knowledgebase-workspace improve dry-run classifier finding. Implements the ADR-028 instruction-locality ladder contract tracked by issue #190 and slice 8b issue #203. The proposed_destination enum is the 10-bin output contract: Delete, Locality 0, Locality 1, Locality 2, Locality 3a, Locality 3b, Locality 3c, Locality 3d, Locality 3e, and Locality 4. compliance_risk is required on every finding: deterministic applies to Locality 0 and mechanically enforced Locality 3a/3b/3c/3d destinations; agent-dependent applies to Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A. Delete findings may use the risk class appropriate to their proof path. The schema intentionally documents but does not enforce the proposed_destination-to-compliance_risk mapping; classifier logic owns that cross-field validation. expected_token_efficiency_rank is the integer rank derived from ADR-028's token-efficiency rule: estimated trigger frequency multiplied by per-fire cost, with lower ranks being cheaper. cache_strategy identifies the skill-corpus indexing strategy that generated the finding and is closed to the Phase 4/Q11 values mtime_first_para and hybrid_signature. suggested_artifact_path remains required because Phase 4 classifier prose includes the suggested artifact path in each finding output.",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "source_file",
     "source_section",
-    "destination",
+    "proposed_destination",
     "rationale",
     "compliance_risk",
     "expected_token_efficiency_rank",
@@ -27,7 +27,7 @@
       "minLength": 1,
       "description": "Heading, subsection, or signal identifier within source_file."
     },
-    "destination": {
+    "proposed_destination": {
       "type": "string",
       "enum": [
         "Delete",
@@ -58,18 +58,22 @@
     },
     "expected_token_efficiency_rank": {
       "type": "integer",
-      "description": "Relative integer rank of estimated trigger frequency multiplied by per-fire cost across candidate destinations; lower ranks are cheaper."
+      "minimum": 0,
+      "description": "Relative non-negative integer rank of estimated trigger frequency multiplied by per-fire cost across candidate destinations; lower ranks are cheaper."
     },
     "cache_strategy": {
       "type": "string",
-      "minLength": 1,
-      "description": "Skill-corpus cache strategy that generated the finding. Known values include mtime_first_para and the documented future hybrid_signature upgrade path; future strategies remain schema-compatible."
+      "enum": [
+        "mtime_first_para",
+        "hybrid_signature"
+      ],
+      "description": "Skill-corpus cache strategy that generated the finding. Closed to mtime_first_para and the documented hybrid_signature upgrade path so typos do not break Phase 7 cache-strategy tallies."
     },
     "suggested_artifact_path": {
       "type": "string",
       "minLength": 1,
       "pattern": "^(?!.*[\\s\\x00-\\x1F\\x7F])(?!/)(?![A-Za-z]:)(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\\.\\.?($|/))[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$",
-      "description": "Repo-relative target artifact path for the proposed destination. Absolute paths, URI schemes, parent-directory segments, empty path segments, whitespace, shell metacharacters, and control characters are rejected."
+      "description": "Repo-relative target artifact path for the proposed destination. Required per Phase 4 classifier prose even though the Phase 3 seven-key enumeration omitted it. Absolute paths, URI schemes, parent-directory segments, empty path segments, whitespace, shell metacharacters, and control characters are rejected."
     },
     "deletion_candidate": {
       "type": [

--- a/tests/kb/test_audit_workspace_finding_schema.py
+++ b/tests/kb/test_audit_workspace_finding_schema.py
@@ -31,19 +31,23 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
         cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
     def test_all_10_destination_bins_validate(self) -> None:
+        """AC #2 (issue #203): all 10 destination bins validate."""
+
         for finding in self._destination_examples():
-            with self.subTest(destination=finding["destination"]):
+            with self.subTest(proposed_destination=finding["proposed_destination"]):
                 self.assert_schema_valid(finding)
 
     def test_two_examples_per_compliance_risk_value_validate(self) -> None:
+        """AC #6 (issue #203): two examples per compliance_risk value validate."""
+
         examples = {
             "deterministic": [
-                self._finding(destination="Locality 0", compliance_risk="deterministic"),
-                self._finding(destination="Locality 3d", compliance_risk="deterministic"),
+                self._finding(proposed_destination="Locality 0", compliance_risk="deterministic"),
+                self._finding(proposed_destination="Locality 3d", compliance_risk="deterministic"),
             ],
             "agent-dependent": [
-                self._finding(destination="Locality 1", compliance_risk="agent-dependent"),
-                self._finding(destination="Locality 4", compliance_risk="agent-dependent"),
+                self._finding(proposed_destination="Locality 1", compliance_risk="agent-dependent"),
+                self._finding(proposed_destination="Locality 4", compliance_risk="agent-dependent"),
             ],
         }
 
@@ -53,41 +57,93 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
                 for finding in findings:
                     self.assert_schema_valid(finding)
 
-    def test_schema_rejects_missing_required_field(self) -> None:
-        finding = self._finding()
-        finding.pop("suggested_artifact_path")
+    def test_required_fields_complete_coverage(self) -> None:
+        """AC #1 (issue #203): every required finding field is enforced."""
 
-        with self.assertRaisesRegex(SchemaValidationError, "missing required property"):
-            self._validate_with_schema(finding, self.schema)
+        for required_field in self.schema["required"]:
+            with self.subTest(required_field=required_field):
+                finding = self._finding()
+                finding.pop(required_field)
+                self.assert_schema_rejects(finding, required_field, "missing required property")
+
+    def test_schema_rejects_unknown_property(self) -> None:
+        """AC #6 (issue #203): invalid findings reject unknown contract fields."""
+
+        finding = self._finding(mystery_field="x")
+
+        self.assert_schema_rejects(finding, "mystery_field", "unexpected properties")
+
+    def test_optional_nullable_fields_accept_string_null_or_absent(self) -> None:
+        """AC #6 (issue #203): optional citation fields accept string, null, or absent."""
+
+        for field_name in ("deletion_candidate", "citation"):
+            with self.subTest(field_name=field_name, value="absent"):
+                self.assert_schema_valid(self._finding())
+            with self.subTest(field_name=field_name, value=None):
+                self.assert_schema_valid(self._finding(**{field_name: None}))
+            with self.subTest(field_name=field_name, value="artifact path + snippet"):
+                self.assert_schema_valid(self._finding(**{field_name: "artifact path + snippet"}))
+            for invalid_value in (42, []):
+                with self.subTest(field_name=field_name, invalid_value=invalid_value):
+                    finding = self._finding(**{field_name: invalid_value})
+                    self.assert_schema_rejects(finding, field_name, "expected type")
 
     def test_schema_rejects_invalid_destination(self) -> None:
-        finding = self._finding(destination="OutOfBand")
+        """AC #2 (issue #203): destination bins are closed to the 10 approved values."""
 
-        with self.assertRaisesRegex(SchemaValidationError, "destination"):
-            self._validate_with_schema(finding, self.schema)
+        finding = self._finding(proposed_destination="OutOfBand")
+
+        self.assert_schema_rejects(finding, "proposed_destination", "not in enum")
 
     def test_schema_rejects_invalid_compliance_risk(self) -> None:
+        """AC #3 (issue #203): compliance_risk is deterministic or agent-dependent."""
+
         finding = self._finding(compliance_risk="maybe-deterministic")
 
-        with self.assertRaisesRegex(SchemaValidationError, "compliance_risk"):
-            self._validate_with_schema(finding, self.schema)
+        self.assert_schema_rejects(finding, "compliance_risk", "not in enum")
 
-    def test_schema_rejects_non_numeric_expected_token_efficiency_rank(self) -> None:
-        invalid_ranks = ("3", 3.5, True)
+    def test_schema_rejects_invalid_expected_token_efficiency_rank(self) -> None:
+        """AC #4 (issue #203): expected_token_efficiency_rank is a non-negative integer."""
 
-        for invalid_rank in invalid_ranks:
+        invalid_cases = (
+            ("3", "expected type"),
+            (3.5, "expected type"),
+            (True, "expected type"),
+            (-1, "minimum"),
+        )
+
+        for invalid_rank, expected_message in invalid_cases:
             with self.subTest(invalid_rank=invalid_rank):
                 finding = self._finding(expected_token_efficiency_rank=invalid_rank)
-                with self.assertRaisesRegex(SchemaValidationError, "expected_token_efficiency_rank"):
-                    self._validate_with_schema(finding, self.schema)
+                self.assert_schema_rejects(
+                    finding,
+                    "expected_token_efficiency_rank",
+                    expected_message,
+                )
 
-    def test_schema_rejects_empty_cache_strategy(self) -> None:
-        finding = self._finding(cache_strategy="")
+    def test_cache_strategy_enum_accepts_documented_values_and_rejects_typo(self) -> None:
+        """AC #5 (issue #203): cache_strategy is the closed Phase 4/Q11 enum."""
 
-        with self.assertRaisesRegex(SchemaValidationError, "cache_strategy"):
-            self._validate_with_schema(finding, self.schema)
+        for valid_strategy in ("mtime_first_para", "hybrid_signature"):
+            with self.subTest(valid_strategy=valid_strategy):
+                self.assert_schema_valid(self._finding(cache_strategy=valid_strategy))
+
+        for invalid_strategy in ("", "mtime_first_paragraph"):
+            with self.subTest(invalid_strategy=invalid_strategy):
+                finding = self._finding(cache_strategy=invalid_strategy)
+                self.assert_schema_rejects(finding, "cache_strategy", "not in enum")
+
+    def test_schema_rejects_min_length_string_fields_when_empty(self) -> None:
+        """AC #1 (issue #203): required text fields reject empty strings."""
+
+        for field_name in ("source_file", "source_section", "rationale", "suggested_artifact_path"):
+            with self.subTest(field_name=field_name):
+                finding = self._finding(**{field_name: ""})
+                self.assert_schema_rejects(finding, field_name, "minLength")
 
     def test_schema_rejects_unsafe_repo_relative_paths(self) -> None:
+        """AC #6 (issue #203): invalid path examples reject unsafe repo paths."""
+
         unsafe_cases = (
             ("source_file", "/etc/passwd"),
             ("source_file", "file:///AGENTS.md"),
@@ -108,18 +164,29 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
         for field_name, unsafe_path in unsafe_cases:
             with self.subTest(field_name=field_name, unsafe_path=unsafe_path):
                 finding = self._finding(**{field_name: unsafe_path})
-                with self.assertRaisesRegex(SchemaValidationError, field_name):
-                    self._validate_with_schema(finding, self.schema)
+                self.assert_schema_rejects(finding, field_name, "pattern")
 
     def assert_schema_valid(self, finding: dict[str, Any]) -> None:
         self._validate_with_schema(deepcopy(finding), self.schema)
+
+    def assert_schema_rejects(
+        self,
+        finding: dict[str, Any],
+        field_name: str,
+        expected_message: str,
+    ) -> None:
+        with self.assertRaises(SchemaValidationError) as context:
+            self._validate_with_schema(finding, self.schema)
+        message = str(context.exception)
+        self.assertIn(field_name, message)
+        self.assertIn(expected_message, message)
 
     @staticmethod
     def _finding(**overrides: Any) -> dict[str, Any]:
         finding = {
             "source_file": "AGENTS.md",
             "source_section": "## Write-surface matrix",
-            "destination": "Locality 3a",
+            "proposed_destination": "Locality 3a",
             "rationale": (
                 "Per ADR-028 hidden-ratchet invariant: matching hook guidance can be "
                 "delivered at the tool boundary."
@@ -136,61 +203,61 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
     def _destination_examples(cls) -> tuple[dict[str, Any], ...]:
         return (
             cls._finding(
-                destination="Delete",
+                proposed_destination="Delete",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=0,
                 suggested_artifact_path="AGENTS.md",
             ),
             cls._finding(
-                destination="Locality 0",
+                proposed_destination="Locality 0",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=1,
                 suggested_artifact_path="scripts/hooks/check_instructions_applyto_present.py",
             ),
             cls._finding(
-                destination="Locality 1",
+                proposed_destination="Locality 1",
                 compliance_risk="agent-dependent",
                 expected_token_efficiency_rank=2,
                 suggested_artifact_path=".github/instructions/scripts.instructions.md",
             ),
             cls._finding(
-                destination="Locality 2",
+                proposed_destination="Locality 2",
                 compliance_risk="agent-dependent",
                 expected_token_efficiency_rank=3,
                 suggested_artifact_path=".github/skills/audit-knowledgebase-workspace/SKILL.md",
             ),
             cls._finding(
-                destination="Locality 3a",
+                proposed_destination="Locality 3a",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=4,
                 suggested_artifact_path=".github/hooks/hooks.json",
             ),
             cls._finding(
-                destination="Locality 3b",
+                proposed_destination="Locality 3b",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=5,
                 suggested_artifact_path=".github/hooks/check_locality_ratchet.py",
             ),
             cls._finding(
-                destination="Locality 3c",
+                proposed_destination="Locality 3c",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=6,
                 suggested_artifact_path=".github/hooks/check_context_md_format.py",
             ),
             cls._finding(
-                destination="Locality 3d",
+                proposed_destination="Locality 3d",
                 compliance_risk="deterministic",
                 expected_token_efficiency_rank=7,
                 suggested_artifact_path=".pre-commit-config.yaml",
             ),
             cls._finding(
-                destination="Locality 3e",
+                proposed_destination="Locality 3e",
                 compliance_risk="agent-dependent",
                 expected_token_efficiency_rank=8,
                 suggested_artifact_path=".github/hooks/hooks.json",
             ),
             cls._finding(
-                destination="Locality 4",
+                proposed_destination="Locality 4",
                 compliance_risk="agent-dependent",
                 expected_token_efficiency_rank=9,
                 suggested_artifact_path=".github/copilot-instructions.md",
@@ -233,6 +300,11 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
             pattern = schema.get("pattern")
             if pattern is not None and re.search(pattern, instance) is None:
                 raise SchemaValidationError(f"{path}: string does not match pattern {pattern!r}")
+
+        if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+            minimum = schema.get("minimum")
+            if minimum is not None and instance < minimum:
+                raise SchemaValidationError(f"{path}: number below minimum {minimum}")
 
     @staticmethod
     def _assert_type(instance: Any, expected_type: str | list[str], path: str) -> None:

--- a/tests/kb/test_audit_workspace_finding_schema.py
+++ b/tests/kb/test_audit_workspace_finding_schema.py
@@ -1,0 +1,257 @@
+"""Tests for the audit-workspace 10-bin classifier finding schema."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = (
+    REPO_ROOT
+    / ".github"
+    / "skills"
+    / "audit-knowledgebase-workspace"
+    / "schema"
+    / "finding.schema.json"
+)
+
+
+class SchemaValidationError(AssertionError):
+    """Raised by the stdlib-only schema validator used in this test module."""
+
+
+class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def test_all_10_destination_bins_validate(self) -> None:
+        for finding in self._destination_examples():
+            with self.subTest(destination=finding["destination"]):
+                self.assert_schema_valid(finding)
+
+    def test_two_examples_per_compliance_risk_value_validate(self) -> None:
+        examples = {
+            "deterministic": [
+                self._finding(destination="Locality 0", compliance_risk="deterministic"),
+                self._finding(destination="Locality 3d", compliance_risk="deterministic"),
+            ],
+            "agent-dependent": [
+                self._finding(destination="Locality 1", compliance_risk="agent-dependent"),
+                self._finding(destination="Locality 4", compliance_risk="agent-dependent"),
+            ],
+        }
+
+        for compliance_risk, findings in examples.items():
+            with self.subTest(compliance_risk=compliance_risk):
+                self.assertEqual(len(findings), 2)
+                for finding in findings:
+                    self.assert_schema_valid(finding)
+
+    def test_schema_rejects_missing_required_field(self) -> None:
+        finding = self._finding()
+        finding.pop("suggested_artifact_path")
+
+        with self.assertRaisesRegex(SchemaValidationError, "missing required property"):
+            self._validate_with_schema(finding, self.schema)
+
+    def test_schema_rejects_invalid_destination(self) -> None:
+        finding = self._finding(destination="OutOfBand")
+
+        with self.assertRaisesRegex(SchemaValidationError, "destination"):
+            self._validate_with_schema(finding, self.schema)
+
+    def test_schema_rejects_invalid_compliance_risk(self) -> None:
+        finding = self._finding(compliance_risk="maybe-deterministic")
+
+        with self.assertRaisesRegex(SchemaValidationError, "compliance_risk"):
+            self._validate_with_schema(finding, self.schema)
+
+    def test_schema_rejects_non_numeric_expected_token_efficiency_rank(self) -> None:
+        invalid_ranks = ("3", 3.5, True)
+
+        for invalid_rank in invalid_ranks:
+            with self.subTest(invalid_rank=invalid_rank):
+                finding = self._finding(expected_token_efficiency_rank=invalid_rank)
+                with self.assertRaisesRegex(SchemaValidationError, "expected_token_efficiency_rank"):
+                    self._validate_with_schema(finding, self.schema)
+
+    def test_schema_rejects_empty_cache_strategy(self) -> None:
+        finding = self._finding(cache_strategy="")
+
+        with self.assertRaisesRegex(SchemaValidationError, "cache_strategy"):
+            self._validate_with_schema(finding, self.schema)
+
+    def test_schema_rejects_unsafe_repo_relative_paths(self) -> None:
+        unsafe_cases = (
+            ("source_file", "/etc/passwd"),
+            ("source_file", "file:///AGENTS.md"),
+            ("suggested_artifact_path", "../../outside"),
+            ("suggested_artifact_path", "docs//double-slash.md"),
+            ("suggested_artifact_path", "docs/run;rm.md"),
+            ("suggested_artifact_path", "docs/has space.md"),
+            ("source_file", "docs/good.md\n"),
+            ("suggested_artifact_path", "docs/good.md\n"),
+            ("suggested_artifact_path", "docs/good.md\t"),
+            ("suggested_artifact_path", r"docs\good.md"),
+            ("suggested_artifact_path", "docs/foo:bar.md"),
+            ("suggested_artifact_path", "docs/foo*.md"),
+            ("suggested_artifact_path", "docs/"),
+            ("suggested_artifact_path", "docs/./file.md"),
+        )
+
+        for field_name, unsafe_path in unsafe_cases:
+            with self.subTest(field_name=field_name, unsafe_path=unsafe_path):
+                finding = self._finding(**{field_name: unsafe_path})
+                with self.assertRaisesRegex(SchemaValidationError, field_name):
+                    self._validate_with_schema(finding, self.schema)
+
+    def assert_schema_valid(self, finding: dict[str, Any]) -> None:
+        self._validate_with_schema(deepcopy(finding), self.schema)
+
+    @staticmethod
+    def _finding(**overrides: Any) -> dict[str, Any]:
+        finding = {
+            "source_file": "AGENTS.md",
+            "source_section": "## Write-surface matrix",
+            "destination": "Locality 3a",
+            "rationale": (
+                "Per ADR-028 hidden-ratchet invariant: matching hook guidance can be "
+                "delivered at the tool boundary."
+            ),
+            "compliance_risk": "deterministic",
+            "expected_token_efficiency_rank": 3,
+            "cache_strategy": "mtime_first_para",
+            "suggested_artifact_path": ".github/hooks/check_locality_ratchet.py",
+        }
+        finding.update(overrides)
+        return finding
+
+    @classmethod
+    def _destination_examples(cls) -> tuple[dict[str, Any], ...]:
+        return (
+            cls._finding(
+                destination="Delete",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=0,
+                suggested_artifact_path="AGENTS.md",
+            ),
+            cls._finding(
+                destination="Locality 0",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=1,
+                suggested_artifact_path="scripts/hooks/check_instructions_applyto_present.py",
+            ),
+            cls._finding(
+                destination="Locality 1",
+                compliance_risk="agent-dependent",
+                expected_token_efficiency_rank=2,
+                suggested_artifact_path=".github/instructions/scripts.instructions.md",
+            ),
+            cls._finding(
+                destination="Locality 2",
+                compliance_risk="agent-dependent",
+                expected_token_efficiency_rank=3,
+                suggested_artifact_path=".github/skills/audit-knowledgebase-workspace/SKILL.md",
+            ),
+            cls._finding(
+                destination="Locality 3a",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=4,
+                suggested_artifact_path=".github/hooks/hooks.json",
+            ),
+            cls._finding(
+                destination="Locality 3b",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=5,
+                suggested_artifact_path=".github/hooks/check_locality_ratchet.py",
+            ),
+            cls._finding(
+                destination="Locality 3c",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=6,
+                suggested_artifact_path=".github/hooks/check_context_md_format.py",
+            ),
+            cls._finding(
+                destination="Locality 3d",
+                compliance_risk="deterministic",
+                expected_token_efficiency_rank=7,
+                suggested_artifact_path=".pre-commit-config.yaml",
+            ),
+            cls._finding(
+                destination="Locality 3e",
+                compliance_risk="agent-dependent",
+                expected_token_efficiency_rank=8,
+                suggested_artifact_path=".github/hooks/hooks.json",
+            ),
+            cls._finding(
+                destination="Locality 4",
+                compliance_risk="agent-dependent",
+                expected_token_efficiency_rank=9,
+                suggested_artifact_path=".github/copilot-instructions.md",
+            ),
+        )
+
+    @classmethod
+    def _validate_with_schema(cls, instance: Any, schema: dict[str, Any], path: str = "$") -> None:
+        expected_type = schema.get("type")
+        if expected_type is not None:
+            cls._assert_type(instance, expected_type, path)
+
+        if "enum" in schema and instance not in schema["enum"]:
+            raise SchemaValidationError(f"{path}: value {instance!r} not in enum")
+
+        if isinstance(instance, dict):
+            required = schema.get("required", [])
+            for property_name in required:
+                if property_name not in instance:
+                    raise SchemaValidationError(f"{path}: missing required property {property_name!r}")
+
+            properties = schema.get("properties", {})
+            if schema.get("additionalProperties") is False:
+                extra = sorted(set(instance) - set(properties))
+                if extra:
+                    raise SchemaValidationError(f"{path}: unexpected properties {extra!r}")
+
+            for property_name, property_schema in properties.items():
+                if property_name in instance:
+                    cls._validate_with_schema(
+                        instance[property_name],
+                        property_schema,
+                        f"{path}.{property_name}",
+                    )
+
+        if isinstance(instance, str):
+            min_length = schema.get("minLength")
+            if min_length is not None and len(instance) < min_length:
+                raise SchemaValidationError(f"{path}: string shorter than minLength {min_length}")
+            pattern = schema.get("pattern")
+            if pattern is not None and re.search(pattern, instance) is None:
+                raise SchemaValidationError(f"{path}: string does not match pattern {pattern!r}")
+
+    @staticmethod
+    def _assert_type(instance: Any, expected_type: str | list[str], path: str) -> None:
+        expected_types = [expected_type] if isinstance(expected_type, str) else expected_type
+        for single_type in expected_types:
+            if single_type == "object" and isinstance(instance, dict):
+                return
+            if single_type == "string" and isinstance(instance, str):
+                return
+            if single_type == "integer" and isinstance(instance, int) and not isinstance(instance, bool):
+                return
+            if single_type == "number" and (
+                isinstance(instance, (int, float)) and not isinstance(instance, bool)
+            ):
+                return
+            if single_type == "null" and instance is None:
+                return
+        raise SchemaValidationError(f"{path}: expected type {expected_types!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #203 — JSON Schema for the 10-bin classifier output (slice 8b).

## Acceptance status

- [x] Schema file at `.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json`
- [x] Validates all 10 destination bins
- [x] `compliance_risk` enum: `deterministic` | `agent-dependent`
- [x] `expected_token_efficiency_rank` required, integer per Phase 4 token-efficiency rule
- [x] `cache_strategy` field present and compatible with slice 8a `mtime_first_para` plus future values
- [x] Test fixtures: 10 destination examples + 4 compliance_risk examples + invalid examples
- [x] Repo-relative path hardening for `source_file` and `suggested_artifact_path`
- [x] pytest passing

## Validation

- `python3 -m pytest tests/kb/test_audit_workspace_finding_schema.py -v` → 8 passed, 29 subtests passed
- `python3 -m pytest tests/kb/test_audit_workspace_cache.py tests/kb/test_context_md_freshness.py tests/kb/test_audit_workspace_finding_schema.py -q` → 21 passed, 38 subtests passed
- CI check-runs on the PR head are success/skipped only as of the latest REST poll.

## Cross-functional review

Dispatched code, test, security, and documentation reviewers. One P2 security finding around unsafe repo-relative path values was remediated; final security re-review reported no blocking findings. Gemini review comments about rank and path edge-case test coverage were addressed in the amended commit and replied to via REST.

Closes #203.