### PR TITLE
docs(adr): polish ADR-030/031/032 cross-links

### DIFF
--- a/docs/decisions/ADR-005-write-concurrency-guards.md
+++ b/docs/decisions/ADR-005-write-concurrency-guards.md
@@ -62,7 +62,11 @@ Lock contention must fail closed, return non-zero, and emit
 
 ## Related decisions
 
-- [ADR-031](ADR-031-lock-holder-pid-tracking.md) - Lock holder PID/start-time tracking for lock-unavailable UX
+- [`ADR-031`](ADR-031-lock-holder-pid-tracking.md) — Extends the
+  `lock_unavailable` envelope with `holder_pid`, `holder_alive`,
+  `holder_started_at`, and `holder_context_hash` so operators can
+  distinguish active lock holders from stale metadata while preserving
+  `ADR-005` fail-closed semantics.
 
 ## References
 

--- a/docs/decisions/ADR-019-fleet-jules-orchestration.md
+++ b/docs/decisions/ADR-019-fleet-jules-orchestration.md
@@ -258,7 +258,9 @@ archiving, re-run the account probe (`jules-account-probe.ts`) to confirm
 
 ## Related decisions
 
-- [ADR-032](ADR-032-fleet-quota-saturation-soft-warn.md) - Fleet quota-saturation soft-warn exit code for bare FAILED_PRECONDITION
+- [`ADR-032`](ADR-032-fleet-quota-saturation-soft-warn.md) — Extends
+  fleet error routing with the `quota_saturation` classification and
+  exit-0 soft-warn behavior for transient Jules session quota saturation.
 
 ## Amendment 3
 

--- a/docs/decisions/ADR-022-afk-uses-scripts-hitl-uses-copilot-cli.md
+++ b/docs/decisions/ADR-022-afk-uses-scripts-hitl-uses-copilot-cli.md
@@ -106,3 +106,9 @@ AFK advisory workflows (Tier 2):
 **What changed:** Initial decision framed this as a binary (AFK = scripts, HITL = Copilot CLI). Grilling surfaced that ADR-014 §4 AFK-allowlists several read-only advisory skills (`suggest-backlinks`, `cross-reference-symmetry-check`, etc.) that require LM judgment but produce no writes. These cannot be handled by deterministic scripts and are not HITL (no human gates each finding). Added Tier 2 "AFK advisory pass" to model this class.
 
 **What didn't change:** The Tier 1 rule — Python scripts, not Copilot CLI, for AFK writes — is unchanged. `validate_afk_output.py` remains the gate for any Tier 1 write.
+
+## Related decisions
+
+- [`ADR-030`](ADR-030-cli-write-confirmation.md) — Keeps the deterministic script
+  write path's explicit `--apply` confirmation ceremony aligned with the
+  AFK/HITL executor boundary this ADR defines.

--- a/docs/decisions/ADR-030-cli-write-confirmation.md
+++ b/docs/decisions/ADR-030-cli-write-confirmation.md
@@ -93,8 +93,12 @@ Rollback:
 
 ## Related decisions
 
-- [ADR-005](ADR-005-write-concurrency-guards.md) - Enforce write concurrency with workflow group and local file lock
-- [ADR-022](ADR-022-afk-uses-scripts-hitl-uses-copilot-cli.md) - AFK automation uses deterministic scripts; Copilot CLI reserved for HITL
+- [`ADR-005`](ADR-005-write-concurrency-guards.md) — Write-capable
+  optional-surface commands still acquire declared locks before `--apply`
+  writes; the flag migration does not weaken lock requirements.
+- [`ADR-022`](ADR-022-afk-uses-scripts-hitl-uses-copilot-cli.md) — Keeps
+  AFK write automation in deterministic scripts while preserving Copilot CLI
+  for HITL; `--apply` is the script-side confirmation ceremony.
 
 ## References
 

--- a/docs/decisions/ADR-031-lock-holder-pid-tracking.md
+++ b/docs/decisions/ADR-031-lock-holder-pid-tracking.md
@@ -76,8 +76,7 @@ change does not alter governed artifact contracts.
 - [`ADR-005`](ADR-005-write-concurrency-guards.md) — Enforce write
   concurrency with workflow group and local file lock. This ADR extends
   `ADR-005`'s `lock_unavailable` envelope with holder PID/start-time metadata
