### PR TITLE
refactor(audit-workspace): polish finding schema (#232)

### DIFF
--- a/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
+++ b/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "repo://wryenmeek/knowledgebase/.github/skills/audit-knowledgebase-workspace/schema/finding.schema.json",
+  "$comment": "$id intentionally uses repo:// rather than https:// because this schema is a repository-governed artifact with no canonical web publication URL; repo:// keeps identity tied to owner/repo/path while remaining an absolute URI.",
   "title": "Audit workspace improve classifier finding",
-  "description": "JSON Schema for a single audit-knowledgebase-workspace improve dry-run classifier finding. Implements the ADR-028 instruction-locality ladder contract tracked by issue #190 and slice 8b issue #203. The proposed_destination enum is the 10-bin output contract: Delete, Locality 0, Locality 1, Locality 2, Locality 3a, Locality 3b, Locality 3c, Locality 3d, Locality 3e, and Locality 4. compliance_risk is required on every finding: deterministic applies to Locality 0 and mechanically enforced Locality 3a/3b/3c/3d destinations; agent-dependent applies to Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A. Delete findings may use the risk class appropriate to their proof path. The schema intentionally documents but does not enforce the proposed_destination-to-compliance_risk mapping; classifier logic owns that cross-field validation. expected_token_efficiency_rank is the integer rank derived from ADR-028's token-efficiency rule: estimated trigger frequency multiplied by per-fire cost, with lower ranks being cheaper. cache_strategy identifies the skill-corpus indexing strategy that generated the finding and is closed to the Phase 4/Q11 values mtime_first_para and hybrid_signature. suggested_artifact_path remains required because Phase 4 classifier prose includes the suggested artifact path in each finding output.",
+  "description": "JSON Schema for a single audit-knowledgebase-workspace improve dry-run classifier finding.\n\nIt implements the ADR-028 instruction-locality ladder contract tracked by issue #190 and slice 8b issue #203. Destination, compliance-risk, token-rank, cache-strategy, and suggested-path details live on their individual properties so validators and reviewers can reason about each contract independently.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -54,7 +55,7 @@
         "deterministic",
         "agent-dependent"
       ],
