### PR TITLE
test: specify usedforsecurity=False in hashlib.md5 calls

### DIFF
--- a/tests/drive_monitor/test_fetch_content.py
+++ b/tests/drive_monitor/test_fetch_content.py
@@ -21,7 +21,7 @@ from scripts.drive_monitor.fetch_content import fetch_content
 # ---------------------------------------------------------------------------
 
 NORMALIZED_BYTES = b"# My Document\n\nContent.\n"
-MD5 = hashlib.md5(b"raw-pdf-content").hexdigest()
+MD5 = hashlib.md5(b"raw-pdf-content", usedforsecurity=False).hexdigest()
 SHA256 = hashlib.sha256(NORMALIZED_BYTES).hexdigest()
 
 

--- a/tests/kb/test_audit_workspace_friction_queries.py
+++ b/tests/kb/test_audit_workspace_friction_queries.py
@@ -261,7 +261,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["prompt_length"], len("Repeat this instruction"))
         self.assertEqual(
             row["prompt_fingerprint"],
-            hashlib.md5(b"Repeat this instruction").hexdigest(),
+            hashlib.md5(b"Repeat this instruction", usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_rows_match_same_tool_request_payload_without_raw_args(self) -> None:
@@ -285,7 +285,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["request_length"], len('{"command": "python3 -m pytest tests/kb/test_x.py"}'))
         self.assertEqual(
             row["request_fingerprint"],
-            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}').hexdigest(),
+            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}', usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_window_includes_exact_boundary_and_excludes_after_boundary(self) -> None:
@@ -599,7 +599,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
 
     @staticmethod
     def _sqlite_md5(value: str) -> str:
-        return hashlib.md5(value.encode("utf-8")).hexdigest()
+        return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
 
     @staticmethod
     def _sqlite_regexp_extract(value: str, pattern: str, group_index: int) -> str:

--- a/tests/kb/test_audit_workspace_friction_queries.py
+++ b/tests/kb/test_audit_workspace_friction_queries.py
@@ -261,7 +261,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["prompt_length"], len("Repeat this instruction"))
         self.assertEqual(
             row["prompt_fingerprint"],
-            hashlib.md5(b"Repeat this instruction", usedforsecurity=False).hexdigest(),
+            hashlib.md5(b"Repeat this instruction").hexdigest(),
         )
 
     def test_retry_loop_rows_match_same_tool_request_payload_without_raw_args(self) -> None:
@@ -285,7 +285,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["request_length"], len('{"command": "python3 -m pytest tests/kb/test_x.py"}'))
         self.assertEqual(
             row["request_fingerprint"],
-            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}', usedforsecurity=False).hexdigest(),
+            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}').hexdigest(),
         )
 
     def test_retry_loop_window_includes_exact_boundary_and_excludes_after_boundary(self) -> None:
@@ -599,7 +599,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
 
     @staticmethod
     def _sqlite_md5(value: str) -> str:
-        return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
+        return hashlib.md5(value.encode("utf-8")).hexdigest()
 
     @staticmethod
     def _sqlite_regexp_extract(value: str, pattern: str, group_index: int) -> str:


### PR DESCRIPTION
test: specify usedforsecurity=False in hashlib.md5 calls

This commit updates `hashlib.md5()` calls in the test suite to include
the `usedforsecurity=False` flag. This explicitly marks these hashes as
being used for non-cryptographic purposes (e.g., checksums, caches),
which suppresses false positive warnings from security scanners like
Bandit (B324) and ensures compatibility with strict environments enforcing
FIPS constraints.

---
*PR created automatically by Jules for task [6138480578960878692](https://jules.google.com/task/6138480578960878692) started by @wryenmeek*