### PR TITLE
fix(ci): add # v3.2.0 version comment to fleet-dispatch SHA pin (#334)

### DIFF
--- a/.github/workflows/fleet-dispatch.yml
+++ b/.github/workflows/fleet-dispatch.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Create GitHub App token for auto-merge
         id: app-token
         if: steps.app-token-inputs.outputs.available == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         continue-on-error: true
         with:
           app-id: ${{ secrets.GH_APP_ID }}


### PR DESCRIPTION
Closes #334.

## Problem
`tests/kb/test_workflow_sha_pins.py::test_pinned_refs_have_version_comments` has been failing on every PR since commit `fc33db8` (partial #310 implementation) because the new `actions/create-github-app-token` ref was SHA-pinned without the required `# vX.Y.Z` version comment.

## Fix
One-line change: append `# v3.2.0` to `.github/workflows/fleet-dispatch.yml:151`.

SHA `bcd2ba49218906704ab6c1aa796996da409d3eb1` confirmed via GitHub Tags API as `actions/create-github-app-token@v3.2.0`.

## Validation
```
$ python3 -m pytest tests/kb/test_workflow_sha_pins.py -v
==================== 4 passed, 51 subtests passed in 0.10s =====================
```

No behavior change — comment-only edit. Unblocks pytest in CI-2 diagnostics for every open PR.