-  for actionable diagnostics. `ADR-005`'s status was updated to reflect the
-  bidirectional cross-reference (2026-06-20).
+  for actionable diagnostics.
 
 ## References
 

--- a/docs/decisions/ADR-031-lock-holder-pid-tracking.md
+++ b/docs/decisions/ADR-031-lock-holder-pid-tracking.md
@@ -55,7 +55,9 @@ Adopt Resolution A:
 - `SurfaceResult` consumers can branch on structured holder context.
 - Change applies uniformly across all lock-path variants that use
   `exclusive_write_lock()`.
-- The `holder_context_hash` preserves context privacy by not exposing raw PIDs in unauthenticated logging surfaces.
+- The `holder_context_hash` privacy trade-off is explicit: callers get a
+  stable SHA-256 fingerprint over raw PID/start-time context without leaking
+  the PID or process start time into unauthenticated logging surfaces.
 
 ### Trade-offs
 
@@ -71,7 +73,11 @@ change does not alter governed artifact contracts.
 
 ## Related decisions
 
-- [ADR-005](ADR-005-write-concurrency-guards.md) — Enforce write concurrency with workflow group and local file lock. This ADR extends ADR-005's `lock_unavailable` envelope with holder PID/start-time metadata for actionable diagnostics. ADR-005's status was updated to reflect the bidirectional cross-reference (2026-06-20).
+- [`ADR-005`](ADR-005-write-concurrency-guards.md) — Enforce write
+  concurrency with workflow group and local file lock. This ADR extends
+  `ADR-005`'s `lock_unavailable` envelope with holder PID/start-time metadata
+  for actionable diagnostics. `ADR-005`'s status was updated to reflect the
+  bidirectional cross-reference (2026-06-20).
 
 ## References
 

--- a/docs/decisions/ADR-032-fleet-quota-saturation-soft-warn.md
+++ b/docs/decisions/ADR-032-fleet-quota-saturation-soft-warn.md
@@ -37,13 +37,16 @@ Without the distinction:
   diagnostic signal behind a generic hard-fail.
 
 This repo's fleet dispatch was blocked for 11+ consecutive runs due to this
