### PR TITLE
test: verify extract_frontmatter byte contract and update docstring

### DIFF
--- a/scripts/kb/page_template_utils.py
+++ b/scripts/kb/page_template_utils.py
@@ -127,7 +127,8 @@ def extract_frontmatter(text: str) -> tuple[str | None, str]:
     """Extract a YAML frontmatter block and the body from a markdown document.
 
     Returns a tuple of (frontmatter, body). If no frontmatter block is found,
-    returns (None, original_text).
+    returns (None, original_text). The original body bytes (including CRLF and
+    trailing newlines) are preserved verbatim.
     """
     if not text.lstrip(" \t").startswith("---"):
         return None, text

--- a/scripts/kb/page_template_utils.py
+++ b/scripts/kb/page_template_utils.py
@@ -127,7 +127,7 @@ def extract_frontmatter(text: str) -> tuple[str | None, str]:
     """Extract a YAML frontmatter block and the body from a markdown document.
 
     Returns a tuple of (frontmatter, body). If no frontmatter block is found,
-    returns (None, original_text). The original body bytes (including CRLF and
+    returns (None, original_text). The original body characters (including CRLF and
     trailing newlines) are preserved verbatim.
     """
     if not text.lstrip(" \t").startswith("---"):

--- a/tests/kb/test_extract_frontmatter.py
+++ b/tests/kb/test_extract_frontmatter.py
@@ -1,0 +1,25 @@
+import unittest
+from scripts.kb.page_template_utils import extract_frontmatter
+
+class TestExtractFrontmatter(unittest.TestCase):
+
+    def test_extract_frontmatter_cases(self):
+        cases = [
+            ("Happy LF", "---\nfm\n---\nbody\n", "fm", "body\n"),
+            ("Happy CRLF", "---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
+            ("Leading whitespace", "  ---\nfm\n---\nbody", "fm", "body"),
+            ("Empty frontmatter", "---\n---\nbody\n", "", "body\n"),
+            ("No frontmatter pass-through", "no frontmatter\n", None, "no frontmatter\n"),
+            ("Unclosed delim", "---\nunclosed\nbody\n", None, "---\nunclosed\nbody\n"),
+            ("mid-body", "---\nfm\n---\nbody\n---\nmore\n", "fm", "body\n---\nmore\n"),
+            ("File ending at closing delim", "---\nfm\n---", "fm", ""),
+        ]
+
+        for name, text, expected_fm, expected_body in cases:
+            with self.subTest(name=name):
+                fm, body = extract_frontmatter(text)
+                self.assertEqual(fm, expected_fm)
+                self.assertEqual(body, expected_body)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/kb/test_extract_frontmatter.py
+++ b/tests/kb/test_extract_frontmatter.py
@@ -1,25 +1,20 @@
-import unittest
+import pytest
 from scripts.kb.page_template_utils import extract_frontmatter
 
-class TestExtractFrontmatter(unittest.TestCase):
-
-    def test_extract_frontmatter_cases(self):
-        cases = [
-            ("Happy LF", "---\nfm\n---\nbody\n", "fm", "body\n"),
-            ("Happy CRLF", "---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
-            ("Leading whitespace", "  ---\nfm\n---\nbody", "fm", "body"),
-            ("Empty frontmatter", "---\n---\nbody\n", "", "body\n"),
-            ("No frontmatter pass-through", "no frontmatter\n", None, "no frontmatter\n"),
-            ("Unclosed delim", "---\nunclosed\nbody\n", None, "---\nunclosed\nbody\n"),
-            ("mid-body", "---\nfm\n---\nbody\n---\nmore\n", "fm", "body\n---\nmore\n"),
-            ("File ending at closing delim", "---\nfm\n---", "fm", ""),
-        ]
-
-        for name, text, expected_fm, expected_body in cases:
-            with self.subTest(name=name):
-                fm, body = extract_frontmatter(text)
-                self.assertEqual(fm, expected_fm)
-                self.assertEqual(body, expected_body)
-
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize(
+    "name, text, expected_fm, expected_body",
+    [
+        ("Happy LF", "---\nfm\n---\nbody\n", "fm", "body\n"),
+        ("Happy CRLF", "---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
+        ("Leading whitespace", "  ---\nfm\n---\nbody", "fm", "body"),
+        ("Empty frontmatter", "---\n---\nbody\n", "", "body\n"),
+        ("No frontmatter pass-through", "no frontmatter\n", None, "no frontmatter\n"),
+        ("Unclosed delim", "---\nunclosed\nbody\n", None, "---\nunclosed\nbody\n"),
+        ("mid-body", "---\nfm\n---\nbody\n---\nmore\n", "fm", "body\n---\nmore\n"),
+        ("File ending at closing delim", "---\nfm\n---", "fm", ""),
+    ]
+)
+def test_extract_frontmatter_cases(name, text, expected_fm, expected_body):
+    fm, body = extract_frontmatter(text)
+    assert fm == expected_fm
+    assert body == expected_body


### PR DESCRIPTION
Added unit tests and clarified docstring to strictly verify and define the byte-level contract for the `extract_frontmatter` parser.

---
*PR created automatically by Jules for task [4114211118562511535](https://jules.google.com/task/4114211118562511535) started by @wryenmeek*