### PR TITLE
refactor(audit-workspace): polish friction queries (#240)

### DIFF
--- a/.github/skills/CONTEXT.md
+++ b/.github/skills/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: directory
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 ---
 
 # CONTEXT — .github/skills/

--- a/.github/skills/audit-knowledgebase-workspace/logic/friction_queries.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/friction_queries.py
@@ -38,7 +38,7 @@ TELEMETRY_GAP_ACKNOWLEDGMENT = (
 DEFAULT_LIMIT = 50
 DEFAULT_DAYS = 7
 RETRY_WINDOW_MINUTES = 15
-_REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_REPO_PATTERN = re.compile(r"^(?!\.+/)(?![^/]+/\.+$)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 FrictionQueryTemplate = dict[str, Any]
 QueryRows = Sequence[Mapping[str, Any]]
@@ -50,48 +50,8 @@ def chronicle_commits_query(*, repo: str, days: int = DEFAULT_DAYS) -> FrictionQ
 
     interval = _interval(days)
     repo_literal = _repo_literal(repo)
-    # Loose temporal coupling: any matching /chronicle improve prompt within the time window before the commit counts; not a tight cause-effect link.
-    primary = f"""
-SELECT
-  sr.session_id,
-  COALESCE(s.repository, '') AS repository,
-  sr.ref_value AS commit_sha,
-  sr.created_at AS commit_recorded_at,
-  MAX(t.timestamp) AS chronicle_prompt_at,
-  'chronicle_commits' AS friction_class
-FROM session_refs sr
-JOIN turns t ON t.session_id = sr.session_id
-JOIN sessions s ON s.id = sr.session_id
-WHERE s.repository = {repo_literal}
-  AND sr.ref_type = 'commit'
-  AND sr.created_at > {interval}
-  AND t.timestamp > {interval}
-  AND t.timestamp <= sr.created_at
-  AND COALESCE(t.user_message, '') ILIKE '%/chronicle improve%'
-GROUP BY sr.session_id, COALESCE(s.repository, ''), sr.ref_value, sr.created_at
-ORDER BY sr.created_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
-    broader = f"""
-SELECT
-  sr.session_id,
-  COALESCE(s.repository, '') AS repository,
-  sr.ref_value AS commit_sha,
-  sr.created_at AS commit_recorded_at,
-  MAX(t.timestamp) AS chronicle_prompt_at,
-  'chronicle_commits' AS friction_class
-FROM session_refs sr
-JOIN turns t ON t.session_id = sr.session_id
-JOIN sessions s ON s.id = sr.session_id
-WHERE sr.ref_type = 'commit'
-  AND sr.created_at > {interval}
-  AND t.timestamp > {interval}
-  AND t.timestamp <= sr.created_at
-  AND COALESCE(t.user_message, '') ILIKE '%/chronicle improve%'
-GROUP BY sr.session_id, COALESCE(s.repository, ''), sr.ref_value, sr.created_at
-ORDER BY sr.created_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
+    primary = _chronicle_commits_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
+    broader = _chronicle_commits_sql(repo_filter=None, interval=interval)
     return _template(
         "chronicle_commits",
         primary=primary,
@@ -114,45 +74,8 @@ def repeated_user_prompts_query(*, repo: str, days: int = DEFAULT_DAYS) -> Frict
 
     interval = _interval(days)
     repo_literal = _repo_literal(repo)
-    primary = f"""
-SELECT
-  t.session_id,
-  COALESCE(s.repository, '') AS repository,
-  md5(COALESCE(t.user_message, '')) AS prompt_fingerprint,
-  length(COALESCE(t.user_message, '')) AS prompt_length,
-  COUNT(*) AS repeat_count,
-  MIN(t.timestamp) AS first_prompt_at,
-  MAX(t.timestamp) AS last_prompt_at,
-  'repeated_user_prompts' AS friction_class
-FROM turns t
-JOIN sessions s ON s.id = t.session_id
-WHERE s.repository = {repo_literal}
-  AND t.timestamp > {interval}
-  AND COALESCE(t.user_message, '') <> ''
-GROUP BY t.session_id, COALESCE(s.repository, ''), COALESCE(t.user_message, '')
-HAVING COUNT(*) > 1
-ORDER BY repeat_count DESC, last_prompt_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
-    broader = f"""
-SELECT
-  t.session_id,
-  COALESCE(s.repository, '') AS repository,
-  md5(COALESCE(t.user_message, '')) AS prompt_fingerprint,
-  length(COALESCE(t.user_message, '')) AS prompt_length,
-  COUNT(*) AS repeat_count,
-  MIN(t.timestamp) AS first_prompt_at,
-  MAX(t.timestamp) AS last_prompt_at,
-  'repeated_user_prompts' AS friction_class
-FROM turns t
-JOIN sessions s ON s.id = t.session_id
-WHERE t.timestamp > {interval}
-  AND COALESCE(t.user_message, '') <> ''
-GROUP BY t.session_id, COALESCE(s.repository, ''), COALESCE(t.user_message, '')
-HAVING COUNT(*) > 1
-ORDER BY repeat_count DESC, last_prompt_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
+    primary = _repeated_user_prompts_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
+    broader = _repeated_user_prompts_sql(repo_filter=None, interval=interval)
     return _template(
         "repeated_user_prompts",
         primary=primary,
@@ -174,52 +97,8 @@ def repeated_context_loads_query(*, repo: str, days: int = DEFAULT_DAYS) -> Fric
 
     interval = _interval(days)
     repo_literal = _repo_literal(repo)
-    skill_expr = _skill_name_expression()
-    primary = f"""
-SELECT
-  e.session_id,
-  COALESCE(s.repository, '') AS repository,
-  {skill_expr} AS skill_name,
-  COUNT(*) AS invocation_count,
-  MIN(e.timestamp) AS first_invoked_at,
-  MAX(e.timestamp) AS last_invoked_at,
-  'repeated_context_loads' AS friction_class
-FROM events e
-JOIN sessions s ON s.id = e.session_id
-JOIN tool_requests tr
-  ON tr.session_id = e.session_id
- AND tr.tool_call_id = e.tool_complete_call_id
-WHERE s.repository = {repo_literal}
-  AND e.type = 'tool.execution_complete'
-  AND e.tool_start_name = 'skill'
-  AND e.timestamp > {interval}
-GROUP BY e.session_id, COALESCE(s.repository, ''), {skill_expr}
-HAVING COUNT(*) > 1
-ORDER BY invocation_count DESC, last_invoked_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
-    broader = f"""
-SELECT
-  e.session_id,
-  COALESCE(s.repository, '') AS repository,
-  {skill_expr} AS skill_name,
-  COUNT(*) AS invocation_count,
-  MIN(e.timestamp) AS first_invoked_at,
-  MAX(e.timestamp) AS last_invoked_at,
-  'repeated_context_loads' AS friction_class
-FROM events e
-JOIN sessions s ON s.id = e.session_id
-JOIN tool_requests tr
-  ON tr.session_id = e.session_id
- AND tr.tool_call_id = e.tool_complete_call_id
-WHERE e.type = 'tool.execution_complete'
-  AND e.tool_start_name = 'skill'
-  AND e.timestamp > {interval}
-GROUP BY e.session_id, COALESCE(s.repository, ''), {skill_expr}
-HAVING COUNT(*) > 1
-ORDER BY invocation_count DESC, last_invoked_at DESC
-LIMIT {DEFAULT_LIMIT}
-"""
+    primary = _repeated_context_loads_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
+    broader = _repeated_context_loads_sql(repo_filter=None, interval=interval)
     return _template(
         "repeated_context_loads",
         primary=primary,
@@ -242,8 +121,8 @@ def hook_bypasses_query(*, repo: str, days: int = DEFAULT_DAYS) -> FrictionQuery
 
     interval = _interval(days)
     repo_literal = _repo_literal(repo)
-    primary = _hook_bypass_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
-    broader = _hook_bypass_sql(repo_filter=None, interval=interval)
+    primary = _hook_bypasses_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
+    broader = _hook_bypasses_sql(repo_filter=None, interval=interval)
     return _template(
         "hook_bypasses",
         primary=primary,
@@ -265,8 +144,8 @@ def retry_loops_query(*, repo: str, days: int = DEFAULT_DAYS) -> FrictionQueryTe
 
     interval = _interval(days)
     repo_literal = _repo_literal(repo)
-    primary = _retry_loop_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
-    broader = _retry_loop_sql(repo_filter=None, interval=interval)
+    primary = _retry_loops_sql(repo_filter=f"s.repository = {repo_literal}", interval=interval)
+    broader = _retry_loops_sql(repo_filter=None, interval=interval)
     return _template(
         "retry_loops",
         primary=primary,
@@ -367,8 +246,84 @@ def _template(
     }
 
 
-def _hook_bypass_sql(*, repo_filter: str | None, interval: str) -> str:
-    repo_clause = f"  AND {repo_filter}\n" if repo_filter is not None else ""
+def _chronicle_commits_sql(*, repo_filter: str | None, interval: str) -> str:
+    repo_clause = _repo_filter_clause(repo_filter)
+    # Loose temporal coupling: any matching /chronicle improve prompt within the
+    # time window before the commit counts; not a tight cause-effect link.
+    return f"""
+SELECT
+  sr.session_id,
+  COALESCE(s.repository, '') AS repository,
+  sr.ref_value AS commit_sha,
+  sr.created_at AS commit_recorded_at,
+  MAX(t.timestamp) AS chronicle_prompt_at,
+  'chronicle_commits' AS friction_class
+FROM session_refs sr
+JOIN turns t ON t.session_id = sr.session_id
+JOIN sessions s ON s.id = sr.session_id
+WHERE sr.ref_type = 'commit'
+  AND sr.created_at > {interval}
+  AND t.timestamp > {interval}
+  AND t.timestamp <= sr.created_at
+  AND COALESCE(t.user_message, '') ILIKE '%/chronicle improve%'
+{repo_clause}GROUP BY sr.session_id, COALESCE(s.repository, ''), sr.ref_value, sr.created_at
+ORDER BY sr.created_at DESC
+LIMIT {DEFAULT_LIMIT}
+"""
+
+
+def _repeated_user_prompts_sql(*, repo_filter: str | None, interval: str) -> str:
+    repo_clause = _repo_filter_clause(repo_filter)
+    return f"""
+SELECT
+  t.session_id,
+  COALESCE(s.repository, '') AS repository,
+  md5(COALESCE(t.user_message, '')) AS prompt_fingerprint,
+  length(COALESCE(t.user_message, '')) AS prompt_length,
+  COUNT(*) AS repeat_count,
+  MIN(t.timestamp) AS first_prompt_at,
+  MAX(t.timestamp) AS last_prompt_at,
+  'repeated_user_prompts' AS friction_class
+FROM turns t
+JOIN sessions s ON s.id = t.session_id
+WHERE t.timestamp > {interval}
+  AND COALESCE(t.user_message, '') <> ''
+{repo_clause}GROUP BY t.session_id, COALESCE(s.repository, ''), COALESCE(t.user_message, '')
+HAVING COUNT(*) > 1
+ORDER BY repeat_count DESC, last_prompt_at DESC
+LIMIT {DEFAULT_LIMIT}
+"""
+
+
+def _repeated_context_loads_sql(*, repo_filter: str | None, interval: str) -> str:
+    repo_clause = _repo_filter_clause(repo_filter)
+    skill_expr = _skill_name_expression()
+    return f"""
+SELECT
+  e.session_id,
+  COALESCE(s.repository, '') AS repository,
+  {skill_expr} AS skill_name,
+  COUNT(*) AS invocation_count,
+  MIN(e.timestamp) AS first_invoked_at,
+  MAX(e.timestamp) AS last_invoked_at,
+  'repeated_context_loads' AS friction_class
+FROM events e
+JOIN sessions s ON s.id = e.session_id
+JOIN tool_requests tr
+  ON tr.session_id = e.session_id
+ AND tr.tool_call_id = e.tool_complete_call_id
+WHERE e.type = 'tool.execution_complete'
+  AND e.tool_start_name = 'skill'
+  AND e.timestamp > {interval}
+{repo_clause}GROUP BY e.session_id, COALESCE(s.repository, ''), {skill_expr}
+HAVING COUNT(*) > 1
+ORDER BY invocation_count DESC, last_invoked_at DESC
+LIMIT {DEFAULT_LIMIT}
+"""
+
+
+def _hook_bypasses_sql(*, repo_filter: str | None, interval: str) -> str:
+    repo_clause = _repo_filter_clause(repo_filter)
     turn_predicate = _hook_bypass_predicate("COALESCE(t.user_message, '')")
     tool_predicate = _hook_bypass_predicate("COALESCE(tr.arguments_json, '')")
     return f"""
@@ -427,8 +382,8 @@ LIMIT {DEFAULT_LIMIT}
 """
 
 
-def _retry_loop_sql(*, repo_filter: str | None, interval: str) -> str:
-    repo_clause = f"  AND {repo_filter}\n" if repo_filter is not None else ""
+def _retry_loops_sql(*, repo_filter: str | None, interval: str) -> str:
+    repo_clause = _repo_filter_clause(repo_filter)
     return f"""
 WITH failed_tools AS (
   SELECT
@@ -487,6 +442,10 @@ LIMIT {DEFAULT_LIMIT}
 """
 
 
+def _repo_filter_clause(repo_filter: str | None) -> str:
+    return f"  AND {repo_filter}\n" if repo_filter is not None else ""
+
+
 def _required_sql(template: Mapping[str, Any], key: str) -> str:
     value = template.get(key)
     if not isinstance(value, str) or not value.strip():
@@ -495,6 +454,13 @@ def _required_sql(template: Mapping[str, Any], key: str) -> str:
 
 
 def _normalize_sql(sql: str) -> str:
+    """Normalize generated SQL without hiding its executable first token.
+
+    session_store_sql accepts a single read-only statement. Keep templates free
+    of leading comments/newlines so the normalized string visibly begins with
+    SELECT or WITH for safety tests and operator inspection.
+    """
+
     return "\n".join(line.rstrip() for line in sql.strip().splitlines())
 
 

--- a/.github/skills/audit-knowledgebase-workspace/tests/test_friction_queries.py
+++ b/.github/skills/audit-knowledgebase-workspace/tests/test_friction_queries.py
@@ -1,0 +1,8 @@
+"""Skill-local entrypoint for the canonical friction-query test suite."""
+
+from tests.kb.test_audit_workspace_friction_queries import (
+    AuditWorkspaceFrictionQueryTests as TestAuditWorkspaceFrictionQueryTests,
+)
+
+
+__all__ = ["TestAuditWorkspaceFrictionQueryTests"]

--- a/tests/kb/test_audit_workspace_friction_queries.py
+++ b/tests/kb/test_audit_workspace_friction_queries.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
+import inspect
 import json
 from pathlib import Path
 import re
@@ -120,6 +122,42 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertIn("tool_complete_success = false", templates["retry_loops"]["primary"])
         self.assertIn("INTERVAL '15 minutes'", templates["retry_loops"]["primary"])
 
+    def test_sql_factories_use_uniform_private_helper_shape(self) -> None:
+        module = self._module()
+
+        for helper_name in (
+            "_chronicle_commits_sql",
+            "_repeated_user_prompts_sql",
+            "_repeated_context_loads_sql",
+            "_hook_bypasses_sql",
+            "_retry_loops_sql",
+        ):
+            with self.subTest(helper_name=helper_name):
+                signature = inspect.signature(getattr(module, helper_name))
+                self.assertEqual(tuple(signature.parameters), ("repo_filter", "interval"))
+                for parameter in signature.parameters.values():
+                    self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+
+    def test_sql_templates_parse_under_duckdb_session_store_dialect(self) -> None:
+        if importlib.util.find_spec("duckdb") is None:
+            self.skipTest(
+                "duckdb package unavailable; SQLite fixture covers semantics, "
+                "this smoke test only checks session_store_sql dialect compatibility"
+            )
+
+        import duckdb  # type: ignore[import-not-found]
+
+        module = self._module()
+        db = duckdb.connect(database=":memory:")
+        try:
+            self._create_duckdb_session_store_schema(db)
+            for friction_class, template in self._templates(module).items():
+                for pass_name in ("primary", "broader"):
+                    with self.subTest(friction_class=friction_class, pass_name=pass_name):
+                        db.execute(template[pass_name]).fetchall()
+        finally:
+            db.close()
+
     def test_primary_query_rows_are_returned_for_each_friction_class(self) -> None:
         module = self._module()
         templates = self._templates(module)
@@ -128,7 +166,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
             "repeated_user_prompts": 1,
             "repeated_context_loads": 1,
             "hook_bypasses": 1,
-            "retry_loops": 1,
+            "retry_loops": 2,
         }
 
         for friction_class, template in templates.items():
@@ -159,7 +197,9 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
                         "2026-06-12 09:10:00",
                     )
                 if friction_class == "retry_loops":
-                    self.assertEqual(result["rows"][0]["retry_count"], 1)
+                    rows_by_tool = {row["tool_name"]: row for row in result["rows"]}
+                    self.assertEqual(rows_by_tool["bash"]["retry_count"], 1)
+                    self.assertEqual(rows_by_tool["view"]["retry_count"], 1)
 
     def test_broader_query_runs_when_primary_returns_zero_rows(self) -> None:
         module = self._module()
@@ -169,7 +209,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
             "repeated_user_prompts": 1,
             "repeated_context_loads": 1,
             "hook_bypasses": 1,
-            "retry_loops": 1,
+            "retry_loops": 2,
         }
 
         for friction_class, template in templates.items():
@@ -239,8 +279,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(result["row_count"], 1)
-        row = result["rows"][0]
+        row = next(row for row in result["rows"] if row["tool_name"] == "bash")
         self.assertEqual(row["retry_count"], 1)
         self.assertNotIn("arguments_json", row)
         self.assertEqual(row["request_length"], len('{"command": "python3 -m pytest tests/kb/test_x.py"}'))
@@ -248,6 +287,26 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
             row["request_fingerprint"],
             hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}').hexdigest(),
         )
+
+    def test_retry_loop_window_includes_exact_boundary_and_excludes_after_boundary(self) -> None:
+        module = self._module()
+        template = module.retry_loops_query(repo=REPO)
+        query_log: list[str] = []
+        db = self._build_session_store_fixture(repository=REPO)
+
+        result = module.run_two_pass(
+            template,
+            self._sqlite_query_runner(
+                query_log=query_log,
+                db=db,
+                retry_window_minutes=module.RETRY_WINDOW_MINUTES,
+            ),
+        )
+
+        edge_row = next(row for row in result["rows"] if row["tool_name"] == "view")
+        self.assertEqual(edge_row["failed_at"], "2026-06-12 14:00:00")
+        self.assertEqual(edge_row["retried_at"], "2026-06-12 14:15:00")
+        self.assertEqual(edge_row["retry_count"], 1)
 
     def test_limited_evidence_fallback_adds_telemetry_gap_acknowledgment(self) -> None:
         module = self._module()
@@ -304,6 +363,17 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
             with self.subTest(factory=factory.__name__, invalid="repo"):
                 with self.assertRaises(ValueError):
                     factory(repo="wryenmeek/knowledgebase'; DROP TABLE turns; --")
+            for invalid_repo in (
+                "./knowledgebase",
+                "../knowledgebase",
+                ".../knowledgebase",
+                "wryenmeek/.",
+                "wryenmeek/..",
+                "wryenmeek/...",
+            ):
+                with self.subTest(factory=factory.__name__, invalid_repo=invalid_repo):
+                    with self.assertRaises(ValueError):
+                        factory(repo=invalid_repo)
             for invalid_days in (0, 366, True, 7.5):
                 with self.subTest(factory=factory.__name__, invalid_days=invalid_days):
                     with self.assertRaises((TypeError, ValueError)):
@@ -335,6 +405,10 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
                     value = finding[required_key]
                     if isinstance(value, str):
                         self.assertNotEqual(value, "")
+
+    def test_sqlite_regexp_extract_rejects_python_only_regex_features(self) -> None:
+        with self.assertRaises(AssertionError):
+            self._sqlite_regexp_extract("aa", r"(?<=a)a", 0)
 
     def _sqlite_query_runner(
         self,
@@ -370,6 +444,25 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         )
         converted = re.sub(r"\bILIKE\b", "LIKE", converted, flags=re.IGNORECASE)
         return converted
+
+    @staticmethod
+    def _create_duckdb_session_store_schema(db) -> None:
+        db.execute(
+            """
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, repository TEXT);
+            CREATE TABLE turns (session_id TEXT, turn_index INTEGER, user_message TEXT, timestamp TIMESTAMP);
+            CREATE TABLE session_refs (session_id TEXT, ref_type TEXT, ref_value TEXT, created_at TIMESTAMP);
+            CREATE TABLE events (
+              session_id TEXT,
+              timestamp TIMESTAMP,
+              type TEXT,
+              tool_start_name TEXT,
+              tool_complete_call_id TEXT,
+              tool_complete_success BOOLEAN
+            );
+            CREATE TABLE tool_requests (session_id TEXT, tool_call_id TEXT, arguments_json TEXT);
+            """
+        )
 
     def _build_session_store_fixture(self, *, repository: str) -> sqlite3.Connection:
         db = sqlite3.connect(":memory:")
@@ -486,6 +579,9 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
                 ("retry-loop", "2026-06-12 13:05:00", "tool.execution_complete", "bash", "bash-retry", 1),
                 ("retry-loop", "2026-06-12 13:07:00", "tool.execution_complete", "bash", "bash-unrelated", 1),
                 ("retry-loop", "2026-06-12 13:30:00", "tool.execution_complete", "view", "view-late", 1),
+                ("retry-loop", "2026-06-12 14:00:00", "tool.execution_complete", "view", "view-failed", 0),
+                ("retry-loop", "2026-06-12 14:15:00", "tool.execution_complete", "view", "view-retry-edge", 1),
+                ("retry-loop", "2026-06-12 14:15:01", "tool.execution_complete", "view", "view-retry-late", 1),
             ),
         )
         db.executemany(
@@ -495,6 +591,9 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
                 ("retry-loop", "bash-retry", '{"command": "python3 -m pytest tests/kb/test_x.py"}'),
                 ("retry-loop", "bash-unrelated", '{"command": "git status --short"}'),
                 ("retry-loop", "view-late", '{"path": "AGENTS.md"}'),
+                ("retry-loop", "view-failed", '{"path": "wiki/index.md"}'),
+                ("retry-loop", "view-retry-edge", '{"path": "wiki/index.md"}'),
+                ("retry-loop", "view-retry-late", '{"path": "wiki/index.md"}'),
             ),
         )
 
@@ -504,6 +603,11 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
 
     @staticmethod
     def _sqlite_regexp_extract(value: str, pattern: str, group_index: int) -> str:
+        if re.search(r"\(\?([=!<]|P[<=])|\\[1-9]", pattern):
+            raise AssertionError(
+                "SQLite regexp_extract fixture only accepts DuckDB/RE2-compatible patterns; "
+                "use the DuckDB smoke test for dialect-specific coverage"
+            )
         match = re.search(pattern, value)
         if match is None:
             return ""


### PR DESCRIPTION
> *Implemented by AI fleet agent. Closes #240.*

## Summary

- Refactored all five friction-query helpers through uniform private SQL factories while preserving the public query-template dict shape.
- Added retry-loop 15-minute boundary fixture coverage, pure-dot repo rejection, DuckDB dialect smoke coverage, and SQLite regexp dialect guard.
- Added skill-local friction test entrypoint and refreshed `.github/skills/CONTEXT.md`.

## Tests

- ✅ `python3 -m pytest .github/skills/audit-knowledgebase-workspace/tests/ -v -k friction`
- ✅ All non-wrapper tests pass: 1879 passed + 2440 subtests

## Note on pre-existing worktree-only test failures

Four `tests/kb/test_skill_wrappers.py` tests fail in this isolated worktree because they assert `--repo-name knowledgebase` literal while wrappers derive the name from `REPO_ROOT.name`. This is unrelated to #240 (which scopes to friction queries) and is tracked in #250. The same 4 tests pass on `main` and will pass when this PR is merged.

Friction-query targeted tests pass: ✅
All non-wrapper tests pass: ✅ (1879 passed + 2440 subtests)
