### PR TITLE
⚡ Bolt: [Performance] Avoid intermediate set allocation in missing keys check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2026-06-25 - [Performance] Optimized Python String Slicing vs splitlines()
 **Learning:** Using `text.splitlines()` on large text strings creates a heavy memory footprint by tokenizing strings into `O(N)` arrays. For fast-path validation like extracting frontmatter delimiters or stripping metadata, isolating subsets of strings with `.find('\n')` achieves `O(1)` space allocation. Furthermore, calling `.lstrip()` or `.partition()` on large, untokenized strings will create full-sized string object copies under the hood.
 **Action:** When validating single lines in a large text document, use `newline_pos = text.find('\n')` and slice `text[:newline_pos]` before applying fast-path methods like `.lstrip()` or `.startswith()`.
+## 2026-06-25 - [Performance] Avoid intermediate set allocation in missing keys check
+**Learning:** When computing the difference between a set and a dictionary's keys to check for missing required fields, `required - set(my_dict)` or `required - set(my_dict.keys())` creates an unnecessary `O(N)` set object in memory.
+**Action:** Use dictionary view set operations or natively implemented set methods, such as `required.difference(my_dict)` or `required.difference(my_dict.keys())` to achieve better performance and eliminate redundant allocations.

--- a/scripts/kb/checkpoint_registry.py
+++ b/scripts/kb/checkpoint_registry.py
@@ -504,7 +504,9 @@ def _validate_batches(raw_batches: Any) -> list[str]:
         if not isinstance(batch, dict):
             errors.append(f"batches[{index}] must be an object")
             continue
-        missing = required_fields - set(batch)
+        # OPTIMIZATION: Use .difference(dict) instead of - set(dict.keys())
+        # to avoid allocating an intermediate set object.
+        missing = required_fields.difference(batch)
         for field in sorted(missing):
             errors.append(f"batches[{index}].{field} is required")
         batch_id = batch.get("batch_id")
@@ -565,7 +567,9 @@ def _validate_items(raw_items: Any, repo_root: Path) -> list[str]:
         if not isinstance(item, dict):
             errors.append(f"items[{index}] must be an object")
             continue
-        missing = required_fields - set(item)
+        # OPTIMIZATION: Use .difference(dict) instead of - set(dict.keys())
+        # to avoid allocating an intermediate set object.
+        missing = required_fields.difference(item)
         for field in sorted(missing):
             errors.append(f"items[{index}].{field} is required")
         key = item.get("item_key")

--- a/scripts/kb/rejection_validators.py
+++ b/scripts/kb/rejection_validators.py
@@ -110,7 +110,9 @@ def validate_frontmatter(fields: dict[str, Any]) -> list[str]:
     required = {"slug", "sha256", "rejected_date", "source_path",
                 "rejection_reason", "rejection_category", "reviewed_by",
                 "reconsidered_date"}
-    missing = required - set(fields.keys())
+    # OPTIMIZATION: Use .difference(dict) instead of - set(dict.keys())
+    # to avoid allocating an intermediate set object.
+    missing = required.difference(fields)
     if missing:
         errors.append(f"missing required frontmatter fields: {sorted(missing)}")
 


### PR DESCRIPTION
💡 What: Changed `required - set(dict)` to `required.difference(dict)`.
🎯 Why: Set `.difference()` in Python accepts any iterable natively. Wrapping a dictionary in `set()` allocates an unnecessary intermediate `O(N)` set object before performing the difference operation.
📊 Impact: Eliminates redundant memory allocation during validation loops in `checkpoint_registry.py` and `rejection_validators.py`.

---
*PR created automatically by Jules for task [15652741333968009126](https://jules.google.com/task/15652741333968009126) started by @wryenmeek*