### PR TITLE
fix(hooks): honor approval flag exemptions before equals rejection

### DIFF
--- a/docs/decisions/ADR-030-cli-write-confirmation.md
+++ b/docs/decisions/ADR-030-cli-write-confirmation.md
@@ -85,6 +85,13 @@ Migration:
    so an off-by-one in either direction hard-fails CI — adding a non-exempt
    script without decrementing fails, and decrementing without removing a
    script also fails. The strict-equality form prevents silent ratchet drift.
+4. **Exemption precedence.** Transitional exempt paths in
+   `scripts/hooks/check_approval_flag.py::_EXEMPT_PATHS` short-circuit **all**
+   `--approval` content checks — including the post-deadline equals-form
+   rejection. An exempt path must drop its legacy `--approval` and `--approval=`
+   literals before it can be removed from `_EXEMPT_PATHS`. Regression coverage
+   lives in `tests/kb/test_approval_migration_ratchet.py::test_hook_allows_exempt_approval_equals_after_deadline`
+   (precedence) and `test_exempt_paths_membership_locked` (allowlist growth).
 
 Rollback:
 

--- a/scripts/_optional_surface_common.py
+++ b/scripts/_optional_surface_common.py
@@ -445,14 +445,8 @@ def add_approval_arg(parser: argparse.ArgumentParser) -> None:
 
 def normalize_apply_alias(argv: Sequence[str]) -> list[str]:
     """Map ``--apply`` to legacy ``--approval approved`` for deprecation window."""
-    # Self-obfuscated to avoid the literal substring "--approval=" appearing in
-    # this file. After APPROVAL_EQUALS_REJECTION_DEADLINE (2026-12-31) the
-    # pre-commit hook `scripts/hooks/check_approval_flag.py` rejects any file
-    # containing the legacy `--approval=<value>` spelling — including, after
-    # PR #317's reordering, files in `_EXEMPT_PATHS`. The hook intentionally
-    # cannot bypass exempts for this check, so this detector site must avoid
-    # the literal. The hook itself uses the same string-concat trick (line 16
-    # of check_approval_flag.py). See v-code post-merge review, 2026-06-20.
+    # Keep the equals-form detector self-obfuscated so this compatibility helper
+    # does not become noisy if it is ever removed from the hook exemption list.
     _LEGACY_APPROVAL_EQUALS_PREFIX = "--approval" + "="
     args = list(argv)
     if any(token.startswith(_LEGACY_APPROVAL_EQUALS_PREFIX) for token in args):

--- a/scripts/hooks/check_approval_flag.py
+++ b/scripts/hooks/check_approval_flag.py
@@ -264,6 +264,13 @@ def main(argv: list[str] | None = None) -> int:
         if read_error is not None:
             failures.append(read_error)
             continue
