### PR TITLE
feat: generate empty fleet tasks when 0 issues are provided

### DIFF
--- a/.fleet/2026_06_24/issue_tasks.json
+++ b/.fleet/2026_06_24/issue_tasks.json
@@ -1,0 +1,8 @@
+{
+  "repo": "wryenmeek/knowledgebase",
+  "analyzed_at": "2026-06-24T09:27:00.581Z",
+  "root_causes": [],
+  "tasks": [],
+  "unaddressable": [],
+  "file_ownership": {}
+}

--- a/.fleet/2026_06_24/issue_tasks.md
+++ b/.fleet/2026_06_24/issue_tasks.md
@@ -1,0 +1,26 @@
+# Issue Analysis: wryenmeek/knowledgebase
+
+> Analyzed 0 issues on 2026-06-24T09:27:00.581Z
+
+## Executive Summary
+
+Found 0 issues to analyze. No root causes were identified, and no issues are unaddressable. The repository health appears stable with no current dispatchable issues.
+
+## Root Cause Analysis
+
+*(No root causes identified)*
+
+## Task Plan
+
+| # | Task | Root Cause | Issues | Files | Risk |
+|---|------|-----------|--------|-------|------|
+
+## File Ownership Matrix
+
+| File | Task | Change Type |
+|------|------|-------------|
+
+## Unaddressable Issues
+
+| Issue | Reason | Suggested Owner |
+|-------|--------|-----------------|


### PR DESCRIPTION
This commit addresses the case where the fleet scripts analyze 0 issues by creating standard, empty `.fleet/*` files (`issue_tasks.md` and `issue_tasks.json`). The empty files prevent the staging validation logic (`bun scripts/fleet/preMergeSanityCheck.ts`) or later pipeline stages from failing when no actual issues are triaged. Both files adhere strictly to their required structural schemas.

---
*PR created automatically by Jules for task [16476856003589030119](https://jules.google.com/task/16476856003589030119) started by @wryenmeek*