### PR TITLE
test(kb): lock extract_frontmatter byte contract

### DIFF
--- a/scripts/kb/page_template_utils.py
+++ b/scripts/kb/page_template_utils.py
@@ -124,11 +124,18 @@ def validate_page_template_path(
 
 
 def extract_frontmatter(text: str) -> tuple[str | None, str]:
-    """Extract a YAML frontmatter block and the body from a markdown document.
+    """Extract a YAML frontmatter block and body from a markdown document.
 
-    Returns a tuple of (frontmatter, body). If no frontmatter block is found,
-    returns (None, original_text). The original body characters (including CRLF and
-    trailing newlines) are preserved verbatim.
+    Returns ``(frontmatter_str | None, body_str)``. When a frontmatter block
+    matches, ``body_str`` is exactly ``text[match.end():]`` after the optional
+    leading UTF-8 BOM strip described below, so the body characters are
+    preserved verbatim. Body CRLF sequences are not normalized to LF, and a
+    trailing body newline is preserved rather than dropped. This differs from
+    the pre-PR-#298 ``splitlines()`` implementation, which normalized CRLF and
+    dropped exactly one trailing body newline.
+
+    If no frontmatter block is found, returns ``(None, text)`` unchanged for
+    non-BOM inputs.
 
     UTF-8 BOM (`\\ufeff`) at the start of the text is stripped before parsing
     so files saved by Windows editors with the BOM still resolve their

--- a/tests/kb/test_extract_frontmatter.py
+++ b/tests/kb/test_extract_frontmatter.py
@@ -1,41 +1,52 @@
-"""Byte-level contract tests for `extract_frontmatter`.
+"""Byte-level contract tests for ``extract_frontmatter``.
 
-Covers happy-path LF + CRLF inputs, leading whitespace, empty frontmatter,
-missing/unclosed delimiters, the file-ends-at-closing-delim edge case,
-and UTF-8 BOM-prefixed inputs (Issue #321). The `name` parameter on each
-case is plumbed only as a pytest-generated test ID label; it is not
-asserted in the test body.
-
-BOM handling (#321): the parser strips a single leading `\\ufeff` before
-detecting frontmatter so files saved by Windows editors with a UTF-8 BOM
-still resolve their frontmatter. The stripped BOM is not echoed back into
-the returned body.
+Issue #303 locks the regex-based extraction behavior introduced by PR #298:
+returned body text is preserved verbatim, including CRLF sequences and trailing
+newlines. The BOM cases preserve the Issue #321 regression coverage in this
+dedicated test file.
 """
+
+from __future__ import annotations
+
 import pytest
+
 from scripts.kb.page_template_utils import extract_frontmatter
+
 
 @pytest.mark.parametrize(
     "name, text, expected_fm, expected_body",
     [
-        ("Happy LF", "---\nfm\n---\nbody\n", "fm", "body\n"),
-        ("Happy CRLF", "---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
-        ("Leading whitespace", "  ---\nfm\n---\nbody", "fm", "body"),
-        ("Empty frontmatter", "---\n---\nbody\n", "", "body\n"),
-        ("No frontmatter pass-through", "no frontmatter\n", None, "no frontmatter\n"),
-        ("Unclosed delim", "---\nunclosed\nbody\n", None, "---\nunclosed\nbody\n"),
-        ("mid-body", "---\nfm\n---\nbody\n---\nmore\n", "fm", "body\n---\nmore\n"),
-        ("File ending at closing delim", "---\nfm\n---", "fm", ""),
-        # BOM cases (Issue #321): leading \ufeff must be stripped before
-        # frontmatter detection, otherwise the parser silently treats
-        # Windows-saved files as frontmatter-less.
-        ("BOM + LF", "\ufeff---\nfm\n---\nbody\n", "fm", "body\n"),
-        ("BOM + CRLF", "\ufeff---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
-        # Edge case: BOM with no frontmatter — BOM is stripped, body returned
-        # without the BOM (caller can re-add if they need byte identity).
-        ("BOM + no frontmatter", "\ufeffno frontmatter\n", None, "no frontmatter\n"),
-    ]
+        ("happy_lf", "---\nfm\n---\nbody\n", "fm", "body\n"),
+        ("happy_crlf", "---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
+        ("leading_whitespace", "  ---\nfm\n---\nbody", "fm", "body"),
+        ("empty_frontmatter", "---\n---\nbody\n", "", "body\n"),
+        ("no_frontmatter_pass_through", "no frontmatter\n", None, "no frontmatter\n"),
+        ("unclosed_delim", "---\nunclosed\nbody\n", None, "---\nunclosed\nbody\n"),
+        (
+            "mid_body_delimiter_without_opening",
+            "body\n---\nfake: value\n---\nmore\n",
+            None,
+            "body\n---\nfake: value\n---\nmore\n",
+        ),
+        (
+            "body_delimiter_after_frontmatter",
+            "---\nfm\n---\nbody\n---\nmore\n",
+            "fm",
+            "body\n---\nmore\n",
+        ),
+        ("file_ending_at_closing_delim", "---\nfm\n---", "fm", ""),
+        ("bom_lf", "\ufeff---\nfm\n---\nbody\n", "fm", "body\n"),
+        ("bom_crlf", "\ufeff---\r\nfm\r\n---\r\nbody\r\n", "fm", "body\r\n"),
+        ("bom_no_frontmatter", "\ufeffno frontmatter\n", None, "no frontmatter\n"),
+    ],
 )
-def test_extract_frontmatter_cases(name, text, expected_fm, expected_body):
+def test_extract_frontmatter_byte_contract(
+    name: str,
+    text: str,
+    expected_fm: str | None,
+    expected_body: str,
+) -> None:
     fm, body = extract_frontmatter(text)
-    assert fm == expected_fm
-    assert body == expected_body
+
+    assert fm == expected_fm, f"{name}: fm mismatch"
+    assert body == expected_body, f"{name}: body mismatch (byte contract drift)"


### PR DESCRIPTION
## Summary

Locks the current regex-based `extract_frontmatter` byte/character contract from PR #298 without changing behavior.

The documented contract is now explicit:
- when frontmatter matches, returned body is `text[match.end():]`
- body CRLF is preserved, not normalized to LF
- trailing body newlines are preserved
- non-BOM inputs without frontmatter return `(None, original_text)` unchanged
- existing BOM stripping behavior remains documented separately

## Test coverage

`tests/kb/test_extract_frontmatter.py` now asserts both `fm` and `body` for these cases:
1. LF frontmatter/body preserves trailing body newline
2. CRLF frontmatter/body preserves CRLF in the body
3. leading whitespace before opening delimiter still matches
4. empty frontmatter returns `""` and preserves body
5. no frontmatter passes through original text
6. unclosed delimiter passes through original text
7. mid-body `---` without an opening frontmatter delimiter does not retrigger
8. `---` inside the body after valid frontmatter remains body text
9. file ending at closing delimiter returns an empty body
10. existing BOM LF regression case
11. existing BOM CRLF regression case
12. existing BOM no-frontmatter regression case

## Verification

- `python3 -m pytest tests/kb/test_extract_frontmatter.py -v` — 12 passed
- `python3 -m pytest tests/kb/test_page_template_utils*.py tests/kb/test_extract_frontmatter.py -v` — 31 passed
- `pre-commit run --files scripts/kb/page_template_utils.py tests/kb/test_extract_frontmatter.py` — passed

Closes #303