+        # Exempt paths short-circuit before the equals-form rejection so transitional
+        # compatibility files (e.g. scripts/_optional_surface_common.py) can keep the
+        # self-obfuscated legacy-flag detector past APPROVAL_EQUALS_REJECTION_DEADLINE.
+        # The literal token is intentionally not spelled here; the ratchet test
+        # `test_approval_flag_script_count_matches_contract_exactly` greps source for the
+        # bare string, so emitting it would inflate the count and require a contract bump.
+        # See issue #300 / regression test test_hook_allows_exempt_approval_equals_after_deadline.
         if staged_path.path in _EXEMPT_PATHS:
             continue
         if (

--- a/scripts/hooks/check_approval_flag.py
+++ b/scripts/hooks/check_approval_flag.py
@@ -264,8 +264,8 @@ def main(argv: list[str] | None = None) -> int:
         if read_error is not None:
             failures.append(read_error)
             continue
-        # Enforce equals-sign rejection before exemptions so transitional
-        # compatibility files cannot silently keep the legacy equals syntax.
+        if staged_path.path in _EXEMPT_PATHS:
+            continue
         if (
             _contains_approval_equals(staged_text)
             and _migration_deadline_passed()
@@ -274,8 +274,6 @@ def main(argv: list[str] | None = None) -> int:
                 f"{staged_path.path}: {_APPROVAL_EQUALS_TOKEN}<value> is forbidden after "
                 f"{APPROVAL_EQUALS_REJECTION_DEADLINE.isoformat()}; use --apply"
             )
-            continue
-        if staged_path.path in _EXEMPT_PATHS:
             continue
         if not _contains_approval_flag(staged_text):
             continue

--- a/tests/kb/test_approval_migration_ratchet.py
+++ b/tests/kb/test_approval_migration_ratchet.py
@@ -26,7 +26,7 @@ def _legacy_approval_script_files() -> list[Path]:
     return sorted(files)
 
 
-def test_approval_flag_script_count_does_not_exceed_contract() -> None:
+def test_approval_flag_script_count_matches_contract_exactly() -> None:
     files = _legacy_approval_script_files()
     assert len(files) == MAX_APPROVAL_FLAG_SCRIPTS, (
         f"{len(files)} scripts still use --approval but MAX_APPROVAL_FLAG_SCRIPTS="
@@ -162,13 +162,40 @@ def test_hook_rejects_approval_equals_after_deadline(monkeypatch, capsys) -> Non
     assert "--approval=<value> is forbidden after" in captured.err
 
 
-def test_hook_rejects_approval_equals_for_fake_exempt_path(monkeypatch, capsys) -> None:
-    exempt_path = "scripts/fake_exempt.py"
-    monkeypatch.setattr(check_approval_flag, "_EXEMPT_PATHS", frozenset({exempt_path}))
+def test_hook_allows_exempt_approval_equals_after_deadline(monkeypatch) -> None:
     monkeypatch.setattr(
         check_approval_flag,
         "_staged_script_paths",
-        lambda: ([check_approval_flag.StagedScriptPath("M", exempt_path)], None),
+        lambda: (
+            [
+                check_approval_flag.StagedScriptPath(
+                    "M",
+                    "scripts/_optional_surface_common.py",
+                )
+            ],
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        check_approval_flag,
+        "_get_staged_content",
+        lambda path: ('argv = ["--approval=approved"]\n', None),
+    )
+    monkeypatch.setattr(
+        check_approval_flag,
+        "_migration_deadline_passed",
+        lambda today=None: True,
+    )
+
+    assert check_approval_flag.main([]) == 0
+
+
+def test_hook_rejects_approval_equals_for_non_exempt_path(monkeypatch, capsys) -> None:
+    path = "scripts/non_exempt.py"
+    monkeypatch.setattr(
+        check_approval_flag,
+        "_staged_script_paths",
+        lambda: ([check_approval_flag.StagedScriptPath("M", path)], None),
     )
     monkeypatch.setattr(
         check_approval_flag,

--- a/tests/kb/test_approval_migration_ratchet.py
+++ b/tests/kb/test_approval_migration_ratchet.py
@@ -190,6 +190,23 @@ def test_hook_allows_exempt_approval_equals_after_deadline(monkeypatch) -> None:
     assert check_approval_flag.main([]) == 0
 
 
+def test_exempt_paths_membership_locked() -> None:
+    """Force PR-review scrutiny on any change to _EXEMPT_PATHS.
+
+    Membership confers two bypasses: the new-legacy-script check and (after
+    APPROVAL_EQUALS_REJECTION_DEADLINE) the equals-form rejection. Growing this
+    set silently extends the deprecation window for additional files, so any
+    addition must be deliberate — this test fails closed when the set drifts.
+    Locked per security-auditor LOW-1 finding on PR #363.
+    """
+    assert check_approval_flag._EXEMPT_PATHS == frozenset(
+        {
+            "scripts/_optional_surface_common.py",
+            "scripts/kb/checkpoint_registry.py",
+        }
+    )
+
+
 def test_hook_rejects_approval_equals_for_non_exempt_path(monkeypatch, capsys) -> None:
     path = "scripts/non_exempt.py"
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #300

## Summary
Fixes a P1 bug in `scripts/hooks/check_approval_flag.py` plus a related test-naming cleanup, identified in post-merge retrospective review of session `927fa98..eb0e044`:

### Bug 1: Time-bomb on compatibility alias file
Reordered `check_approval_flag.py` so `_EXEMPT_PATHS` (which includes `scripts/_optional_surface_common.py`) is consulted **before** the equals-form rejection. Without this, every edit to the alias file would fail pre-commit after `APPROVAL_EQUALS_REJECTION_DEADLINE = 2026-12-31`.

Added regression test `test_hook_allows_exempt_approval_equals_after_deadline` to lock the precedence ordering, plus paired negative test `test_hook_rejects_approval_equals_for_non_exempt_path`.

### Bug 2: Ratchet test name implied loose semantics (clarification, not behavior change)
The assertion in `test_approval_flag_script_count_does_not_exceed_contract` was **already `==`** — the `<=` → `==` tightening landed in **PR #317** (`530ef01`), as ADR-030 line 84 records. But the test was still named `does_not_exceed_contract`, which made reviewers and future maintainers believe the ratchet was loose (this is what the original issue #300 finding caught).

Renamed to `test_approval_flag_script_count_matches_contract_exactly` so the name matches the actual `==` enforcement. No semantic test change; no contract change (`MAX_APPROVAL_FLAG_SCRIPTS = 8` continues to match the actual count).

Bug 1 remains the only behavior-changing fix in this PR.

## Acceptance (from issue)
- [x] Pre-commit hook passes when editing `scripts/_optional_surface_common.py` after the deadline (verified by new regression test)
- [x] `MAX_APPROVAL_FLAG_SCRIPTS` cannot drift up *or* be left stale at a higher value than the actual count (already true via `==` since PR #317; name now matches)
- [x] Both existing tests still pass
- [x] New test added for Bug 1 fix

## Verification
- Targeted: 29 passed (`test_approval_migration_ratchet.py`, `test_contracts.py`)
- Full suite: 2171 passed, 1 skipped

## Cross-functional review (post-creation)
Cross-functional review (`@code-reviewer`, `@test-engineer`, `@security-auditor`, `@documentation-engineer`) ran on 2026-06-21. All four agents returned APPROVE. Remediations applied to this PR:
- ✅ PR body corrected (Bug 2 framing was misleading — was a name change, not a `<=`→`==` change)
- ✅ Precedence-explaining comment added at the new `_EXEMPT_PATHS` check call site (cr-363 P3, de-363 P2-1)
- ✅ ADR-030 Migration section: additive precedence clarification — body-only edit per the new ADR-amendment tie-breaker (de-363 P2-2)
- ✅ `_EXEMPT_PATHS` membership lock test added (sa-363 LOW-1)
- Deferred follow-ups (low value, out of scope): rename sibling `test_unittest_file_count_does_not_exceed_contract` (de-363 P3-3); add rename/multi-file/empty-diff/pre-deadline edge-case tests (te-363 P2-2–P2-5)

## Dispatch context
Dispatched in-session from triage review of 25 open issues (severity:high P1 bug). Sibling cloud dispatches to `@copilot` for Tier 0/1 and maintenance issues are tracked under #345–#349, #332, #335, #340.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>