-defect (tracked in issue #82, cross-referenced with `wryenmeek/hot-springs-island#595`).
+defect (tracked in issue #82, cross-referenced with
+[wryenmeek/hot-springs-island#595](https://github.com/wryenmeek/hot-springs-island/issues/595)).
 
 ## Decision
 
 Introduce a `quota_saturation` sub-class of `MutationErrorClass` and a
 sub-classifier in `classifyFromSignals` with the following signal-precedence
-ordering (per wryenmeek/hot-springs-island#595 final implementation):
+ordering (informed by
+[wryenmeek/hot-springs-island#595](https://github.com/wryenmeek/hot-springs-island/issues/595)
+and adjusted for this repo's bare-body production response):
 
 1. **Explicit quota signals** (`QUOTA`, `SESSION LIMIT/CAP`, `SATURATED` in the
    upper-cased body) → classify as `quota_saturation` (non-retryable, soft-warn).
@@ -82,8 +85,15 @@ All other `MutationFailureError` classifications retain the existing
 
 ## Alternatives considered
 
-- **Keep `failed_precondition` classification and suppress `exit(1)`**
-  - Rejected because suppressing the generic `failed_precondition` error would also swallow genuine account misconfiguration faults without emitting a failure signal. We only want to softly warn on transient quota events.
+1. **Mirror [HSI #595](https://github.com/wryenmeek/hot-springs-island/issues/595)
+   final ordering without precedence inversion.** Rejected: production
+   bare-body shape would still hard-fail.
+2. **Keep `failed_precondition` and just suppress `exit(1)`.** Rejected:
+   conflates classification with routing and would also swallow genuine
+   account-misconfiguration faults without emitting a failure signal.
+3. **Do nothing.** Rejected: 11+ consecutive blocked runs showed quota
+   saturation was actively blocking ready-for-agent dispatch rather than an
+   acceptable noisy edge case.
 
 ## Consequences
 
@@ -118,6 +128,7 @@ constants, the `quota_saturation` category entry, and its routing in
 ## References
 
 - Issue #82 — Jules `FAILED_PRECONDITION` blocking Fleet for 11+ consecutive runs.
-- `wryenmeek/hot-springs-island#595` — canonical cross-repo fix (same fault signature).
+- [wryenmeek/hot-springs-island#595](https://github.com/wryenmeek/hot-springs-island/issues/595)
+  — canonical cross-repo fix (same fault signature).
 - `scripts/fleet/github/mutation-diagnostics.ts` — classifier implementation.
 - `scripts/fleet/_fleet_output.ts` — `handleFleetFatalError` routing.

--- a/docs/decisions/ADR-032-fleet-quota-saturation-soft-warn.md
+++ b/docs/decisions/ADR-032-fleet-quota-saturation-soft-warn.md
@@ -1,7 +1,7 @@
 # ADR-032: Fleet quota-saturation soft-warn exit code for bare FAILED_PRECONDITION
 
 ## Status
-Accepted
+Accepted — extends ADR-019
 
 ## Date
 2026-06-19
@@ -124,6 +124,12 @@ branch to always return `"failed_precondition"` instead of the three-step
 quota/account-mismatch/default check. The `QUOTA_SIGNAL_RE`, `ACCOUNT_MISMATCH_RE`
 constants, the `quota_saturation` category entry, and its routing in
 `handleFleetFatalError` can then be removed independently.
+
+## Related decisions
+
+- [`ADR-019`](ADR-019-fleet-jules-orchestration.md) — Fleet orchestration defines
+  the Jules dispatch and merge surface that this ADR extends with
+  quota-saturation error classification and exit-0 soft-warn behavior.
 
 ## References
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -38,4 +38,4 @@ This directory captures durable architecture and governance decisions derived fr
 | [ADR-029](ADR-029-test-framework-conventions.md) | Test framework conventions | Accepted — amended in-place |
 | [ADR-030](ADR-030-cli-write-confirmation.md) | CLI write-confirmation flag migration | Accepted |
 | [ADR-031](ADR-031-lock-holder-pid-tracking.md) | Lock holder PID/start-time tracking for lock-unavailable UX | Accepted — extends ADR-005 |
-| [ADR-032](ADR-032-fleet-quota-saturation-soft-warn.md) | Fleet quota-saturation soft-warn exit code for bare FAILED_PRECONDITION | Accepted |
+| [ADR-032](ADR-032-fleet-quota-saturation-soft-warn.md) | Fleet quota-saturation soft-warn exit code for bare FAILED_PRECONDITION | Accepted — extends ADR-019 |


### PR DESCRIPTION
## Summary

ADR-030/031/032 now carry the missing decision polish from the retrospective: rejected alternatives are explicit, reciprocal ADR links are navigable, and the lock-holder privacy trade-off is recorded where future readers will look for consequences.

Closes #304.

## Issue #304 checklist

- ✅ P1-1 — Added `## Alternatives considered` to `ADR-032` with the three rejected options from the issue.
- ✅ P1-2 — Verified the README index cell for `ADR-031` already reads `Accepted — extends ADR-005`; cascade tests confirm it is synced.
- ✅ P1-3 — Extended back-references from `ADR-005` to `ADR-031` and from `ADR-019` to `ADR-032`.
- ✅ P2-4 — Verified `ADR-031` already follows Context → Decision → Alternatives → Consequences → References ordering.
- ✅ P2-5 — Surfaced the `holder_context_hash` privacy trade-off in `ADR-031` positive consequences.
- ✅ P2-6 — Expanded `ADR-030` related decisions for `ADR-005` lock requirements and `ADR-022` HITL/AFK script boundaries.
- ✅ P2-7 — Expanded `wryenmeek/hot-springs-island#595` references in `ADR-032` to full GitHub URLs.
- ⏳ P2-8 — Deferred: adding an automated tripwire for the `2026-12-31` deprecation deadline is out of scope for this docs-only PR and would require a new test; tracked in #332.

## Validation

- ✅ `pre-commit run --files docs/decisions/ADR-030-cli-write-confirmation.md docs/decisions/ADR-031-lock-holder-pid-tracking.md docs/decisions/ADR-032-fleet-quota-saturation-soft-warn.md docs/decisions/ADR-005-write-concurrency-guards.md docs/decisions/ADR-019-fleet-jules-orchestration.md docs/decisions/README.md`
- ✅ `python3 -m pytest tests/kb/test_adr_readme_status_sync.py tests/kb/test_doc_cascade_completeness.py -v`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GitHub_Copilot_CLI](https://img.shields.io/badge/GitHub_Copilot_CLI-000000)
