### PR TITLE
refactor(fleet): extract shared output helpers

### DIFF
--- a/scripts/fleet/_fleet_output.ts
+++ b/scripts/fleet/_fleet_output.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  getSanitizedErrorMessage,
+  MutationFailureError,
+  PreflightFailureError,
+  type SanitizedErrorEnvelope,
+} from "./github/mutation-diagnostics.js";
+
+export interface FleetFatalMessages {
+  preflight: string;
+  mutation: string;
+  genericPrefix: string;
+}
+
+export function logMutationAttemptFailure(
+  message: string,
+  envelope: SanitizedErrorEnvelope
+): void {
+  console.error(message);
+  console.error(JSON.stringify(envelope));
+}
+
+export function handleFleetFatalError(
+  error: unknown,
+  messages: FleetFatalMessages
+): never {
+  if (error instanceof PreflightFailureError) {
+    console.error(messages.preflight);
+    console.error(JSON.stringify(error.envelope));
+    process.exit(1);
+  }
+
+  if (error instanceof MutationFailureError) {
+    console.error(messages.mutation);
+    console.error(JSON.stringify(error.terminalEnvelope));
+    process.exit(1);
+  }
+
+  console.error(`${messages.genericPrefix}${getSanitizedErrorMessage(error)}`);
+  process.exit(1);
+}

--- a/scripts/fleet/fleet-dispatch.ts
+++ b/scripts/fleet/fleet-dispatch.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import path from "node:path";
-import { findUpSync } from "find-up";
 import { Octokit } from "octokit";
 import type { IssueAnalysis } from "./types.js";
 import { jules } from "@google/jules-sdk";
@@ -23,13 +22,16 @@ import {
   assertMutationPreflight,
   getSanitizedErrorMessage,
   MUTATION_EXECUTION_CONTRACT,
-  MutationFailureError,
   PreflightFailureError,
   resolveMutationMaxAttempts,
   runMutationWithDiagnostics,
 } from "./github/mutation-diagnostics.js";
 import { validateTaskOwnership } from "./github/task-manifest-validation.js";
-import { resolveFleetDir } from "./github/fleet-paths.js";
+import { findFleetRepoRoot, resolveFleetDir } from "./github/fleet-paths.js";
+import {
+  handleFleetFatalError,
+  logMutationAttemptFailure,
+} from "./_fleet_output.js";
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -104,7 +106,7 @@ export async function main(): Promise<void> {
       .format(new Date())
       .replaceAll("-", "_");
 
-  const root = path.dirname(findUpSync(".git", { type: "directory" })!);
+  const root = findFleetRepoRoot();
   let fleetDir: string;
   try {
     fleetDir = resolveFleetDir(root, date);
@@ -153,8 +155,10 @@ export async function main(): Promise<void> {
             },
           }),
         onAttemptFailure: (envelope) => {
-          console.error(`⚠️ Jules dispatch mutation attempt failed for task "${task.id}".`);
-          console.error(JSON.stringify(envelope));
+          logMutationAttemptFailure(
+            `⚠️ Jules dispatch mutation attempt failed for task "${task.id}".`,
+            envelope
+          );
         },
       });
 
