### PR TITLE
refactor(audit-workspace): polish skill_corpus_cache (#229)

### DIFF
--- a/.github/skills/audit-knowledgebase-workspace/SKILL.md
+++ b/.github/skills/audit-knowledgebase-workspace/SKILL.md
@@ -95,6 +95,7 @@ python3 -m pytest tests/kb/test_doc_cascade_completeness.py tests/kb/test_docs_i
 - [`docs/decisions/ADR-007-control-plane-layering-and-packaging.md`](../../../docs/decisions/ADR-007-control-plane-layering-and-packaging.md)
 - [`docs/ideas/wiki-curation-agent-framework.md`](../../../docs/ideas/wiki-curation-agent-framework.md)
 - Phase 4 classifier/apply work (issues #202–#211; #202–#206 landed, #207–#211 open)
+- [`logic/skill_corpus_cache.py`](logic/skill_corpus_cache.py) — Decision Q11 skill-corpus cache; deferred classifier input.
 - [`references/locality-ladder.md`](references/locality-ladder.md)
 - [`tests/kb/test_framework_references.py`](../../../tests/kb/test_framework_references.py)
 - [`tests/kb/test_skill_wrappers.py`](../../../tests/kb/test_skill_wrappers.py)

--- a/.github/skills/audit-knowledgebase-workspace/logic/redundancy_generator.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/redundancy_generator.py
@@ -33,9 +33,27 @@ if __package__ in (None, ""):
 from scripts.kb.write_utils import check_no_symlink_path
 
 try:
-    from skill_corpus_cache import CACHE_FILENAME, CACHE_STRATEGY, SkillCorpus
+    from skill_corpus_cache import (
+        CACHE_FILENAME,
+        CACHE_PAYLOAD_ENTRIES_KEY,
+        CACHE_PAYLOAD_STRATEGY_KEY,
+        CACHE_STRATEGY,
+        ENTRY_FIRST_PARAGRAPH_KEY,
+        ENTRY_FRONTMATTER_KEY,
+        ENTRY_MTIME_NS_KEY,
+        SkillCorpus,
+    )
 except ImportError:  # pragma: no cover - exercised when imported as a package
-    from .skill_corpus_cache import CACHE_FILENAME, CACHE_STRATEGY, SkillCorpus
+    from .skill_corpus_cache import (
+        CACHE_FILENAME,
+        CACHE_PAYLOAD_ENTRIES_KEY,
+        CACHE_PAYLOAD_STRATEGY_KEY,
+        CACHE_STRATEGY,
+        ENTRY_FIRST_PARAGRAPH_KEY,
+        ENTRY_FRONTMATTER_KEY,
+        ENTRY_MTIME_NS_KEY,
+        SkillCorpus,
+    )
 
 
 MAX_ATTEMPTS = 3
@@ -515,17 +533,52 @@ def _load_cached_skill_corpus(cache_path: Path) -> SkillCorpus:
     if not isinstance(payload, dict):
         raise ValueError("cached skill-corpus root must be a JSON object")
 
+    cache_strategy = payload.get(CACHE_PAYLOAD_STRATEGY_KEY)
+    entries = payload.get(CACHE_PAYLOAD_ENTRIES_KEY)
+    if CACHE_PAYLOAD_STRATEGY_KEY in payload or CACHE_PAYLOAD_ENTRIES_KEY in payload:
+        if not isinstance(cache_strategy, str) or cache_strategy not in VALID_CACHE_STRATEGIES:
+            raise ValueError("cached skill-corpus root has invalid cache_strategy")
+        if not isinstance(entries, dict):
+            raise ValueError("cached skill-corpus root missing entries object")
+        return _coerce_cached_skill_entries(entries, cache_strategy=cache_strategy)
+
+    return _coerce_legacy_cached_skill_entries(payload)
+
+
+def _coerce_cached_skill_entries(
+    entries: dict[Any, Any], *, cache_strategy: str
+) -> SkillCorpus:
+    corpus: SkillCorpus = {}
+    for cache_key, entry in entries.items():
+        if not isinstance(cache_key, str) or not isinstance(entry, dict):
+            raise ValueError("cached skill-corpus entries must be keyed JSON objects")
+        frontmatter = entry.get(ENTRY_FRONTMATTER_KEY)
+        first_paragraph = entry.get(ENTRY_FIRST_PARAGRAPH_KEY)
+        mtime_ns = entry.get(ENTRY_MTIME_NS_KEY)
+        if not isinstance(frontmatter, dict):
+            raise ValueError(f"cached skill-corpus entry missing frontmatter: {cache_key}")
+        if not isinstance(first_paragraph, str):
+            raise ValueError(f"cached skill-corpus entry missing first_paragraph: {cache_key}")
+        if not isinstance(mtime_ns, int) or isinstance(mtime_ns, bool):
+            raise ValueError(f"cached skill-corpus entry missing mtime_ns: {cache_key}")
+        corpus[cache_key] = {
+            "frontmatter": dict(frontmatter),
+            "first_paragraph": first_paragraph,
+            "mtime_ns": mtime_ns,
+            "cache_strategy": cache_strategy,
+        }
+    return corpus
+
+
+def _coerce_legacy_cached_skill_entries(payload: dict[Any, Any]) -> SkillCorpus:
     corpus: SkillCorpus = {}
     for cache_key, entry in payload.items():
         if not isinstance(cache_key, str) or not isinstance(entry, dict):
             raise ValueError("cached skill-corpus entries must be keyed JSON objects")
-        if not isinstance(entry.get("frontmatter"), dict):
-            raise ValueError(f"cached skill-corpus entry missing frontmatter: {cache_key}")
-        if not isinstance(entry.get("first_paragraph"), str):
-            raise ValueError(f"cached skill-corpus entry missing first_paragraph: {cache_key}")
-        if entry.get("cache_strategy") not in VALID_CACHE_STRATEGIES:
+        cache_strategy = entry.get(CACHE_PAYLOAD_STRATEGY_KEY)
+        if cache_strategy not in VALID_CACHE_STRATEGIES:
             raise ValueError(f"cached skill-corpus entry has invalid cache_strategy: {cache_key}")
-        corpus[cache_key] = entry
+        corpus.update(_coerce_cached_skill_entries({cache_key: entry}, cache_strategy=cache_strategy))
     return corpus
 
 
@@ -545,6 +598,7 @@ def _bounded_files(repo_root: Path, root: Path, pattern: str) -> list[Path]:
         if resolved.is_file():
             files.append(resolved)
     return files
+
 
 def _validate_skill_corpus_path(repo_root: Path, path: Path) -> str:
     relative_path = _repo_relative_path(repo_root, path)

--- a/.github/skills/audit-knowledgebase-workspace/logic/skill_corpus_cache.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/skill_corpus_cache.py
@@ -1,9 +1,11 @@
 """Skill-corpus cache for audit-workspace classifier prompt inputs.
 
 The cache intentionally stores only each ``SKILL.md`` file's frontmatter and
-first post-frontmatter paragraph. Per Decision Q11, invalidation is mtime-only:
-touch-only changes re-extract, while content changes that reset mtime can remain
-stale until a later chronicle run surfaces the missed redundancy.
+first prose paragraph. Per Decision Q11, invalidation is mtime-only: touch-only
+changes re-extract, while content changes that reset mtime can remain stale
+until a later chronicle run surfaces the missed redundancy.
+
+Tracking: issue #202 (slice 8a).
 """
 
 from __future__ import annotations
@@ -11,7 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
-from typing import Any
+from typing import Any, TypedDict
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
@@ -23,8 +25,33 @@ from scripts.kb.write_utils import check_no_symlink_path, write_text_capturing_p
 CACHE_FILENAME = "skill-corpus.json"
 CACHE_STRATEGY = "mtime_first_para"
 GOVERNED_CACHE_ROOTS = ("wiki", "raw", "docs")
+CACHE_PAYLOAD_STRATEGY_KEY = "cache_strategy"
+CACHE_PAYLOAD_ENTRIES_KEY = "entries"
+ENTRY_FRONTMATTER_KEY = "frontmatter"
+ENTRY_FIRST_PARAGRAPH_KEY = "first_paragraph"
+ENTRY_MTIME_NS_KEY = "mtime_ns"
 
-SkillCorpusEntry = dict[str, object]
+
+class SkillCorpusEntry(TypedDict):
+    """Runtime cache entry returned to classifier callers."""
+
+    frontmatter: dict[str, object]
+    first_paragraph: str
+    mtime_ns: int
+    cache_strategy: str
+
+
+class _PersistedSkillCorpusEntry(TypedDict):
+    frontmatter: dict[str, object]
+    first_paragraph: str
+    mtime_ns: int
+
+
+class _SkillCorpusCachePayload(TypedDict):
+    cache_strategy: str
+    entries: dict[str, _PersistedSkillCorpusEntry]
+
+
 SkillCorpus = dict[str, SkillCorpusEntry]
 
 
@@ -34,7 +61,7 @@ def get_skill_corpus(
     *,
     force_refresh: bool = False,
 ) -> SkillCorpus:
-    """Return cached frontmatter + first-paragraph entries for direct skill docs.
+    """Return cached frontmatter + first prose paragraph entries for direct skill docs.
 
     ``skill_root`` is expected to be ``.github/skills`` or a test fixture with
     the same shape. Cache JSON is written to ``cache_dir / CACHE_FILENAME`` and
@@ -49,9 +76,9 @@ def get_skill_corpus(
     cache_path = cache_dir_path / CACHE_FILENAME
     _check_cache_path(cache_path)
 
-    cached_entries = {} if force_refresh else _load_cache(cache_path)
+    cached_entries, cache_needs_rewrite = ({}, False) if force_refresh else _load_cache(cache_path)
     corpus: SkillCorpus = {}
-    cache_changed = force_refresh
+    cache_changed = force_refresh or cache_needs_rewrite
 
     for skill_path in _iter_skill_files(skill_root_path):
         stat = skill_path.stat()
@@ -104,6 +131,8 @@ def _extract_skill_entry(skill_path: Path, mtime_ns: int) -> SkillCorpusEntry:
 
 
 def _extract_first_paragraph(body: str) -> str:
+    """Return the first non-heading prose paragraph from a skill body."""
+
     paragraph_lines: list[str] = []
     for line in body.splitlines():
         stripped = line.strip()
@@ -117,55 +146,62 @@ def _extract_first_paragraph(body: str) -> str:
     return "\n".join(paragraph_lines)
 
 
-def _cached_entry_is_fresh(entry: Any, *, mtime_ns: int) -> bool:
-    if not isinstance(entry, dict):
+def _cached_entry_is_fresh(entry: SkillCorpusEntry | None, *, mtime_ns: int) -> bool:
+    """Return whether a validated cache entry matches current mtime and strategy."""
+
+    if entry is None:
         return False
-    return (
-        entry.get("mtime_ns") == mtime_ns
-        and entry.get("cache_strategy") == CACHE_STRATEGY
-        and isinstance(entry.get("frontmatter"), dict)
-        and isinstance(entry.get("first_paragraph"), str)
-    )
+    return entry["mtime_ns"] == mtime_ns and entry["cache_strategy"] == CACHE_STRATEGY
 
 
-def _normalize_cached_entry(entry: Any) -> SkillCorpusEntry:
+def _normalize_cached_entry(entry: SkillCorpusEntry) -> SkillCorpusEntry:
     return {
         "frontmatter": dict(entry["frontmatter"]),
         "first_paragraph": entry["first_paragraph"],
         "mtime_ns": entry["mtime_ns"],
-        "cache_strategy": CACHE_STRATEGY,
+        "cache_strategy": entry["cache_strategy"],
     }
 
 
-def _load_cache(cache_path: Path) -> SkillCorpus:
+def _load_cache(cache_path: Path) -> tuple[SkillCorpus, bool]:
     if not cache_path.exists():
-        return {}
+        return {}, False
     check_no_symlink_path(cache_path)
     try:
         payload = json.loads(cache_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {}
+        return {}, True
     if not isinstance(payload, dict):
-        return {}
+        return {}, True
 
-    cache: SkillCorpus = {}
-    for key, value in payload.items():
-        if isinstance(key, str) and isinstance(value, dict):
-            cache[key] = value
-    return cache
+    cache_strategy = payload.get(CACHE_PAYLOAD_STRATEGY_KEY)
+    entries = payload.get(CACHE_PAYLOAD_ENTRIES_KEY)
+    if isinstance(cache_strategy, str) and isinstance(entries, dict):
+        return _coerce_cache_entries(entries, cache_strategy=cache_strategy), False
+    return _coerce_legacy_cache_entries(payload), True
 
 
 def _write_cache(cache_path: Path, corpus: SkillCorpus) -> None:
-    serialized = json.dumps(corpus, indent=2, sort_keys=True)
+    payload: _SkillCorpusCachePayload = {
+        "cache_strategy": CACHE_STRATEGY,
+        "entries": {
+            cache_key: _persisted_cache_entry(entry) for cache_key, entry in corpus.items()
+        },
+    }
+    serialized = json.dumps(payload, indent=2, sort_keys=True)
     write_text_capturing_previous_safe(cache_path, f"{serialized}\n")
 
 
 def _check_cache_path(cache_path: Path) -> None:
+    """Reject symlinked cache path components before cache read/write."""
+
     if cache_path.exists() or cache_path.is_symlink():
         check_no_symlink_path(cache_path)
 
 
 def _validate_cache_dir(skill_root: Path, cache_dir: Path) -> Path:
+    """Resolve cache_dir to the skill-local path outside governed roots."""
+
     requested_cache_dir = cache_dir if cache_dir.is_absolute() else Path.cwd() / cache_dir
     check_no_symlink_path(requested_cache_dir)
     resolved_cache_dir = requested_cache_dir.resolve(strict=False)
@@ -185,6 +221,63 @@ def _validate_cache_dir(skill_root: Path, cache_dir: Path) -> Path:
     return resolved_cache_dir
 
 
+def _coerce_cache_entries(entries: dict[Any, Any], *, cache_strategy: str) -> SkillCorpus:
+    if cache_strategy != CACHE_STRATEGY:
+        return {}
+
+    cache: SkillCorpus = {}
+    for key, value in entries.items():
+        entry = _coerce_cache_entry(value, cache_strategy=cache_strategy)
+        if isinstance(key, str) and entry is not None:
+            cache[key] = entry
+    return cache
+
+
+def _coerce_legacy_cache_entries(payload: dict[Any, Any]) -> SkillCorpus:
+    cache: SkillCorpus = {}
+    for key, value in payload.items():
+        entry = _coerce_cache_entry(value, cache_strategy=None)
+        if isinstance(key, str) and entry is not None:
+            cache[key] = entry
+    return cache
+
+
+def _coerce_cache_entry(value: Any, *, cache_strategy: str | None) -> SkillCorpusEntry | None:
+    if not isinstance(value, dict):
+        return None
+
+    resolved_cache_strategy = (
+        cache_strategy
+        if cache_strategy is not None
+        else value.get(CACHE_PAYLOAD_STRATEGY_KEY)
+    )
+    frontmatter = value.get(ENTRY_FRONTMATTER_KEY)
+    first_paragraph = value.get(ENTRY_FIRST_PARAGRAPH_KEY)
+    mtime_ns = value.get(ENTRY_MTIME_NS_KEY)
+    if (
+        resolved_cache_strategy != CACHE_STRATEGY
+        or not isinstance(frontmatter, dict)
+        or not isinstance(first_paragraph, str)
+        or not isinstance(mtime_ns, int)
+        or isinstance(mtime_ns, bool)
+    ):
+        return None
+    return {
+        "frontmatter": dict(frontmatter),
+        "first_paragraph": first_paragraph,
+        "mtime_ns": mtime_ns,
+        "cache_strategy": resolved_cache_strategy,
+    }
+
+
+def _persisted_cache_entry(entry: SkillCorpusEntry) -> _PersistedSkillCorpusEntry:
+    return {
+        "frontmatter": dict(entry["frontmatter"]),
+        "first_paragraph": entry["first_paragraph"],
+        "mtime_ns": entry["mtime_ns"],
+    }
+
+
 def _repo_root_for_skill_root(skill_root: Path) -> Path | None:
     if skill_root.name == "skills" and skill_root.parent.name == ".github":
         return skill_root.parents[1]
@@ -193,7 +286,12 @@ def _repo_root_for_skill_root(skill_root: Path) -> Path | None:
 
 __all__ = [
     "CACHE_FILENAME",
+    "CACHE_PAYLOAD_ENTRIES_KEY",
+    "CACHE_PAYLOAD_STRATEGY_KEY",
     "CACHE_STRATEGY",
+    "ENTRY_FIRST_PARAGRAPH_KEY",
+    "ENTRY_FRONTMATTER_KEY",
+    "ENTRY_MTIME_NS_KEY",
     "SkillCorpus",
     "SkillCorpusEntry",
     "default_cache_dir",

--- a/tests/kb/test_audit_workspace_cache.py
+++ b/tests/kb/test_audit_workspace_cache.py
@@ -108,6 +108,79 @@ class SkillCorpusCacheTests(RuntimeWorkspaceTestCase):
         self.assertEqual(headed_entry["first_paragraph"], "First prose paragraph")
         self.assertEqual(headed_entry["cache_strategy"], "mtime_first_para")
 
+    def test_unicode_first_prose_paragraph_is_preserved(self) -> None:
+        first_paragraph = "Café policy résumé — 医療 coverage stays deterministic ✅"
+        skill_path = self._write_skill(
+            "unicode-prose",
+            self._skill_body("unicode-prose", first_paragraph, leading_blank=True),
+        )
+
+        corpus = self.module.get_skill_corpus(self.skill_root, self.cache_dir)
+
+        self.assertEqual(self._entry_for(corpus, skill_path)["first_paragraph"], first_paragraph)
+
+    def test_large_first_prose_paragraph_is_not_truncated(self) -> None:
+        first_paragraph = "Large paragraph " + ("0123456789abcdef " * 512)
+        skill_path = self._write_skill(
+            "large-prose",
+            self._skill_body("large-prose", first_paragraph, leading_blank=True),
+        )
+
+        corpus = self.module.get_skill_corpus(self.skill_root, self.cache_dir)
+
+        self.assertEqual(self._entry_for(corpus, skill_path)["first_paragraph"], first_paragraph)
+
+    def test_persists_cache_strategy_once_at_top_level(self) -> None:
+        skill_path = self._write_skill(
+            "top-level-strategy",
+            self._skill_body("top-level-strategy", "Top-level strategy", leading_blank=True),
+        )
+
+        corpus = self.module.get_skill_corpus(self.skill_root, self.cache_dir)
+
+        cache_path = self.cache_dir / self.module.CACHE_FILENAME
+        persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+        persisted_entry = persisted["entries"][str(skill_path.resolve())]
+        self.assertEqual(persisted["cache_strategy"], "mtime_first_para")
+        self.assertNotIn("cache_strategy", persisted_entry)
+        self.assertEqual(persisted_entry["first_paragraph"], "Top-level strategy")
+        self.assertEqual(self._entry_for(corpus, skill_path)["cache_strategy"], "mtime_first_para")
+
+    def test_legacy_per_entry_cache_strategy_hits_cache_and_rewrites_top_level_shape(self) -> None:
+        skill_path = self._write_skill(
+            "legacy-strategy",
+            self._skill_body("legacy-strategy", "Legacy strategy", leading_blank=True),
+        )
+        mtime_ns = skill_path.stat().st_mtime_ns
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = self.cache_dir / self.module.CACHE_FILENAME
+        cache_path.write_text(
+            json.dumps(
+                {
+                    str(skill_path.resolve()): {
+                        "frontmatter": {"name": "legacy-strategy"},
+                        "first_paragraph": "Legacy strategy",
+                        "mtime_ns": mtime_ns,
+                        "cache_strategy": "mtime_first_para",
+                    }
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(
+            self.module,
+            "_extract_skill_entry",
+            side_effect=AssertionError("fresh legacy cache should remain a cache hit"),
+        ):
+            corpus = self.module.get_skill_corpus(self.skill_root, self.cache_dir)
+
+        persisted = json.loads(cache_path.read_text(encoding="utf-8"))
+        self.assertEqual(self._entry_for(corpus, skill_path)["first_paragraph"], "Legacy strategy")
+        self.assertEqual(persisted["cache_strategy"], "mtime_first_para")
+        self.assertNotIn("cache_strategy", persisted["entries"][str(skill_path.resolve())])
+
     def test_mtime_change_causes_cache_miss_and_reextracts(self) -> None:
         skill_path = self._write_skill(
             "mtime-miss",
@@ -128,7 +201,7 @@ class SkillCorpusCacheTests(RuntimeWorkspaceTestCase):
         refreshed = self.module.get_skill_corpus(self.skill_root, self.cache_dir)
         refreshed_entry = self._entry_for(refreshed, skill_path)
         self.assertEqual(refreshed_entry["first_paragraph"], "Updated first paragraph")
-        self.assertGreater(refreshed_entry["mtime_ns"], original_mtime_ns)
+        self.assertEqual(refreshed_entry["mtime_ns"], original_mtime_ns + 1_000_000_000)
 
     def test_no_mtime_change_uses_cache_without_rereading_skill_file(self) -> None:
         skill_path = self._write_skill(
@@ -244,7 +317,7 @@ class SkillCorpusCacheTests(RuntimeWorkspaceTestCase):
         )
         persisted = json.loads(cache_path.read_text(encoding="utf-8"))
         self.assertEqual(
-            persisted[str(skill_path.resolve())]["first_paragraph"],
+            persisted["entries"][str(skill_path.resolve())]["first_paragraph"],
             "Recovered first paragraph",
         )
 

--- a/tests/kb/test_audit_workspace_redundancy_generator.py
+++ b/tests/kb/test_audit_workspace_redundancy_generator.py
@@ -132,7 +132,7 @@ class AuditWorkspaceRedundancyGeneratorTests(RuntimeWorkspaceTestCase):
     def test_loads_precomputed_skill_corpus_cache_without_materializing(self) -> None:
         cache_path = self._cache_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_payload = self._skill_corpus(cache_strategy="mtime_first_para")
+        cache_payload = self._cache_payload(cache_strategy="mtime_first_para")
         cache_path.write_text(json.dumps(cache_payload, sort_keys=True), encoding="utf-8")
         before = self.snapshot_workspace()
         captured_prompts: list[str] = []
@@ -172,11 +172,13 @@ class AuditWorkspaceRedundancyGeneratorTests(RuntimeWorkspaceTestCase):
         cache_path.write_text(
             json.dumps(
                 {
-                    str(readme_path.resolve()): {
-                        "frontmatter": {},
-                        "first_paragraph": "Unrelated repo-local snippet.",
-                        "mtime_ns": 1,
-                        "cache_strategy": "mtime_first_para",
+                    "cache_strategy": "mtime_first_para",
+                    "entries": {
+                        str(readme_path.resolve()): {
+                            "frontmatter": {},
+                            "first_paragraph": "Unrelated repo-local snippet.",
+                            "mtime_ns": 1,
+                        }
                     }
                 }
             ),
@@ -737,7 +739,7 @@ class AuditWorkspaceRedundancyGeneratorTests(RuntimeWorkspaceTestCase):
         source_path = self.write_file("docs/test.md", "Higher-locality guidance.\n")
         cache_path = self._cache_path()
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(json.dumps(self._skill_corpus()), encoding="utf-8")
+        cache_path.write_text(json.dumps(self._cache_payload()), encoding="utf-8")
         output = io.StringIO()
 
         with patch.object(self.module, "_call_llm", return_value='{"claims": []}') as call:
@@ -804,6 +806,19 @@ class AuditWorkspaceRedundancyGeneratorTests(RuntimeWorkspaceTestCase):
                 "mtime_ns": 1,
                 "cache_strategy": cache_strategy,
             }
+        }
+
+    def _cache_payload(self, *, cache_strategy: str = "mtime_first_para") -> dict[str, object]:
+        return {
+            "cache_strategy": cache_strategy,
+            "entries": {
+                cache_key: {
+                    "frontmatter": entry["frontmatter"],
+                    "first_paragraph": entry["first_paragraph"],
+                    "mtime_ns": entry["mtime_ns"],
+                }
+                for cache_key, entry in self._skill_corpus(cache_strategy=cache_strategy).items()
+            },
         }
 
     def _cache_path(self) -> Path:


### PR DESCRIPTION
## Summary

- Add issue #202 provenance and helper docstrings to `skill_corpus_cache.py`.
- Replace loose cache entry aliases with `TypedDict` shapes and persist `cache_strategy` once at the cache payload root.
- Preserve legacy per-entry cache compatibility while rewriting fresh hits into the new top-level payload shape.
- Add Unicode, multi-KB paragraph, exact mtime, payload-shape, and redundancy-loader test coverage.
- Add the requested `SKILL.md` reference for the cache module.

## Verification

- `python3 -m pytest tests/kb/test_audit_workspace_cache.py tests/kb/test_audit_workspace_redundancy_generator.py -q` — 47 passed, 19 subtests passed
- `python3 -m pytest tests/kb/test_audit_workspace_*.py tests/kb/test_framework_write_surface_matrix.py -q` — 112 passed, 470 subtests passed
- `python3 .github/skills/audit-knowledgebase-workspace/logic/audit_workspace.py --mode improve` — pass, writes_attempted 0
- `python3 -m unittest tests.kb.test_framework_references` — OK
- `python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents` — OK
- `python3 -m pytest tests/kb/test_doc_cascade_completeness.py tests/kb/test_docs_ideas_archival.py -q` — 7 passed, 80 subtests passed
- `python3 -m pytest tests/ -q --tb=line` — 1879 passed, 2396 subtests passed, 4 failures in `tests/kb/test_skill_wrappers.py` caused by isolated worktree basename `issue-229` producing `--repo-name issue-229` where tests expect `knowledgebase`; no failures in files changed by this PR

> **Pre-existing worktree-only test failures**
> 4 `tests/kb/test_skill_wrappers.py` tests fail in isolated worktrees due to `REPO_ROOT.name` derivation — unrelated to this change, tracked in #250.

> *Implemented by AI fleet agent. Closes #229.*