-      "description": "Risk class surfaced for reviewer judgment. ADR-028 maps Locality 0 and Locality 3a/3b/3c/3d to deterministic; Locality 1, Locality 2, Locality 3e, and Locality 4 mechanism-A to agent-dependent. This schema does not enforce that cross-field mapping."
+      "description": "Risk class surfaced for reviewer judgment. ADR-028 maps Locality 0 and mechanically enforced Locality 3a/3b/3c/3d to deterministic. Locality 1, Locality 2, Locality 3e, and Locality 4 Mechanism-A (the planning-doc label for ADR-028's trailer-escape path) are agent-dependent. This schema documents but does not enforce the cross-field mapping."
     },
     "expected_token_efficiency_rank": {
       "type": "integer",

--- a/tests/kb/test_audit_workspace_finding_schema.py
+++ b/tests/kb/test_audit_workspace_finding_schema.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+# Keep the module import: this file uses unittest.TestCase and unittest.main(),
+# matching the dominant tests/kb convention.
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = (
@@ -18,6 +20,27 @@ SCHEMA_PATH = (
     / "audit-knowledgebase-workspace"
     / "schema"
     / "finding.schema.json"
+)
+ASSERTION_KEYWORDS_SUPPORTED_BY_STDLIB_VALIDATOR = frozenset(
+    {
+        "additionalProperties",
+        "enum",
+        "minimum",
+        "minLength",
+        "pattern",
+        "properties",
+        "required",
+        "type",
+    }
+)
+ANNOTATION_KEYWORDS_IGNORED_BY_STDLIB_VALIDATOR = frozenset(
+    {
+        "$comment",
+        "$id",
+        "$schema",
+        "description",
+        "title",
+    }
 )
 
 
@@ -121,6 +144,11 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
                     expected_message,
                 )
 
+    def test_schema_accepts_integral_float_for_integer_type(self) -> None:
+        """Mirror jsonschema's integer semantics: JSON number 3.0 is integral."""
+
+        self.assert_schema_valid(self._finding(expected_token_efficiency_rank=3.0))
+
     def test_cache_strategy_enum_accepts_documented_values_and_rejects_typo(self) -> None:
         """AC #5 (issue #203): cache_strategy is the closed Phase 4/Q11 enum."""
 
@@ -165,6 +193,17 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
             with self.subTest(field_name=field_name, unsafe_path=unsafe_path):
                 finding = self._finding(**{field_name: unsafe_path})
                 self.assert_schema_rejects(finding, field_name, "pattern")
+
+    def test_validator_schema_keyword_subset_is_documented(self) -> None:
+        """The stdlib validator documents every schema keyword it supports or ignores."""
+
+        used_keywords = self._schema_keywords(self.schema)
+        documented_keywords = (
+            ASSERTION_KEYWORDS_SUPPORTED_BY_STDLIB_VALIDATOR
+            | ANNOTATION_KEYWORDS_IGNORED_BY_STDLIB_VALIDATOR
+        )
+
+        self.assertLessEqual(used_keywords, documented_keywords)
 
     def assert_schema_valid(self, finding: dict[str, Any]) -> None:
         self._validate_with_schema(deepcopy(finding), self.schema)
@@ -266,6 +305,14 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
 
     @classmethod
     def _validate_with_schema(cls, instance: Any, schema: dict[str, Any], path: str = "$") -> None:
+        """Validate with the documented stdlib subset, not full JSON Schema.
+
+        Supported assertion keywords are listed in
+        ASSERTION_KEYWORDS_SUPPORTED_BY_STDLIB_VALIDATOR. Annotation keywords in
+        ANNOTATION_KEYWORDS_IGNORED_BY_STDLIB_VALIDATOR may appear in the schema
+        and are intentionally ignored by this test-local validator.
+        """
+
         expected_type = schema.get("type")
         if expected_type is not None:
             cls._assert_type(instance, expected_type, path)
@@ -314,8 +361,13 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
                 return
             if single_type == "string" and isinstance(instance, str):
                 return
-            if single_type == "integer" and isinstance(instance, int) and not isinstance(instance, bool):
-                return
+            if single_type == "integer":
+                if isinstance(instance, bool):
+                    continue
+                if isinstance(instance, int):
+                    return
+                if isinstance(instance, float) and instance.is_integer():
+                    return
             if single_type == "number" and (
                 isinstance(instance, (int, float)) and not isinstance(instance, bool)
             ):
@@ -323,6 +375,14 @@ class AuditWorkspaceFindingSchemaTests(unittest.TestCase):
             if single_type == "null" and instance is None:
                 return
         raise SchemaValidationError(f"{path}: expected type {expected_types!r}")
+
+    @classmethod
+    def _schema_keywords(cls, schema: dict[str, Any]) -> set[str]:
+        keywords = set(schema)
+        properties = schema.get("properties", {})
+        for property_schema in properties.values():
+            keywords.update(cls._schema_keywords(property_schema))
+        return keywords
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> *Implemented by AI fleet agent. Closes #232.*

## Summary
Finding schema review is easier now: the top-level description is split for readability, while destination, risk, token-rank, cache-strategy, and path details remain with their individual properties.

The schema identity now documents why `repo://` is the right `$id` scheme for a repository-governed artifact, and the Mechanism-A wording explicitly bridges the planning-doc label to ADR-028's trailer-escape path.

The stdlib-only validator now names its supported JSON Schema keyword subset, accepts `3.0` as an integer to mirror `jsonschema` semantics, and keeps the dominant `import unittest` convention documented in place.

## Tests
- `python3 -m pytest tests/kb/test_audit_workspace_finding_schema.py -v`

No `.github/skills/audit-knowledgebase-workspace/tests/` files reference the finding schema, so there were no additional skill-local schema tests to run.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this is a schema/test-only refactor with no runtime service, workflow, or user-facing behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Copilot_CLI](https://img.shields.io/badge/Copilot_CLI-000000)
