### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix MD5 hashlib vulnerability warning

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,7 @@
 **Vulnerability:** GITHUB_TOKEN and JULES_API_KEY tokens were hardcoded as raw validation checks and inline `process.env` lookups across `fleet-dispatch.ts`, `fleet-merge.ts`, and `fleet-plan.ts`.
 **Learning:** Checking or importing tokens ad hoc leads to duplicate or missed token checks. Centralizing these environment variables ensures token visibility and validation on startup across multiple files, while also supporting `console.log` redacting of these tokens everywhere.
 **Prevention:** Always export a single object/file handling tokens and sensitive environmental variables (e.g., `env.ts`) to avoid duplicated code, missing error checks, and incomplete log scrubbing.
+## 2026-06-21 - Fix Bandit Alert for MD5 Usage
+**Vulnerability:** Use of weak MD5 hash without `usedforsecurity=False`.
+**Learning:** `hashlib.md5()` triggers `bandit` scanners and FIPS enforcement unless explicitly marked as non-security related.
+**Prevention:** Always pass `usedforsecurity=False` when using MD5 for checksums or versioning to suppress false positives and ensure compatibility in strict environments.

--- a/scripts/drive_monitor/fetch_content.py
+++ b/scripts/drive_monitor/fetch_content.py
@@ -136,7 +136,7 @@ def _fetch_and_store_asset(
             md5_checksum = entry.get("current_md5_checksum")
             if not md5_checksum:
                 # Compute MD5 from downloaded bytes as fallback
-                md5_checksum = hashlib.md5(asset_bytes).hexdigest()
+                md5_checksum = hashlib.md5(asset_bytes, usedforsecurity=False).hexdigest()
             version_segment = md5_checksum
             drive_version = None
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Use of `hashlib.md5()` triggered Bandit scanning tools and poses compatibility issues in FIPS environments.
🎯 **Impact:** False positives in security scans and potential `ValueError` crashes in FIPS-enforced Python instances.
🔧 **Fix:** Passed `usedforsecurity=False` explicitly to `hashlib.md5()` as it is only used for version segment checksums.
✅ **Verification:** Ran `bandit -r scripts/drive_monitor/fetch_content.py` successfully and ensured `pytest tests/drive_monitor/` passes.

---
*PR created automatically by Jules for task [5546581669312933552](https://jules.google.com/task/5546581669312933552) started by @wryenmeek*