### PR TITLE
refactor(audit-workspace): harden stale generator (#243)

### DIFF
--- a/.github/skills/CONTEXT.md
+++ b/.github/skills/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: directory
-last_updated: 2026-06-13
+last_updated: 2026-06-15
 ---
 
 # CONTEXT — .github/skills/
@@ -19,7 +19,7 @@ Vocabulary for the skill and agent persona layer. `AGENTS.md` takes precedence o
 | AFK lane | Operator-direct pathway for tasks on the ADR-014 allowlist. Skips persona pipeline but still requires lock, log entry, and post-publication patrol. |
 | evidence-verifier → policy-arbiter → synthesis-curator pipeline | The three-persona sequence that governs non-AFK synthesis. `knowledgebase-orchestrator` tests enforce this ordering — AFK cannot bypass without an allowlist entry. |
 | synthesis combined entrypoint | `.github/skills/synthesize-entity-page/logic/synthesize_combined.py` — CI-3 entrypoint that synthesizes entity + concept pages in one critical section under a single `wiki/.kb_write.lock` acquisition. |
-| `parents[4]` import pattern | The canonical way to import from `scripts.kb` inside skill logic files: `sys.path.insert(0, str(Path(__file__).resolve().parents[4]))`. Resolves 4 levels up from `logic/<file>.py` to the repo root. |
+| `parents[4]` import pattern | The canonical way to import from `scripts.kb` inside skill logic files: prepend `str(Path(__file__).resolve().parents[4])` to `sys.path`. Resolves 4 levels up from `logic/<file>.py` to the repo root; changed logic may de-duplicate before prepending to avoid repeated global-state mutation. |
 | skill-first execution | When a task matches a skill, invoke and follow that skill workflow. Do not quick-implement around an applicable skill. |
 | instruction ratchet | The pattern where always-on instruction files such as `.github/copilot-instructions.md` grow monotonically add-only, decoupled from customization-surface growth. Measured by net line change in a window where skill count is flat. |
 | Locality | A trigger-frequency ordinal for instruction destinations (Locality 0–4); frequency increases monotonically. Locality 4 = every turn (always-on); Locality 0 = only when a single file is read. See ADR-028 (pending). |
@@ -33,7 +33,7 @@ Vocabulary for the skill and agent persona layer. `AGENTS.md` takes precedence o
 | Skill-first execution | If a task matches a skill, invoke the skill workflow. Do not skip required skill phases for non-trivial work. |
 | Fail-closed on lock/policy | Skill logic files in `logic/` must fail closed on any lock contention, policy gap, or validation error. Partial success is treated as failure on protected/write paths. |
 | Combined synthesis uses one lock | CI-3 synthesis flows run entity and concept draft generation under one lock-critical section (`synthesize_combined.py`) and release only after all writes/index/log updates complete. |
-| `parents[4]` for imports | Skill logic files use `sys.path.insert(0, str(Path(__file__).resolve().parents[4]))` to import from `scripts.kb`. Never inline-reimplement helpers from canonical modules. |
+| `parents[4]` for imports | Skill logic files resolve the repo root with `Path(__file__).resolve().parents[4]` before importing from `scripts.kb`. Never inline-reimplement helpers from canonical modules. |
 | Logic files need matrix rows | Every `logic/*.py` file needs a row in the AGENTS.md write-surface matrix. A doc-only skill (no `logic/`) needs no row. |
 
 ## File Roles

--- a/.github/skills/audit-knowledgebase-workspace/logic/stale_generator.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/stale_generator.py
@@ -29,9 +29,16 @@ import subprocess
 import sys
 from typing import Callable, Sequence
 
+
+def _prepend_sys_path_once(path: Path) -> None:
+    path_text = str(path)
+    sys.path[:] = [entry for entry in sys.path if entry != path_text]
+    sys.path.insert(0, path_text)
+
+
 if __package__ in (None, ""):
-    sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    _prepend_sys_path_once(Path(__file__).resolve().parents[4])
+    _prepend_sys_path_once(Path(__file__).resolve().parent)
 
 from scripts.kb.contracts import (
     CHECKPOINT_REGISTRY_LOCK_PATH,
@@ -49,6 +56,7 @@ ISSUE_COMMAND_TIMEOUT_SECONDS = 5
 MAX_INSTRUCTION_CHARS = 50_000
 MAX_REFERENCES_PER_KIND = 100
 MAX_TOTAL_PROBES = 200
+MAX_ISSUE_REFERENCE_DIGITS = 10
 VALID_CACHE_STRATEGIES = (CACHE_STRATEGY, "hybrid_signature")
 GOVERNANCE_LOCK_PATHS = frozenset(
     {
@@ -67,7 +75,9 @@ PATH_REFERENCE_RE = re.compile(
     r"|\.gitkeep)\b",
     re.IGNORECASE,
 )
-ISSUE_REFERENCE_RE = re.compile(r"(?<![A-Za-z0-9])#([0-9]{1,5})\b")
+ISSUE_REFERENCE_RE = re.compile(
+    rf"(?<![A-Za-z0-9])#([0-9]{{1,{MAX_ISSUE_REFERENCE_DIGITS}}})\b"
+)
 ADR_REFERENCE_RE = re.compile(r"\bADR-([0-9]{1,4})\b", re.IGNORECASE)
 STATUS_HEADING_RE = re.compile(r"^#{2,3}\s+status\b", re.IGNORECASE)
 SCHEMELESS_URL_PATH_RE = re.compile(r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+/")
@@ -81,11 +91,12 @@ SYMBOL_PLAIN_REFERENCE_RE = re.compile(
 )
 BACKTICK_CALL_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)\(\)`")
 BACKTICK_IDENTIFIER_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
-SAFE_REPO_RELATIVE_PATH_RE = re.compile(
+SAFE_REPO_RELATIVE_PATH_PATTERN = (
     r"^(?!.*[\s\x00-\x1F\x7F])(?!/)(?![A-Za-z]:)"
     r"(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*(?:^|/)\.\.?($|/))"
     r"[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$"
 )
+SAFE_REPO_RELATIVE_PATH_RE = re.compile(SAFE_REPO_RELATIVE_PATH_PATTERN)
 
 CommandRunner = Callable[
     [Sequence[str], Path, int],
@@ -147,13 +158,18 @@ def generate_stale_findings(
     tracked_python_files = (
         _tracked_python_files(repo_root=repo_root_path, runner=runner) if symbol_references else ()
     )
-    for symbol in symbol_references:
-        if not _python_symbol_exists(
-            symbol,
+    existing_python_symbols = (
+        _existing_python_symbols(
+            symbol_references,
             repo_root=repo_root_path,
             runner=runner,
             python_files=tracked_python_files,
-        ):
+        )
+        if symbol_references
+        else frozenset()
+    )
+    for symbol in symbol_references:
+        if symbol not in existing_python_symbols:
             findings.append(
                 _finding(
                     source_file=normalized_source_file,
@@ -309,7 +325,38 @@ def _git_path_exists(
     return bool(result.stdout.strip())
 
 
-def _python_symbol_exists(
+def _existing_python_symbols(
+    symbols: tuple[str, ...],
+    *,
+    repo_root: Path,
+    runner: CommandRunner,
+    python_files: tuple[str, ...],
+) -> frozenset[str]:
+    if not symbols or not python_files:
+        return frozenset()
+
+    existing_symbols: set[str] = set()
+    for symbol in symbols:
+        try:
+            if _python_symbol_exists_with_rg(
+                symbol,
+                repo_root=repo_root,
+                runner=runner,
+                python_files=python_files,
+            ):
+                existing_symbols.add(symbol)
+        except RuntimeError as exc:
+            if "rg CLI is required" not in str(exc):
+                raise
+            return _python_fallback_defined_symbols(
+                symbols,
+                repo_root=repo_root,
+                python_files=python_files,
+            )
+    return frozenset(existing_symbols)
+
+
+def _python_symbol_exists_with_rg(
     symbol: str,
     *,
     repo_root: Path,
@@ -318,25 +365,11 @@ def _python_symbol_exists(
 ) -> bool:
     if not python_files:
         return False
-    try:
-        result = runner(
-            ["rg", "-l", "--fixed-strings", "--type", "python", "--", symbol, *python_files],
-            repo_root,
-            COMMAND_TIMEOUT_SECONDS,
-        )
-    except RuntimeError as exc:
-        if "rg CLI is required" not in str(exc):
-            raise
-        candidate_paths = _python_files_containing_text(
-            symbol,
-            repo_root=repo_root,
-            python_files=python_files,
-        )
-        return _python_symbol_defined(
-            symbol,
-            repo_root=repo_root,
-            candidate_paths=candidate_paths,
-        )
+    result = runner(
+        ["rg", "-l", "--fixed-strings", "--type", "python", "--", symbol, *python_files],
+        repo_root,
+        COMMAND_TIMEOUT_SECONDS,
+    )
     if result.returncode == 1:
         return False
     if result.returncode != 0:
@@ -384,36 +417,49 @@ def _python_symbol_defined(
             raise RuntimeError(f"unable to read rg match path: {candidate_path}") from exc
         except SyntaxError as exc:
             raise RuntimeError(f"unable to parse rg match path: {candidate_path}") from exc
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                if node.name == symbol:
-                    return True
-            if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
-                if symbol in _assignment_target_names(node):
-                    return True
-            if isinstance(node, (ast.Import, ast.ImportFrom)):
-                if symbol in _imported_names(node):
-                    return True
+        if symbol in _defined_symbol_names(tree):
+            return True
     return False
 
 
-def _python_files_containing_text(
-    symbol: str,
+def _python_fallback_defined_symbols(
+    symbols: tuple[str, ...],
     *,
     repo_root: Path,
     python_files: tuple[str, ...],
-) -> tuple[str, ...]:
-    matched_paths: list[str] = []
+) -> frozenset[str]:
+    sought_symbols = set(symbols)
+    defined_symbols: set[str] = set()
     for python_file in python_files:
         path = (repo_root / python_file).resolve()
         if not path.is_relative_to(repo_root):
             raise ValueError(f"tracked Python path escapes repository root: {python_file}")
         try:
-            if symbol in path.read_text(encoding="utf-8"):
-                matched_paths.append(python_file)
+            file_text = path.read_text(encoding="utf-8")
         except OSError as exc:
             raise RuntimeError(f"unable to read tracked Python path: {python_file}") from exc
-    return tuple(matched_paths)
+        if not any(symbol in file_text for symbol in sought_symbols):
+            continue
+        try:
+            tree = ast.parse(file_text, filename=python_file)
+        except SyntaxError as exc:
+            raise RuntimeError(f"unable to parse tracked Python path: {python_file}") from exc
+        defined_symbols.update(_defined_symbol_names(tree) & sought_symbols)
+        if sought_symbols.issubset(defined_symbols):
+            break
+    return frozenset(defined_symbols)
+
+
+def _defined_symbol_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            names.update(_assignment_target_names(node))
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(_imported_names(node))
+    return names
 
 
 def _assignment_target_names(node: ast.Assign | ast.AnnAssign | ast.AugAssign) -> set[str]:
@@ -456,7 +502,7 @@ def _issue_is_closed(
     repo_root: Path,
     runner: CommandRunner,
 ) -> bool:
-    if not issue_number.isdigit() or len(issue_number) > 5:
+    if not issue_number.isdigit() or len(issue_number) > MAX_ISSUE_REFERENCE_DIGITS:
         raise ValueError(f"invalid issue number: {issue_number}")
     result = runner(
         ["gh", "issue", "view", issue_number, "--json", "state", "--jq", ".state"],
@@ -571,8 +617,10 @@ __all__ = [
     "COMMAND_TIMEOUT_SECONDS",
     "ISSUE_COMMAND_TIMEOUT_SECONDS",
     "MAX_INSTRUCTION_CHARS",
+    "MAX_ISSUE_REFERENCE_DIGITS",
     "MAX_REFERENCES_PER_KIND",
     "MAX_TOTAL_PROBES",
+    "SAFE_REPO_RELATIVE_PATH_PATTERN",
     "VALID_CACHE_STRATEGIES",
     "StaleFinding",
     "build_adr_supersession_map",

--- a/.github/skills/audit-knowledgebase-workspace/tests/test_stale_generator.py
+++ b/.github/skills/audit-knowledgebase-workspace/tests/test_stale_generator.py
@@ -1,0 +1,6 @@
+"""Skill-local pytest entrypoint for deterministic stale-generator tests."""
+
+from tests.kb.test_audit_workspace_stale_generator import AuditWorkspaceStaleGeneratorTests
+
+
+__all__ = ["AuditWorkspaceStaleGeneratorTests"]

--- a/tests/kb/test_audit_workspace_stale_generator.py
+++ b/tests/kb/test_audit_workspace_stale_generator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,6 +36,31 @@ class AuditWorkspaceStaleGeneratorTests(RuntimeWorkspaceTestCase):
         super().setUp()
         self.module = load_module("audit_workspace_stale_generator", STALE_GENERATOR_PATH)
         self.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def test_runtime_safe_path_pattern_matches_finding_schema(self) -> None:
+        schema_patterns = {
+            self.schema["properties"]["source_file"]["pattern"],
+            self.schema["properties"]["suggested_artifact_path"]["pattern"],
+        }
+
+        self.assertEqual(schema_patterns, {self.module.SAFE_REPO_RELATIVE_PATH_PATTERN})
+
+    def test_import_setup_does_not_duplicate_sys_path_entries(self) -> None:
+        repo_root = str(STALE_GENERATOR_PATH.resolve().parents[4])
+        logic_dir = str(STALE_GENERATOR_PATH.resolve().parent)
+        expected_paths = {repo_root, logic_dir}
+        original_path = list(sys.path)
+
+        try:
+            sys.path[:] = ["sentinel-before", repo_root, "sentinel-between", logic_dir]
+            load_module("audit_workspace_stale_generator_sys_path_a", STALE_GENERATOR_PATH)
+            load_module("audit_workspace_stale_generator_sys_path_b", STALE_GENERATOR_PATH)
+
+            self.assertEqual(sys.path[:2], [logic_dir, repo_root])
+            for expected_path in expected_paths:
+                self.assertEqual(sys.path.count(expected_path), 1)
+        finally:
+            sys.path[:] = original_path
 
     def test_instruction_mentions_missing_file_emits_stale_finding(self) -> None:
         instruction = "When debugging, read docs/missing-runbook.md before proceeding."
@@ -141,6 +167,21 @@ class AuditWorkspaceStaleGeneratorTests(RuntimeWorkspaceTestCase):
 
         self.assertEqual(findings, ())
         self.assertEqual(run.call_args.args[0], ["git", "ls-files", "--", "pyproject.toml"])
+
+    def test_numeric_dotted_toml_filename_remains_accepted(self) -> None:
+        instruction = "Respect 1.2.3.toml before changing version fixtures."
+
+        with patch.object(self.module.subprocess, "run") as run:
+            run.return_value = self._completed(["git"], stdout="1.2.3.toml\n")
+            findings = self.module.generate_stale_findings(
+                instruction,
+                source_file="AGENTS.md",
+                source_section="## Build, test, and verify commands",
+                repo_root=self.workspace_root,
+            )
+
+        self.assertEqual(findings, ())
+        self.assertEqual(run.call_args.args[0], ["git", "ls-files", "--", "1.2.3.toml"])
 
     def test_instruction_mentions_hidden_dotted_files_emits_stale_findings(self) -> None:
         instruction = "Seed .env.example, .secrets.baseline, and .gitkeep when bootstrapping."
@@ -364,6 +405,41 @@ class AuditWorkspaceStaleGeneratorTests(RuntimeWorkspaceTestCase):
         self.assert_schema_valid(findings[0])
         self.assertIn("missing_symbol", findings[0]["deletion_candidate"])
 
+    def test_missing_rg_binary_fallback_reads_each_tracked_file_once(self) -> None:
+        instruction = "Use function present_symbol and function missing_symbol before changing runtime."
+        self.write_file(
+            "scripts/kb/present.py",
+            "def present_symbol():\n    return None\n",
+        )
+        read_count = 0
+        original_read_text = Path.read_text
+
+        def counting_read_text(path: Path, *args: object, **kwargs: object) -> str:
+            nonlocal read_count
+            if path.name == "present.py":
+                read_count += 1
+            return original_read_text(path, *args, **kwargs)
+
+        with (
+            patch.object(self.module.subprocess, "run") as run,
+            patch.object(self.module.Path, "read_text", counting_read_text),
+        ):
+            run.side_effect = (
+                self._completed(["git"], stdout="scripts/kb/present.py\n"),
+                FileNotFoundError(),
+            )
+            findings = self.module.generate_stale_findings(
+                instruction,
+                source_file="AGENTS.md",
+                source_section="## Codebase-specific patterns",
+                repo_root=self.workspace_root,
+            )
+
+        self.assertEqual(read_count, 1)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("missing_symbol", findings[0]["deletion_candidate"])
+        self.assertEqual(run.call_count, 2)
+
     def test_backticked_tool_name_does_not_emit_symbol_finding(self) -> None:
         instruction = "Run `pytest` before merging."
 
@@ -462,6 +538,38 @@ class AuditWorkspaceStaleGeneratorTests(RuntimeWorkspaceTestCase):
             run.call_args.args[0],
             ["gh", "issue", "view", "206", "--json", "state", "--jq", ".state"],
         )
+
+    def test_six_digit_issue_reference_uses_gh_probe(self) -> None:
+        instruction = "Keep this workaround until #100000 is resolved."
+
+        with patch.object(self.module.subprocess, "run") as run:
+            run.return_value = self._completed(["gh"], stdout="open\n")
+            findings = self.module.generate_stale_findings(
+                instruction,
+                source_file=".github/copilot-instructions.md",
+                source_section="## Operational patterns",
+                repo_root=self.workspace_root,
+            )
+
+        self.assertEqual(findings, ())
+        self.assertEqual(
+            run.call_args.args[0],
+            ["gh", "issue", "view", "100000", "--json", "state", "--jq", ".state"],
+        )
+
+    def test_issue_reference_above_digit_cap_is_ignored_before_gh_probe(self) -> None:
+        instruction = "Do not treat #12345678901 as a bounded GitHub issue reference."
+
+        with patch.object(self.module.subprocess, "run") as run:
+            findings = self.module.generate_stale_findings(
+                instruction,
+                source_file=".github/copilot-instructions.md",
+                source_section="## Operational patterns",
+                repo_root=self.workspace_root,
+            )
+
+        self.assertEqual(findings, ())
+        run.assert_not_called()
 
     def test_issue_zero_reference_is_ignored_before_gh_probe(self) -> None:
         instruction = "Do not treat #0 as a real GitHub issue reference."
@@ -642,6 +750,21 @@ class AuditWorkspaceStaleGeneratorTests(RuntimeWorkspaceTestCase):
                     source_section="## Operational patterns",
                     repo_root=self.workspace_root,
                 )
+
+    def test_tracked_python_path_escape_fails_closed_before_rg_probe(self) -> None:
+        instruction = "Use symbol `missing_symbol` before changing runtime."
+
+        with patch.object(self.module.subprocess, "run") as run:
+            run.return_value = self._completed(["git"], stdout="../outside.py\n")
+            with self.assertRaisesRegex(ValueError, "unsafe tracked Python path"):
+                self.module.generate_stale_findings(
+                    instruction,
+                    source_file="AGENTS.md",
+                    source_section="## Operational patterns",
+                    repo_root=self.workspace_root,
+                )
+
+        self.assertEqual(run.call_count, 1)
 
     def test_adversarial_rg_stdout_fails_closed(self) -> None:
         instruction = "Use symbol `missing_symbol` before changing runtime."


### PR DESCRIPTION
> *Implemented by AI fleet agent. Closes #243.*

> **Pre-existing worktree-only test failures**
> 4 `tests/kb/test_skill_wrappers.py` tests fail in isolated worktrees due to `REPO_ROOT.name` derivation — unrelated to this change, tracked in #250.
