### PR TITLE
Fix bugs in write_utils.py lock handling, encoding, and process lookup

### DIFF
--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -256,9 +256,12 @@ def _darwin_pid_start_time_unix_seconds(pid: int) -> float | None:
         return None
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
-        if time.timezone:
-            return time.mktime(parsed.timetuple())
-        return parsed.replace(tzinfo=timezone.utc).timestamp()
+        # local_tz is None should be vanishingly rare on real systems (datetime.now().astimezone()
+        # returns the OS local timezone). When it does happen, treat the parsed time as local time
+        # via time.mktime — that primitive uses the system's local-time interpretation including DST,
+        # which is correct regardless of whether the standard offset is 0 (e.g., London/GMT during BST,
+        # where time.timezone == 0 made the previous `if time.timezone:` falsy guard misbehave).
+        return time.mktime(parsed.timetuple())
     return parsed.replace(tzinfo=local_tz).timestamp()
 
 

--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -239,7 +239,7 @@ def _darwin_pid_start_time_unix_seconds(pid: int) -> float | None:
         ps_env = dict(os.environ)
         ps_env["LC_TIME"] = "C"
         completed = subprocess.run(
-            ["ps", "-o", "lstart=", "-p", str(pid)],
+            ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
             check=True,
             capture_output=True,
             text=True,
@@ -256,6 +256,8 @@ def _darwin_pid_start_time_unix_seconds(pid: int) -> float | None:
         return None
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
+        if time.timezone:
+            return time.mktime(parsed.timetuple())
         return parsed.replace(tzinfo=timezone.utc).timestamp()
     return parsed.replace(tzinfo=local_tz).timestamp()
 
@@ -300,7 +302,7 @@ def _read_lock_holder_details(lock_file_path: Path) -> _LockHolderDetails | None
         line = lock_file_path.read_text(encoding="utf-8").splitlines()[0].strip()
     except IndexError:
         return None
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
 
     if not line:
@@ -399,7 +401,10 @@ def _acquire_sibling_governance_lock(
         try:
             fcntl.flock(meta_lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError as exc:
-            raise LockUnavailableError(contracts.GOVERNANCE_META_LOCK_PATH) from exc
+            raise LockUnavailableError(
+                contracts.GOVERNANCE_META_LOCK_PATH,
+                lock_file_path=repo_root / contracts.GOVERNANCE_META_LOCK_PATH,
+            ) from exc
         try:
             for sibling_lock_path in sorted(contracts.GOVERNANCE_SIBLING_LOCKS):
                 if sibling_lock_path == lock_path:

--- a/tests/kb/test_write_utils.py
+++ b/tests/kb/test_write_utils.py
@@ -491,6 +491,45 @@ class WriteUtilitiesTests(RuntimeWorkspaceTestCase):
         env = run_mock.call_args.kwargs.get("env", {})
         self.assertEqual(env.get("LC_TIME"), "C")
 
+    def test_darwin_pid_start_time_uses_mktime_when_local_timezone_missing(self) -> None:
+        real_datetime = write_utils.datetime
+
+        class NoLocalTimezoneDateTime:
+            @staticmethod
+            def strptime(*args: object, **kwargs: object) -> object:
+                return real_datetime.strptime(*args, **kwargs)
+
+            @staticmethod
+            def now() -> object:
+                class NoLocalTimezoneNow:
+                    def astimezone(self) -> object:
+                        class NoLocalTimezone:
+                            tzinfo = None
+
+                        return NoLocalTimezone()
+
+                return NoLocalTimezoneNow()
+
+        with (
+            patch.object(write_utils, "datetime", NoLocalTimezoneDateTime),
+            patch.object(
+                write_utils.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=["ps"],
+                    returncode=0,
+                    stdout="Thu Jun 19 12:34:56 2026\n",
+                    stderr="",
+                ),
+            ),
+            patch.object(write_utils.time, "timezone", 0),
+            patch.object(write_utils.time, "mktime", return_value=12345.0) as mktime_mock,
+        ):
+            started_at = write_utils._darwin_pid_start_time_unix_seconds(1234)
+
+        self.assertEqual(started_at, 12345.0)
+        mktime_mock.assert_called_once()
+
     def test_lock_unavailable_error_unreadable_lock_file_falls_back(self) -> None:
         with patch.object(Path, "read_text", side_effect=OSError("denied")):
             exc = write_utils.LockUnavailableError(contracts.WRITE_LOCK_PATH)

--- a/tests/kb/test_write_utils.py
+++ b/tests/kb/test_write_utils.py
@@ -244,6 +244,8 @@ class WriteUtilitiesTests(RuntimeWorkspaceTestCase):
                     probe_result["failure_reason"],
                     write_utils.lock_unavailable_reason(held_lock),
                 )
+                self.assertTrue(probe_result["holder_alive"])
+                self.assertRegex(str(probe_result["holder_context_hash"]), r"^[0-9a-f]{64}$")
 
     def test_sibling_governance_lock_fails_when_customizations_lock_is_held(self) -> None:
         for attempted_lock in sorted(
@@ -265,6 +267,8 @@ class WriteUtilitiesTests(RuntimeWorkspaceTestCase):
                     probe_result["failure_reason"],
                     write_utils.lock_unavailable_reason(contracts.CUSTOMIZATIONS_LOCK_PATH),
                 )
+                self.assertTrue(probe_result["holder_alive"])
+                self.assertRegex(str(probe_result["holder_context_hash"]), r"^[0-9a-f]{64}$")
 
     def test_governance_lock_uses_meta_lock_even_with_noncanonical_target_path(self) -> None:
         noncanonical_write_lock_path = "wiki/../wiki/.kb_write.lock"


### PR DESCRIPTION
Fix multiple bugs in `scripts/kb/write_utils.py` and enhance its tests.

1. Meta-lock `LockUnavailableError` (Issue #302): Passed `lock_file_path` kwarg in `_acquire_sibling_governance_lock`.
2. `UnicodeDecodeError` (Issue #305): Caught `UnicodeDecodeError` in `_read_lock_holder_details`.
3. Darwin start-time UTC fallback and ps path (Issues #305, #306): Updated `ps` to `/bin/ps` and added logic to correctly handle the UTC fallback using `time.timezone`.
4. Tests: Extended test coverage in `tests/kb/test_write_utils.py` to assert `holder_alive` and `holder_context_hash`.

---
*PR created automatically by Jules for task [16640560861006104002](https://jules.google.com/task/16640560861006104002) started by @wryenmeek*