@@ -201,20 +205,11 @@ export async function main(): Promise<void> {
 }
 
 export function handleFatalError(error: unknown): never {
-  if (error instanceof PreflightFailureError) {
-    console.error("❌ Fleet dispatch preflight failed.");
-    console.error(JSON.stringify(error.envelope));
-    process.exit(1);
-  }
-
-  if (error instanceof MutationFailureError) {
-    console.error("❌ Jules dispatch mutation hard-failed after bounded retries.");
-    console.error(JSON.stringify(error.terminalEnvelope));
-    process.exit(1);
-  }
-
-  console.error(`❌ Fleet dispatch failed: ${getSanitizedErrorMessage(error)}`);
-  process.exit(1);
+  return handleFleetFatalError(error, {
+    preflight: "❌ Fleet dispatch preflight failed.",
+    mutation: "❌ Jules dispatch mutation hard-failed after bounded retries.",
+    genericPrefix: "❌ Fleet dispatch failed: ",
+  });
 }
 
 if (import.meta.main) {

--- a/scripts/fleet/fleet-merge.ts
+++ b/scripts/fleet/fleet-merge.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import path from "node:path";
-import { findUpSync } from "find-up";
 import type { IssueAnalysis, Task } from "./types.js";
 import { branchExists, getCurrentBranch, getGitRepoInfo } from "./github/git.js";
 import { jules } from "@google/jules-sdk";
@@ -22,7 +21,6 @@ import {
   assertMutationPreflight,
   getSanitizedErrorMessage,
   MUTATION_EXECUTION_CONTRACT,
-  MutationFailureError,
   PreflightFailureError,
   resolveMutationMaxAttempts,
   runMutationWithDiagnostics,
@@ -38,7 +36,11 @@ import {
   requireRedispatchAuthorLogin,
   resolveUpdateBranchFailure,
 } from "./github/merge-runtime.js";
-import { resolveFleetDir } from "./github/fleet-paths.js";
+import { findFleetRepoRoot, resolveFleetDir } from "./github/fleet-paths.js";
+import {
+  handleFleetFatalError,
+  logMutationAttemptFailure,
+} from "./_fleet_output.js";
 
 interface GitHubPR {
   number: number;
@@ -117,7 +119,7 @@ export async function main(): Promise<void> {
       .format(new Date())
       .replaceAll("-", "_");
 
-  const root = path.dirname(findUpSync(".git", { type: "directory" })!);
+  const root = findFleetRepoRoot();
   let fleetDir: string;
   try {
     fleetDir = resolveFleetDir(root, date);
@@ -187,8 +189,10 @@ export async function main(): Promise<void> {
           },
         }),
       onAttemptFailure: (envelope) => {
-        console.error(`⚠️ Jules re-dispatch mutation attempt failed for task "${task.id}".`);
-        console.error(JSON.stringify(envelope));
+        logMutationAttemptFailure(
+          `⚠️ Jules re-dispatch mutation attempt failed for task "${task.id}".`,
+          envelope
+        );
       },
     });
     console.log(`  📝 New session: ${run.id}`);
@@ -325,20 +329,11 @@ export async function main(): Promise<void> {
 }
 
 export function handleFatalError(error: unknown): never {
-  if (error instanceof PreflightFailureError) {
-    console.error("❌ Fleet merge preflight failed.");
-    console.error(JSON.stringify(error.envelope));
-    process.exit(1);
-  }
-
-  if (error instanceof MutationFailureError) {
-    console.error("❌ Jules merge re-dispatch hard-failed after bounded retries.");
-    console.error(JSON.stringify(error.terminalEnvelope));
-    process.exit(1);
-  }
-
-  console.error(`❌ Fleet merge failed: ${getSanitizedErrorMessage(error)}`);
-  process.exit(1);
+  return handleFleetFatalError(error, {
+    preflight: "❌ Fleet merge preflight failed.",
+    mutation: "❌ Jules merge re-dispatch hard-failed after bounded retries.",
+    genericPrefix: "❌ Fleet merge failed: ",
+  });
 }
 
 if (import.meta.main) {

--- a/scripts/fleet/fleet-plan.ts
+++ b/scripts/fleet/fleet-plan.ts
@@ -20,13 +20,15 @@ import { branchExists, getGitRepoInfo, getCurrentBranch } from "./github/git.js"
 import { assertFleetEnvironment } from "./env.js";
 import {
   assertMutationPreflight,
-  getSanitizedErrorMessage,
   MUTATION_EXECUTION_CONTRACT,
-  MutationFailureError,
   PreflightFailureError,
   resolveMutationMaxAttempts,
   runMutationWithDiagnostics,
 } from "./github/mutation-diagnostics.js";
+import {
+  handleFleetFatalError,
+  logMutationAttemptFailure,
+} from "./_fleet_output.js";
 
 export async function main(): Promise<void> {
   assertFleetEnvironment({
@@ -84,8 +86,7 @@ export async function main(): Promise<void> {
         },
       }),
     onAttemptFailure: (envelope) => {
-      console.error("⚠️ Jules planning mutation attempt failed.");
-      console.error(JSON.stringify(envelope));
+      logMutationAttemptFailure("⚠️ Jules planning mutation attempt failed.", envelope);
     },
   });
 
@@ -99,20 +100,11 @@ export async function main(): Promise<void> {
 }
 
 export function handleFatalError(error: unknown): never {
-  if (error instanceof PreflightFailureError) {
-    console.error("❌ Fleet planning preflight failed.");
-    console.error(JSON.stringify(error.envelope));
-    process.exit(1);
-  }
-
-  if (error instanceof MutationFailureError) {
-    console.error("❌ Jules planning mutation hard-failed after bounded retries.");
-    console.error(JSON.stringify(error.terminalEnvelope));
-    process.exit(1);
-  }
-
-  console.error(`❌ Fleet planning failed: ${getSanitizedErrorMessage(error)}`);
-  process.exit(1);
+  return handleFleetFatalError(error, {
+    preflight: "❌ Fleet planning preflight failed.",
+    mutation: "❌ Jules planning mutation hard-failed after bounded retries.",
+    genericPrefix: "❌ Fleet planning failed: ",
+  });
 }
 
 if (import.meta.main) {

--- a/scripts/fleet/github/fleet-paths.test.ts
+++ b/scripts/fleet/github/fleet-paths.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
 import path from "node:path";
-import { resolveFleetDir } from "./fleet-paths.ts";
+import { findFleetRepoRoot, resolveFleetDir } from "./fleet-paths.ts";
+
+const TEST_WORKDIR_ROOT = path.resolve(import.meta.dir, "..", ".test-workdirs");
+
+function withRepoFixture(
+  name: string,
+  setupGitEntry: (repoRoot: string) => void,
+  assertFixture: (nestedPath: string, repoRoot: string) => void
+): void {
+  const repoRoot = path.join(
+    TEST_WORKDIR_ROOT,
+    `${name}-${process.pid}-${Date.now()}`
+  );
+  const nestedPath = path.join(repoRoot, "scripts", "fleet");
+  fs.mkdirSync(nestedPath, { recursive: true });
+  setupGitEntry(repoRoot);
+
+  try {
+    assertFixture(nestedPath, repoRoot);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+    try {
+      fs.rmdirSync(TEST_WORKDIR_ROOT);
+    } catch {
+      // Another fixture may still be using the shared test workdir root.
+    }
+  }
+}
 
 describe("resolveFleetDir", () => {
   test("returns fleet date directory for valid date format", () => {
@@ -19,3 +47,28 @@ describe("resolveFleetDir", () => {
   });
 });
 
+describe("findFleetRepoRoot", () => {
+  test("resolves standard checkouts where .git is a directory", () => {
+    withRepoFixture(
+      "git-directory",
+      (repoRoot) => {
+        fs.mkdirSync(path.join(repoRoot, ".git"));
+      },
+      (nestedPath, repoRoot) => {
+        expect(findFleetRepoRoot(nestedPath)).toBe(repoRoot);
+      }
+    );
+  });
+
+  test("resolves linked worktrees where .git is a file", () => {
+    withRepoFixture(
+      "git-file",
+      (repoRoot) => {
+        fs.writeFileSync(path.join(repoRoot, ".git"), "gitdir: ../.git/worktrees/example\n");
+      },
+      (nestedPath, repoRoot) => {
+        expect(findFleetRepoRoot(nestedPath)).toBe(repoRoot);
+      }
+    );
+  });
+});

--- a/scripts/fleet/github/fleet-paths.ts
+++ b/scripts/fleet/github/fleet-paths.ts
@@ -12,9 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import fs from "node:fs";
 import path from "node:path";
 
 const FLEET_DATE_PATTERN = /^\d{4}_\d{2}_\d{2}$/;
+
+export function findFleetRepoRoot(startDirectory?: string): string {
+  let currentDirectory = path.resolve(startDirectory ?? process.cwd());
+
+  while (true) {
+    const gitPath = path.join(currentDirectory, ".git");
+    if (fs.existsSync(gitPath)) {
+      const gitEntry = fs.statSync(gitPath);
+      if (gitEntry.isFile() || gitEntry.isDirectory()) {
+        return currentDirectory;
+      }
+    }
+
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error("Unable to locate repository root from .git.");
+    }
+    currentDirectory = parentDirectory;
+  }
+}
 
 export function resolveFleetDir(root: string, fleetDate: string): string {
   if (!FLEET_DATE_PATTERN.test(fleetDate)) {
@@ -34,4 +55,3 @@ export function resolveFleetDir(root: string, fleetDate: string): string {
 
   return fleetDir;
 }
-


### PR DESCRIPTION
## Summary
- Extract shared fleet diagnostic/fatal output helpers into `scripts/fleet/_fleet_output.ts`
- Update plan/dispatch/merge entrypoints to use the helper without changing mutation envelope fields
- Add repo-root discovery support/tests for both standard `.git` directories and linked-worktree `.git` files so fleet tests pass in isolated worktrees

Closes #244

## Verification
- `cd scripts/fleet && bun install`
- `cd scripts/fleet && bun build --target bun fleet-plan.ts fleet-dispatch.ts fleet-merge.ts fleet-analyze.ts --outdir dist`
- `cd scripts/fleet && bun test` (85 pass, 0 fail)
