### PR TITLE
Fix truthiness bypass bug in fleet archive-stale-sessions.ts

### DIFF
--- a/scripts/fleet/archive-stale-sessions.test.ts
+++ b/scripts/fleet/archive-stale-sessions.test.ts
@@ -133,6 +133,16 @@ describe("parseCliArgs", () => {
     expect(args.sourceFilter).toBe("sources/github/myorg/myrepo");
   });
 
+  test("trims copy-paste whitespace from --source-filter", () => {
+    const args = parseCliArgs([
+      "--older-than-days",
+      "3",
+      "--source-filter",
+      "  sources/github/myorg/myrepo\n",
+    ]);
+    expect(args.sourceFilter).toBe("sources/github/myorg/myrepo");
+  });
+
   test("--apply with whitespace-only --source-filter is denied", () => {
     expect(() =>
       parseCliArgs(["--older-than-days", "7", "--source-filter", "   ", "--apply"])

--- a/scripts/fleet/archive-stale-sessions.test.ts
+++ b/scripts/fleet/archive-stale-sessions.test.ts
@@ -133,6 +133,18 @@ describe("parseCliArgs", () => {
     expect(args.sourceFilter).toBe("sources/github/myorg/myrepo");
   });
 
+  test("--apply with whitespace-only --source-filter is denied", () => {
+    expect(() =>
+      parseCliArgs(["--older-than-days", "7", "--source-filter", "   ", "--apply"])
+    ).toThrow("--source-filter requires a non-empty value");
+  });
+
+  test("--apply with empty --source-filter is denied", () => {
+    expect(() =>
+      parseCliArgs(["--older-than-days", "7", "--source-filter", "", "--apply"])
+    ).toThrow("--source-filter requires a non-empty value");
+  });
+
   test("parses --apply flag with --repo current", () => {
     const args = parseCliArgs([
       "--older-than-days",

--- a/scripts/fleet/archive-stale-sessions.ts
+++ b/scripts/fleet/archive-stale-sessions.ts
@@ -120,10 +120,12 @@ export function parseCliArgs(argv: string[]): ArchiveCliArgs {
       olderThanDays = parsed;
     } else if (arg === "--source-filter") {
       const value = argv[++i];
-      if (value === undefined || value.trim().length === 0) {
+      const trimmedValue = value?.trim();
+      if (trimmedValue === undefined || trimmedValue.length === 0) {
         throw new Error("--source-filter requires a non-empty value");
       }
-      sourceFilter = value;
+      // Trim defensively so copy-paste whitespace does not break exact source matching.
+      sourceFilter = trimmedValue;
     } else if (arg === "--repo" && argv[i + 1]) {
       const repoVal = argv[++i];
       if (repoVal === "current") {

--- a/scripts/fleet/archive-stale-sessions.ts
+++ b/scripts/fleet/archive-stale-sessions.ts
@@ -120,12 +120,11 @@ export function parseCliArgs(argv: string[]): ArchiveCliArgs {
       olderThanDays = parsed;
     } else if (arg === "--source-filter") {
       const value = argv[++i];
-      const trimmedValue = value?.trim();
-      if (trimmedValue === undefined || trimmedValue.length === 0) {
+      if (value === undefined || value.trim().length === 0) {
         throw new Error("--source-filter requires a non-empty value");
       }
-      // Trim defensively so copy-paste whitespace does not break exact source matching.
-      sourceFilter = trimmedValue;
+      // Trim to defend against accidental copy-paste whitespace
+      sourceFilter = value.trim();
     } else if (arg === "--repo" && argv[i + 1]) {
       const repoVal = argv[++i];
       if (repoVal === "current") {

--- a/scripts/fleet/archive-stale-sessions.ts
+++ b/scripts/fleet/archive-stale-sessions.ts
@@ -118,8 +118,12 @@ export function parseCliArgs(argv: string[]): ArchiveCliArgs {
         );
       }
       olderThanDays = parsed;
-    } else if (arg === "--source-filter" && argv[i + 1]) {
-      sourceFilter = argv[++i];
+    } else if (arg === "--source-filter") {
+      const value = argv[++i];
+      if (value === undefined || value.trim().length === 0) {
+        throw new Error("--source-filter requires a non-empty value");
+      }
+      sourceFilter = value;
     } else if (arg === "--repo" && argv[i + 1]) {
       const repoVal = argv[++i];
       if (repoVal === "current") {

--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -256,7 +256,13 @@ def _darwin_pid_start_time_unix_seconds(pid: int) -> float | None:
         return None
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
-        return parsed.replace(tzinfo=timezone.utc).timestamp()
+        # local_tz is None should be vanishingly rare on real systems
+        # (datetime.now().astimezone() returns the OS local timezone). When it
+        # does happen, treat the parsed time as local time via time.mktime —
+        # that primitive uses the system's local-time interpretation including
+        # DST, which is correct regardless of whether the standard offset is 0
+        # (e.g., London/GMT during BST).
+        return time.mktime(parsed.timetuple())
     return parsed.replace(tzinfo=local_tz).timestamp()
 
 

--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -256,13 +256,7 @@ def _darwin_pid_start_time_unix_seconds(pid: int) -> float | None:
         return None
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
-        # local_tz is None should be vanishingly rare on real systems
-        # (datetime.now().astimezone() returns the OS local timezone). When it
-        # does happen, treat the parsed time as local time via time.mktime —
-        # that primitive uses the system's local-time interpretation including
-        # DST, which is correct regardless of whether the standard offset is 0
-        # (e.g., London/GMT during BST).
-        return time.mktime(parsed.timetuple())
+        return parsed.replace(tzinfo=timezone.utc).timestamp()
     return parsed.replace(tzinfo=local_tz).timestamp()
 
 


### PR DESCRIPTION
Fixes an issue where whitespace-only CLI arguments could bypass validation checks in the stale session archiving script.

---
*PR created automatically by Jules for task [3797964699308059677](https://jules.google.com/task/3797964699308059677) started by @wryenmeek*