### PR TITLE
feat(audit-workspace): OutOfBand cross-skill handoff routing

### DIFF
--- a/.github/skills/audit-knowledgebase-workspace/SKILL.md
+++ b/.github/skills/audit-knowledgebase-workspace/SKILL.md
@@ -8,11 +8,11 @@ category: dev-support
 
 ## Overview
 
-Use this skill to self-audit the framework layer as the skill and agent surface grows. The default flow remains the current structural lint workflow via existing repository checks. The Phase 3 `audit_workspace.py` orchestrator still returns empty findings, while Phase 4 classifier components now exist as tested read-only modules that are not yet wired into that orchestrator.
+Use this skill to self-audit the framework layer as the skill and agent surface grows. The default flow remains the current structural lint workflow via existing repository checks. The Phase 3 `audit_workspace.py` orchestrator still returns empty findings by default, while Phase 4 classifier components and the read-only OutOfBand routing layer now exist as tested modules.
 
 ## Classification
 
-- **Mode:** Read-only scaffold orchestrator plus landed read-only classifier components; **Category:** `dev-support`; **Status:** Active Phase 4 components, not yet orchestrator-wired
+- **Mode:** Read-only scaffold orchestrator plus landed read-only classifier/routing components; **Category:** `dev-support`; **Status:** Active Phase 4 components, not yet fully orchestrator-wired
 - **Boundary:** Audit and handoff only; no self-heal edits, broad crawler, or second runtime.
 - **Accepted reference:** ADR-028 owns the instruction-locality ladder and trailer governance.
 - **Forward references:** apply-mode work (#208–#210), QA gates (#207/#211),
@@ -27,10 +27,12 @@ Use this skill to self-audit the framework layer as the skill and agent surface 
 - You need the Phase 3 `improve` dry-run scaffold without applying mutations
 - Orphaned but useful framework assets need governed follow-up rather than silent deletion
 
-## Phase 4 classifier components (landed; not yet wired into orchestrator)
+## Phase 4 classifier and routing components (landed; not yet fully wired)
 
-These read-only components are present and tested, but `audit_workspace.py --mode
-improve` does not yet compose them into findings:
+These read-only components are present and tested. `audit_workspace.py --mode
+improve` does not yet compose the classifier generators into findings, but it
+does route caller-supplied classifier findings through the OutOfBand handoff
+layer:
 
 | Component | Slice | Purpose | Test coverage |
 |---|---|---|---|
@@ -39,14 +41,15 @@ improve` does not yet compose them into findings:
 | `logic/friction_queries.py` | 8c / #204 | Provide repo-scoped and fallback `session_store_sql` query templates for friction-signal mining. | `tests/kb/test_audit_workspace_friction_queries.py` |
 | `logic/stale_generator.py` | 8d / #205 | Generate deterministic stale deletion-candidate findings from tracked files, symbols, ADR status, and issue state. | `tests/kb/test_audit_workspace_stale_generator.py` |
 | `logic/redundancy_generator.py` | 8e / #206 | Generate cited redundant-up-the-ladder findings from lower-locality evidence. | `tests/kb/test_audit_workspace_redundancy_generator.py` |
+| `logic/outofband_handoff.py` | 9c / #210 | Route findings targeting other skills, agents, or prompts into deterministic `framework-engineer` handoff records without invoking the persona or writing files. | `tests/kb/test_audit_workspace_outofband.py` |
 
 ## Contract
 
 - Input: the current framework workspace or a scoped set of changed framework files
 - Audit targets: skill docs, agent docs, hooks, framework tests, and thin wrapper references
 - Default flow: structural lint only through the existing framework test commands
-- Orchestrator surface: compatibility `default` mode and `improve` dry-run mode in `audit_workspace.py` return empty findings until wiring lands
-- Output: a pass/fail audit summary with zero writes attempted
+- Orchestrator surface: compatibility `default` mode and `improve` dry-run mode in `audit_workspace.py` return empty findings unless caller-supplied classifier findings are provided for routing
+- Output: a pass/fail audit summary with zero writes attempted; cross-skill targets appear under `summary.out_of_band_handoffs`
 - Handoff rule: failures route to the owning skill or `review-wiki-plan`; useful
   orphaned assets route to governed planning rather than ad hoc fixes
 
@@ -56,7 +59,8 @@ improve` does not yet compose them into findings:
 - Attached-tool and wrapper allowlist paths must point to real repo-local files
 - The audit fails closed on missing framework dependencies
 - The logic scaffold is `read-only only`; writable paths are none and writes are forbidden
-- The `improve` orchestrator returns empty findings until component wiring lands
+- The `improve` orchestrator returns empty findings until classifier-generator wiring lands
+- OutOfBand routing is deterministic, read-only, fails closed on unsupported finding destinations, and never invokes the target persona
 - Classifier components are landed and tested, but composed classifier output, apply mode, and lock acquisition are deferred
 
 ## Procedure
@@ -64,7 +68,9 @@ improve` does not yet compose them into findings:
 1. Run the default structural lint flow with the framework test commands below, which audit repo-local links, command examples, wrapper allowlists, and attached-tool references.
 2. When requested, run the orchestrator surface in `--mode improve`; it returns
    an empty findings list and records `writes_attempted: 0` until the landed
-   classifier components are wired in.
+   classifier generators are wired in. Caller-supplied classifier findings are
+   routed read-only, with cross-skill records emitted under
+   `out_of_band_handoffs`.
 3. Route failures to the owning skill or `review-wiki-plan`; route broader
    integration work through governed planning instead of invisible fixes.
 
@@ -72,6 +78,7 @@ improve` does not yet compose them into findings:
 
 ```bash
 python3 .github/skills/audit-knowledgebase-workspace/logic/audit_workspace.py --mode improve
+python3 -m pytest tests/kb/test_audit_workspace_outofband.py -v
 python3 -m unittest tests.kb.test_framework_references tests.kb.test_skill_wrappers
 python3 -m unittest tests.kb.test_framework_contracts tests.kb.test_framework_skills tests.kb.test_framework_agents
 python3 -m pytest tests/kb/test_doc_cascade_completeness.py tests/kb/test_docs_ideas_archival.py -v

--- a/.github/skills/audit-knowledgebase-workspace/logic/audit_workspace.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/audit_workspace.py
@@ -2,20 +2,28 @@
 
 Phase 3 intentionally performs no classification and no mutation. The default
 flow preserves the existing structural-lint audit contract, while the `improve`
-flow is a dry-run scaffold that returns an empty findings list. Any write-capable
-behavior, classifier output, and `.github/.customizations.lock` acquisition are
-deferred to later governed slices.
+flow remains a dry-run scaffold. It returns an empty findings list by default
+and can route caller-supplied classifier findings into read-only OutOfBand
+handoff records. Any write-capable behavior and `.github/.customizations.lock`
+acquisition are deferred to later governed slices.
 """
 
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from pathlib import Path
 import sys
-from typing import Sequence, TextIO
+from typing import Any, Sequence, TextIO
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+try:
+    from outofband_handoff import OutOfBandRoutingError, route_findings
+except ImportError:  # pragma: no cover - exercised when imported as a package
+    from .outofband_handoff import OutOfBandRoutingError, route_findings
 
 from scripts._optional_surface_common import (
     APPROVAL_NONE,
@@ -60,7 +68,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--mode",
         choices=SUPPORTED_MODES,
         default="default",
-        help="default: compatibility scaffold; improve: dry-run scaffold with empty findings.",
+        help=(
+            "default: compatibility scaffold; improve: dry-run scaffold with "
+            "empty findings unless caller-supplied findings are routed."
+        ),
     )
     parser.add_argument("--repo-root", default=".", help="Repository root path.")
     parser.add_argument(
@@ -77,8 +88,9 @@ def audit(
     repo_root: str | Path = ".",
     mode: str = "default",
     approval: str = APPROVAL_NONE,
+    classifier_findings: Sequence[Mapping[str, Any]] | None = None,
 ) -> SurfaceResult:
-    """Return an empty read-only audit result with zero writes attempted."""
+    """Return a read-only audit result with zero writes attempted."""
 
     path_rules = _path_rules()
     if approval != APPROVAL_NONE:
@@ -111,10 +123,30 @@ def audit(
             path_rules=path_rules,
         )
 
+    try:
+        routed_findings = route_findings(
+            tuple(classifier_findings or ()),
+            repo_root=normalized_repo_root,
+        )
+    except OutOfBandRoutingError as exc:
+        return SurfaceResult(
+            surface=SURFACE,
+            mode=mode,
+            status=STATUS_FAIL,
+            reason_code=REASON_CODE_INVALID_INPUT,
+            message=f"finding routing failed closed: {exc}",
+            approval=approval,
+            path_rules=path_rules,
+        )
+
+    findings = [dict(finding) for finding in routed_findings.eligible_findings]
+    out_of_band_handoffs = [
+        dict(handoff) for handoff in routed_findings.out_of_band_handoffs
+    ]
     message = (
         "default structural lint remains external; compatibility scaffold returned empty findings"
         if mode == "default"
-        else "improve dry-run scaffold completed with empty findings"
+        else "improve dry-run scaffold completed with routed findings"
     )
     return SurfaceResult(
         surface=SURFACE,
@@ -126,8 +158,10 @@ def audit(
         path_rules=path_rules,
         items=(),
         summary={
-            "findings": [],
-            "finding_count": 0,
+            "findings": findings,
+            "finding_count": len(findings),
+            "out_of_band_handoffs": out_of_band_handoffs,
+            "out_of_band_handoff_count": len(out_of_band_handoffs),
             "writes_attempted": 0,
             "dry_run": True,
             "read_only": True,

--- a/.github/skills/audit-knowledgebase-workspace/logic/outofband_handoff.py
+++ b/.github/skills/audit-knowledgebase-workspace/logic/outofband_handoff.py
@@ -1,0 +1,222 @@
+"""Read-only OutOfBand handoff routing for audit-workspace findings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+from typing import Any
+
+
+AUDIT_SKILL_NAME = "audit-knowledgebase-workspace"
+AUDIT_SKILL_DIR = f".github/skills/{AUDIT_SKILL_NAME}"
+OUT_OF_BAND_TARGET_PERSONA = "framework-engineer"
+HANDOFF_RECORD_FIELDS: tuple[str, ...] = (
+    "finding_id",
+    "source_file",
+    "source_section",
+    "suggested_artifact_path",
+    "rationale",
+    "target_persona",
+)
+SUPPORTED_FINDING_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "Delete",
+        "Locality 0",
+        "Locality 1",
+        "Locality 2",
+        "Locality 3a",
+        "Locality 3b",
+        "Locality 3c",
+        "Locality 3d",
+        "Locality 3e",
+        "Locality 4",
+    }
+)
+OUT_OF_BAND_TARGETS_BY_SCOPE: dict[str, str] = {
+    "other_skill": OUT_OF_BAND_TARGET_PERSONA,
+    "agent": OUT_OF_BAND_TARGET_PERSONA,
+    "prompt": OUT_OF_BAND_TARGET_PERSONA,
+}
+_REQUIRED_FINDING_FIELDS = (
+    "source_file",
+    "source_section",
+    "proposed_destination",
+    "suggested_artifact_path",
+    "rationale",
+)
+
+
+class OutOfBandRoutingError(ValueError):
+    """Raised when a finding cannot be routed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingResult:
+    """Findings separated into self-owned work and OutOfBand handoff records."""
+
+    eligible_findings: tuple[dict[str, Any], ...]
+    out_of_band_handoffs: tuple[dict[str, str], ...]
+
+
+def route_findings(
+    findings: Sequence[Mapping[str, Any]],
+    *,
+    repo_root: str | Path = ".",
+) -> RoutingResult:
+    """Route cross-skill findings to deterministic framework-engineer handoffs."""
+
+    repo_root_path = Path(repo_root).resolve()
+    eligible_findings: list[dict[str, Any]] = []
+    out_of_band_handoffs: list[dict[str, str]] = []
+
+    for finding in findings:
+        normalized = _normalize_finding(finding, repo_root_path=repo_root_path)
+        route_scope = _route_scope(normalized["suggested_artifact_path"])
+        if route_scope is None:
+            eligible_findings.append(normalized)
+            continue
+
+        target_persona = OUT_OF_BAND_TARGETS_BY_SCOPE.get(route_scope)
+        if target_persona is None:
+            raise OutOfBandRoutingError(f"unsupported OutOfBand route scope: {route_scope}")
+        out_of_band_handoffs.append(
+            _handoff_record(
+                normalized,
+                target_persona=target_persona,
+            )
+        )
+
+    return RoutingResult(
+        eligible_findings=tuple(eligible_findings),
+        out_of_band_handoffs=tuple(out_of_band_handoffs),
+    )
+
+
+def _normalize_finding(
+    finding: Mapping[str, Any],
+    *,
+    repo_root_path: Path,
+) -> dict[str, Any]:
+    for field_name in _REQUIRED_FINDING_FIELDS:
+        if field_name not in finding:
+            raise OutOfBandRoutingError(f"finding missing required field: {field_name}")
+
+    proposed_destination = finding["proposed_destination"]
+    if (
+        not isinstance(proposed_destination, str)
+        or proposed_destination not in SUPPORTED_FINDING_CATEGORIES
+    ):
+        raise OutOfBandRoutingError(
+            f"unsupported proposed_destination: {proposed_destination!r}"
+        )
+
+    source_section = _required_text(finding["source_section"], "source_section")
+    rationale = _required_text(finding["rationale"], "rationale")
+    normalized = dict(finding)
+    normalized["source_file"] = _repo_relative_resolved_path(
+        finding["source_file"],
+        repo_root_path=repo_root_path,
+        field_name="source_file",
+    )
+    normalized["source_section"] = source_section
+    normalized["suggested_artifact_path"] = _repo_relative_resolved_path(
+        finding["suggested_artifact_path"],
+        repo_root_path=repo_root_path,
+        field_name="suggested_artifact_path",
+    )
+    normalized["rationale"] = rationale
+    return normalized
+
+
+def _handoff_record(
+    finding: Mapping[str, Any],
+    *,
+    target_persona: str,
+) -> dict[str, str]:
+    record = {
+        "finding_id": _finding_id(
+            source_file=finding["source_file"],
+            source_section=finding["source_section"],
+            suggested_artifact_path=finding["suggested_artifact_path"],
+        ),
+        "source_file": str(finding["source_file"]),
+        "source_section": str(finding["source_section"]),
+        "suggested_artifact_path": str(finding["suggested_artifact_path"]),
+        "rationale": str(finding["rationale"]),
+        "target_persona": target_persona,
+    }
+    if tuple(record) != HANDOFF_RECORD_FIELDS:
+        raise OutOfBandRoutingError("handoff record schema drift")
+    return record
+
+
+def _finding_id(
+    *,
+    source_file: Any,
+    source_section: Any,
+    suggested_artifact_path: Any,
+) -> str:
+    material = "\0".join(
+        (
+            str(source_file),
+            str(source_section),
+            str(suggested_artifact_path),
+        )
+    )
+    return f"outofband-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _route_scope(repo_relative_path: str) -> str | None:
+    parts = Path(repo_relative_path).parts
+    if _is_under(parts, (".github", "agents")):
+        return "agent"
+    if _is_under(parts, (".github", "prompts")):
+        return "prompt"
+    if _is_under(parts, (".github", "skills")) and len(parts) >= 3:
+        skill_name = parts[2]
+        if skill_name != AUDIT_SKILL_NAME:
+            return "other_skill"
+    return None
+
+
+def _is_under(parts: tuple[str, ...], root_parts: tuple[str, ...]) -> bool:
+    return len(parts) > len(root_parts) and parts[: len(root_parts)] == root_parts
+
+
+def _repo_relative_resolved_path(
+    raw_path: Any,
+    *,
+    repo_root_path: Path,
+    field_name: str,
+) -> str:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise OutOfBandRoutingError(f"{field_name} must be a non-empty string")
+    path = Path(raw_path)
+    resolved = (path if path.is_absolute() else repo_root_path / path).resolve()
+    if not resolved.is_relative_to(repo_root_path):
+        raise OutOfBandRoutingError(f"{field_name} escapes repository root: {raw_path!r}")
+    relative_path = resolved.relative_to(repo_root_path).as_posix()
+    if not relative_path or relative_path == ".":
+        raise OutOfBandRoutingError(f"{field_name} must resolve to a repo-relative path")
+    return relative_path
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OutOfBandRoutingError(f"{field_name} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "AUDIT_SKILL_DIR",
+    "AUDIT_SKILL_NAME",
+    "HANDOFF_RECORD_FIELDS",
+    "OUT_OF_BAND_TARGET_PERSONA",
+    "OUT_OF_BAND_TARGETS_BY_SCOPE",
+    "OutOfBandRoutingError",
+    "RoutingResult",
+    "SUPPORTED_FINDING_CATEGORIES",
+    "route_findings",
+]

--- a/docs/ideas/audit-workspace-improve-flow.md
+++ b/docs/ideas/audit-workspace-improve-flow.md
@@ -1,6 +1,6 @@
 # Audit-Workspace `improve` Flow + Instruction Locality Ladder
 
-**Status:** Implemented (Phase 4) — 11 of 23 slices closed as of 2026-06-15; ADR-028 is Accepted, and remaining apply/wiring plus QA slices are open. See § Slice progress (live) below for the authoritative status; plan body revised 2026-06-07 via grill-with-docs pass (see Appendix A for the 12 design decisions adopted on the user's behalf in autopilot mode).
+**Status:** Implemented (Phase 4) — 12 of 23 slices closed as of 2026-06-15; ADR-028 is Accepted, and remaining apply/wiring plus QA slices are open. See § Slice progress (live) below for the authoritative status; plan body revised 2026-06-07 via grill-with-docs pass (see Appendix A for the 12 design decisions adopted on the user's behalf in autopilot mode).
 **Origin:** Adapted from HSI's `docs/planned-work/audit-workspace-improve-flow.md` (2026-06-06), retargeted for this repo's customization surface
 
 | Field | Value |
@@ -36,14 +36,15 @@ As of 2026-06-15 the 23 vertical-slice issues (#190–#212) tracking this plan h
 | 8c | Phase 4 (friction queries) | [#204](https://github.com/wryenmeek/knowledgebase/issues/204) | ✅ CLOSED | `friction_queries.py` with `tests/kb/test_audit_workspace_friction_queries.py` (PR #237) |
 | 8d | Phase 4 (stale generator) | [#205](https://github.com/wryenmeek/knowledgebase/issues/205) | ✅ CLOSED | `stale_generator.py` with `tests/kb/test_audit_workspace_stale_generator.py` (PR #242) |
 | 8e | Phase 4 (redundancy generator) | [#206](https://github.com/wryenmeek/knowledgebase/issues/206) | ✅ CLOSED | `redundancy_generator.py` with `tests/kb/test_audit_workspace_redundancy_generator.py` (PR #238) |
-| 9a–9c | Phase 4 (`--apply`) | [#208](https://github.com/wryenmeek/knowledgebase/issues/208)–[#210](https://github.com/wryenmeek/knowledgebase/issues/210) | OPEN | Pending |
+| 9a–9b | Phase 4 (`--apply`) | [#208](https://github.com/wryenmeek/knowledgebase/issues/208)–[#209](https://github.com/wryenmeek/knowledgebase/issues/209) | OPEN | Pending — allowlist and lock acquisition remain deferred |
+| 9c | Phase 4 (OutOfBand handoff routing) | [#210](https://github.com/wryenmeek/knowledgebase/issues/210) | ✅ CLOSED | `outofband_handoff.py` routes cross-skill findings to `framework-engineer` handoff records with `tests/kb/test_audit_workspace_outofband.py` |
 | 10 | Phase 7 (real-use) | [#212](https://github.com/wryenmeek/knowledgebase/issues/212) | OPEN (HITL) | Pending |
 | qa-ab | QA gate | [#198](https://github.com/wryenmeek/knowledgebase/issues/198) | OPEN (HITL) | Pending |
 | qa-d | QA gate | [#201](https://github.com/wryenmeek/knowledgebase/issues/201) | OPEN | Pending |
 | qa-f | QA gate | [#207](https://github.com/wryenmeek/knowledgebase/issues/207) | OPEN (HITL) | Pending |
 | qa-g | QA gate | [#211](https://github.com/wryenmeek/knowledgebase/issues/211) | OPEN | Pending |
 
-**Rollup:** 11 of 23 slices CLOSED. **The original critical-path framing "no slices begin until #190 (ADR-028) merges" is no longer accurate** — slices 1b/2/3/6 were independently green-lit and merged ahead of #190 because each was independently buildable; ADR-028 (#190) is now Accepted and anchors the remaining apply/wiring and QA slices.
+**Rollup:** 12 of 23 slices CLOSED. **The original critical-path framing "no slices begin until #190 (ADR-028) merges" is no longer accurate** — slices 1b/2/3/6 were independently green-lit and merged ahead of #190 because each was independently buildable; ADR-028 (#190) is now Accepted and anchors the remaining apply/wiring and QA slices.
 
 ---
 
@@ -375,13 +376,13 @@ The repo has no `.github/instructions/` directory today. Locality 1 mechanism ne
     - Hard-fail conditions: missing dry-run input, unsupported destination, classifier output failing JSON schema validation
 - [ ] Phase 4 amends this row to add narrow write capability for `--apply` mode (see Phase 4 spec).
 - [ ] **Dry-run report schema (load-bearing for Phase 7).** Report emits BOTH human-readable markdown AND a fenced JSON block. The schema below includes the classifier fields that Phase 4 / Phase 7 acceptance depends on, so tests and consumers built against this contract from Phase 3 onward stay forward-compatible:
-    ```json
+```json
     {
       "findings": [
         {
           "source_file": "string — .github/copilot-instructions.md | AGENTS.md",
           "source_section": "string — H2/H3 heading or signal identifier",
-          "proposed_destination": "one of: Delete | Locality 0 | Locality 1 | Locality 2 | Locality 3a | Locality 3b | Locality 3c | Locality 3d | Locality 3e | Locality 4 | OutOfBand",
+          "proposed_destination": "one of: Delete | Locality 0 | Locality 1 | Locality 2 | Locality 3a | Locality 3b | Locality 3c | Locality 3d | Locality 3e | Locality 4",
           "deletion_candidate": "string path+snippet | null",
           "rationale": "string",
           "citation": "string artifact path + snippet | null (required when proposed_destination = Delete via redundant-up-the-ladder)",
@@ -391,7 +392,7 @@ The repo has no `.github/instructions/` directory today. Locality 1 mechanism ne
         }
       ]
     }
-    ```
+```
     Phase 3's stub classifier MUST emit all seven always-required fields (`source_file`, `source_section`, `proposed_destination`, `rationale`, `compliance_risk`, `expected_token_efficiency_rank`, `cache_strategy`) — the two conditionally-nullable fields (`deletion_candidate`, `citation`) may be `null` when not applicable. Stub findings are hardcoded; values may be placeholder but the seven required keys are mandatory so the JSON schema validator in Phase 3 acceptance is exercised against the same shape Phase 4 / Phase 7 will rely on.
 - [ ] Progressive disclosure: Phase B / `--apply` mechanics live in `logic/` scripts loaded only when the flow is requested. SKILL.md root stays small.
 - [ ] **CONTEXT.md cascade:** bump `last_updated` in `.github/skills/CONTEXT.md`.
@@ -402,12 +403,12 @@ The repo has no `.github/instructions/` directory today. Locality 1 mechanism ne
 
 - [ ] Replace the Phase 3 stub with the real classifier:
     - `session_store_sql` query templates for friction signals (chronicle commits, repeated user prompts, repeated context loads, hook bypasses, retry loops).
-    - **11-bin classifier** (input: friction signal; output: one of `Delete | Locality 0 | Locality 1 | Locality 2 | Locality 3a | Locality 3b | Locality 3c | Locality 3d | Locality 3e | Locality 4 | OutOfBand` + rationale + `compliance_risk` field + `expected_token_efficiency_rank` field + `cache_strategy` field + suggested artifact path). Output schema matches the Phase 3 canonical JSON block (the `OutOfBand` value is the cross-skill handoff route described below). **Optimization objective (Decision Q5 revised):** for each finding, propose the tier that **minimizes expected token waste across the rule's actual usage pattern**, computed as `(estimated trigger frequency × per-fire cost)`. Not "find the lowest locality number" — find the cheapest *for this rule's expected trigger pattern*. The `compliance_risk` field (Decision Q4 revised) is `"deterministic"` (Locality 0 + Locality 3a/3b/3c/3d) or `"agent-dependent"` (Locality 1, Locality 2, Locality 3e, Locality 4 mechanism-A). Locality 1 demotions inherit Locality-2-equivalent compliance shape — dry-run report MUST surface this for every Locality 1 finding so the reviewer can decide whether the token-cost advantage justifies the compliance dependency. The `cache_strategy` field (Decision Q11) records which skill-corpus indexing strategy generated the finding (`"mtime_first_para"` baseline; `"hybrid_signature"` if Phase 7 retro escalates per K15 upgrade trigger) so successive runs can be diffed to detect late-caught false-negatives. **Locality 1 destination availability assumes CLI behavior verified by reading `app.js`** (no separate gating on Phase 1.5 — that spike measures agent compliance rate, not feature presence). Prompt MUST mention per-context Locality 1 globs (`scripts/kb/**`, `scripts/fleet/**`, `scripts/github_monitor/**`, `scripts/drive_monitor/**`, `scripts/ingest/**`, `scripts/validation/**`, `scripts/reporting/**`, `scripts/maintenance/**`, `scripts/context/**`, `scripts/hooks/**`, `.github/skills/**`, `.github/agents/**`, `wiki/**`, `schema/**`, `docs/decisions/**`, `tests/kb/**`) as **viable destinations the classifier may propose lazily** — but **do not pre-create empty instruction files** (Decision Q8).
+    - **10-bin classifier plus OutOfBand router** (input: friction signal; finding output: one of `Delete | Locality 0 | Locality 1 | Locality 2 | Locality 3a | Locality 3b | Locality 3c | Locality 3d | Locality 3e | Locality 4` + rationale + `compliance_risk` field + `expected_token_efficiency_rank` field + `cache_strategy` field + suggested artifact path). Output schema matches the Phase 3 canonical JSON block; OutOfBand is a separate routing record derived from cross-skill, agent, or prompt `suggested_artifact_path` values rather than a `proposed_destination` enum value. **Optimization objective (Decision Q5 revised):** for each finding, propose the tier that **minimizes expected token waste across the rule's actual usage pattern**, computed as `(estimated trigger frequency × per-fire cost)`. Not "find the lowest locality number" — find the cheapest *for this rule's expected trigger pattern*. The `compliance_risk` field (Decision Q4 revised) is `"deterministic"` (Locality 0 + Locality 3a/3b/3c/3d) or `"agent-dependent"` (Locality 1, Locality 2, Locality 3e, Locality 4 mechanism-A). Locality 1 demotions inherit Locality-2-equivalent compliance shape — dry-run report MUST surface this for every Locality 1 finding so the reviewer can decide whether the token-cost advantage justifies the compliance dependency. The `cache_strategy` field (Decision Q11) records which skill-corpus indexing strategy generated the finding (`"mtime_first_para"` baseline; `"hybrid_signature"` if Phase 7 retro escalates per K15 upgrade trigger) so successive runs can be diffed to detect late-caught false-negatives. **Locality 1 destination availability assumes CLI behavior verified by reading `app.js`** (no separate gating on Phase 1.5 — that spike measures agent compliance rate, not feature presence). Prompt MUST mention per-context Locality 1 globs (`scripts/kb/**`, `scripts/fleet/**`, `scripts/github_monitor/**`, `scripts/drive_monitor/**`, `scripts/ingest/**`, `scripts/validation/**`, `scripts/reporting/**`, `scripts/maintenance/**`, `scripts/context/**`, `scripts/hooks/**`, `.github/skills/**`, `.github/agents/**`, `wiki/**`, `schema/**`, `docs/decisions/**`, `tests/kb/**`) as **viable destinations the classifier may propose lazily** — but **do not pre-create empty instruction files** (Decision Q8).
     - **Hybrid deletion-candidate generator:**
         - **Stale (deterministic):** path/symbol extraction → `git ls-files` / `rg` check; issue ref extraction → `gh issue view --json state`; ADR-supersession walker over `docs/decisions/`.
         - **Redundant-up-the-ladder (LLM judgment with mandatory citation):** loads every lower-locality artifact as comparison corpus; emits redundancy claims only with cited artifact path + snippet. Uncited claims are dropped.
     - **Skill-corpus indexing (Decision Q11):** Cache SKILL.md frontmatter + first paragraph only (not full bodies); refresh on file mtime change. Accepts the false-negative on first pass when a SKILL body changes meaningfully but the first paragraph doesn't — the next chronicle session that surfaces the missed redundancy will catch it. **Document this tradeoff in the SKILL.md `improve` flow contract.**
-    - **Cross-skill suggestions are out-of-band (Decision Q12):** if the classifier identifies a redundancy or demotion target that would require editing another skill's `SKILL.md` or another agent's persona file, the finding is emitted with `proposed_destination: "OutOfBand"` and routes to a framework-engineer handoff. The `--apply` mode refuses to touch cross-skill files.
+    - **Cross-skill suggestions are out-of-band (Decision Q12):** if the classifier identifies a redundancy or demotion target whose `suggested_artifact_path` would require editing another skill's `SKILL.md`, another agent's persona file, or a prompt template, the finding is routed into an `out_of_band_handoffs` record targeting `framework-engineer`. The `--apply` mode refuses to touch cross-skill files.
 - [ ] **Write-surface matrix row — amend with narrow write capability for `--apply` mode** (Decision Q12 blast-radius containment):
     - Path: `.github/skills/audit-knowledgebase-workspace/logic/**`
     - Runtime mode: `read-only only` for `--dry-run` (default); `blocking-only with narrow write capability` for `--apply`
@@ -424,7 +425,7 @@ The repo has no `.github/instructions/` directory today. Locality 1 mechanism ne
 
 - [ ] Insert the override block as the **first H2 under the H1 title**, before any other content section, in **both** `.github/copilot-instructions.md` and `AGENTS.md`. (Slice 2 / #192 has already landed both copies; this Phase 5 entry now governs the position invariant going forward.) Required structure (showing `copilot-instructions.md`; substitute `# AGENTS` for the AGENTS.md copy):
 
-    ```markdown
+```markdown
     # Copilot project instructions
 
     <!-- LOCALITY-0-INVARIANT: This H2 MUST remain the first H2 under the H1. -->
@@ -451,7 +452,7 @@ The repo has no `.github/instructions/` directory today. Locality 1 mechanism ne
     manually.
 
     ## <existing first content section>
-    ```
+```
 
 - [ ] **Pre-commit hook to enforce Locality 0 invariant:** add `scripts/hooks/check_override_block_position.py` that verifies the override block is the first H2 in **both** `copilot-instructions.md` and `AGENTS.md` whenever either file is staged. Wire into `.pre-commit-config.yaml`.
 - [ ] **Write-surface matrix row** for the new hook (`read-only only`; standard hook hard-fail behavior).

--- a/tests/kb/test_audit_workspace_outofband.py
+++ b/tests/kb/test_audit_workspace_outofband.py
@@ -1,0 +1,193 @@
+"""Tests for audit-workspace OutOfBand handoff routing."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from tests.kb.harnesses import load_module
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HANDOFF_PATH = (
+    REPO_ROOT
+    / ".github"
+    / "skills"
+    / "audit-knowledgebase-workspace"
+    / "logic"
+    / "outofband_handoff.py"
+)
+AUDIT_WORKSPACE_PATH = (
+    REPO_ROOT
+    / ".github"
+    / "skills"
+    / "audit-knowledgebase-workspace"
+    / "logic"
+    / "audit_workspace.py"
+)
+
+
+class AuditWorkspaceOutOfBandRoutingTests(TestCase):
+    def _handoff_module(self):
+        return load_module(f"outofband_handoff_{self._testMethodName}", HANDOFF_PATH)
+
+    def _audit_module(self):
+        return load_module(f"audit_workspace_outofband_{self._testMethodName}", AUDIT_WORKSPACE_PATH)
+
+    def _audit_with_write_guards(self, module, **kwargs: object):
+        guarded_calls = (
+            "builtins.open",
+            "pathlib.Path.open",
+            "pathlib.Path.write_text",
+            "pathlib.Path.write_bytes",
+            "pathlib.Path.touch",
+            "pathlib.Path.mkdir",
+            "pathlib.Path.unlink",
+            "pathlib.Path.rename",
+            "pathlib.Path.replace",
+            "os.makedirs",
+            "os.remove",
+            "os.unlink",
+            "os.rename",
+            "os.replace",
+            "shutil.copyfile",
+            "shutil.move",
+            "subprocess.run",
+        )
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(patch(call)) for call in guarded_calls]
+            result = module.audit(**kwargs)
+            for mocked_call in mocks:
+                mocked_call.assert_not_called()
+            return result
+
+    def test_cross_skill_agent_and_prompt_paths_route_to_framework_engineer(self) -> None:
+        module = self._handoff_module()
+
+        for suggested_path in (
+            ".github/skills/context-engineering/SKILL.md",
+            ".github/agents/framework-engineer.md",
+            ".github/prompts/review-plan.prompt.md",
+        ):
+            with self.subTest(suggested_path=suggested_path):
+                routed = module.route_findings(
+                    (self._finding(suggested_artifact_path=suggested_path),),
+                    repo_root=REPO_ROOT,
+                )
+
+                self.assertEqual(routed.eligible_findings, ())
+                self.assertEqual(len(routed.out_of_band_handoffs), 1)
+                record = routed.out_of_band_handoffs[0]
+                self.assertEqual(
+                    set(record),
+                    {
+                        "finding_id",
+                        "source_file",
+                        "source_section",
+                        "suggested_artifact_path",
+                        "rationale",
+                        "target_persona",
+                    },
+                )
+                self.assertTrue(record["finding_id"].startswith("outofband-"))
+                self.assertEqual(record["source_file"], "AGENTS.md")
+                self.assertEqual(record["source_section"], "## Write-surface matrix")
+                self.assertEqual(record["suggested_artifact_path"], suggested_path)
+                self.assertEqual(record["rationale"], self._finding()["rationale"])
+                self.assertEqual(record["target_persona"], "framework-engineer")
+
+    def test_audit_skill_own_directory_remains_eligible_not_outofband(self) -> None:
+        module = self._handoff_module()
+        finding = self._finding(
+            suggested_artifact_path=".github/skills/audit-knowledgebase-workspace/SKILL.md"
+        )
+
+        routed = module.route_findings((finding,), repo_root=REPO_ROOT)
+
+        self.assertEqual(routed.eligible_findings, (finding,))
+        self.assertEqual(routed.out_of_band_handoffs, ())
+
+    def test_subtle_path_variation_resolves_before_cross_skill_classification(self) -> None:
+        module = self._handoff_module()
+
+        routed = module.route_findings(
+            (
+                self._finding(
+                    suggested_artifact_path=(
+                        ".github/skills/audit-knowledgebase-workspace/../"
+                        "context-engineering/SKILL.md"
+                    )
+                ),
+            ),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertEqual(routed.eligible_findings, ())
+        self.assertEqual(
+            routed.out_of_band_handoffs[0]["suggested_artifact_path"],
+            ".github/skills/context-engineering/SKILL.md",
+        )
+
+    def test_unknown_finding_category_fails_closed(self) -> None:
+        module = self._handoff_module()
+
+        with self.assertRaisesRegex(module.OutOfBandRoutingError, "unsupported proposed_destination"):
+            module.route_findings(
+                (self._finding(proposed_destination="Mystery Locality"),),
+                repo_root=REPO_ROOT,
+            )
+
+    def test_orchestrator_summary_includes_outofband_records(self) -> None:
+        module = self._audit_module()
+
+        result = self._audit_with_write_guards(
+            module,
+            repo_root=REPO_ROOT,
+            mode="improve",
+            classifier_findings=(
+                self._finding(
+                    suggested_artifact_path=".github/agents/documentation-engineer.md"
+                ),
+            ),
+        )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.summary["findings"], [])
+        self.assertEqual(result.summary["finding_count"], 0)
+        self.assertEqual(result.summary["out_of_band_handoff_count"], 1)
+        self.assertEqual(
+            result.summary["out_of_band_handoffs"][0]["target_persona"],
+            "framework-engineer",
+        )
+        self.assertEqual(result.summary["writes_attempted"], 0)
+        self.assertTrue(result.summary["read_only"])
+
+    def test_orchestrator_fails_closed_for_malformed_non_string_category(self) -> None:
+        module = self._audit_module()
+
+        result = module.audit(
+            repo_root=REPO_ROOT,
+            mode="improve",
+            classifier_findings=(self._finding(proposed_destination=[]),),
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.reason_code, "invalid_input")
+        self.assertIn("unsupported proposed_destination", result.message)
+
+    @staticmethod
+    def _finding(**overrides: object) -> dict[str, object]:
+        finding: dict[str, object] = {
+            "source_file": "AGENTS.md",
+            "source_section": "## Write-surface matrix",
+            "proposed_destination": "Locality 2",
+            "rationale": "Cross-skill guidance belongs with its owning framework surface.",
+            "compliance_risk": "agent-dependent",
+            "expected_token_efficiency_rank": 2,
+            "cache_strategy": "mtime_first_para",
+            "suggested_artifact_path": ".github/skills/context-engineering/SKILL.md",
+        }
+        finding.update(overrides)
+        return finding


### PR DESCRIPTION
## Summary
- Add read-only OutOfBand routing for audit-workspace findings targeting other skills, agents, or prompts.
- Emit deterministic `framework-engineer` handoff records in the `audit_workspace` SurfaceResult summary without invoking target personas or attempting writes.
- Close slice 9c in the audit-workspace improve-flow plan while leaving 9a allowlists and 9b lock acquisition deferred.

## Verification
- `python3 .github/skills/audit-knowledgebase-workspace/logic/audit_workspace.py --mode improve`
- `python3 -m pytest tests/kb/test_audit_workspace_outofband.py -v`
- `python3 .github/skills/documentation-and-adrs/logic/validate_doc_batch.py --path docs/ideas/audit-workspace-improve-flow.md`
- `python3 -m pytest tests/kb -v -k "routing or handoff or outofband"`
- `python3 -m pytest tests/kb/test_audit_workspace.py tests/kb/test_docs_ideas_archival.py tests/kb/test_framework_write_surface_matrix.py -q`

Closes #210.
