### PR TITLE
⚡ Bolt: Replace explicit set conversions with difference()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,4 @@
 ## 2026-06-25 - [Performance] Optimized Python String Slicing vs splitlines()
 **Learning:** Using `text.splitlines()` on large text strings creates a heavy memory footprint by tokenizing strings into `O(N)` arrays. For fast-path validation like extracting frontmatter delimiters or stripping metadata, isolating subsets of strings with `.find('\n')` achieves `O(1)` space allocation. Furthermore, calling `.lstrip()` or `.partition()` on large, untokenized strings will create full-sized string object copies under the hood.
 **Action:** When validating single lines in a large text document, use `newline_pos = text.find('\n')` and slice `text[:newline_pos]` before applying fast-path methods like `.lstrip()` or `.startswith()`.
+**Action:** Use `my_set.difference(my_dict)` instead, which natively avoids the O(N) memory overhead of allocating an intermediate set object.

--- a/scripts/kb/checkpoint_registry.py
+++ b/scripts/kb/checkpoint_registry.py
@@ -504,7 +504,8 @@ def _validate_batches(raw_batches: Any) -> list[str]:
         if not isinstance(batch, dict):
             errors.append(f"batches[{index}] must be an object")
             continue
-        missing = required_fields - set(batch)
+        # OPTIMIZATION: Use .difference() instead of - set() to avoid O(N) set allocation
+        missing = required_fields.difference(batch)
         for field in sorted(missing):
             errors.append(f"batches[{index}].{field} is required")
         batch_id = batch.get("batch_id")
@@ -565,7 +566,8 @@ def _validate_items(raw_items: Any, repo_root: Path) -> list[str]:
         if not isinstance(item, dict):
             errors.append(f"items[{index}] must be an object")
             continue
-        missing = required_fields - set(item)
+        # OPTIMIZATION: Use .difference() instead of - set() to avoid O(N) set allocation
+        missing = required_fields.difference(item)
         for field in sorted(missing):
             errors.append(f"items[{index}].{field} is required")
         key = item.get("item_key")

--- a/scripts/kb/rejection_validators.py
+++ b/scripts/kb/rejection_validators.py
@@ -110,7 +110,8 @@ def validate_frontmatter(fields: dict[str, Any]) -> list[str]:
     required = {"slug", "sha256", "rejected_date", "source_path",
                 "rejection_reason", "rejection_category", "reviewed_by",
                 "reconsidered_date"}
-    missing = required - set(fields.keys())
+    # OPTIMIZATION: Use .difference() instead of - set() to avoid O(N) set allocation
+    missing = required.difference(fields)
     if missing:
         errors.append(f"missing required frontmatter fields: {sorted(missing)}")
 


### PR DESCRIPTION
💡 What: Replaced explicit set conversions like `required - set(dictionary)` with `required.difference(dictionary)` in `scripts/kb/checkpoint_registry.py` and `scripts/kb/rejection_validators.py`.
🎯 Why: Using `.difference(dict)` is natively optimized in Python to iterate over the dictionary keys without creating a full set object in memory. This reduces O(N) allocation overhead for intermediate objects.
📊 Impact: Less memory churn during validation and parsing.
🔬 Measurement: Observe memory footprint via memory profiler.

---
*PR created automatically by Jules for task [8635724209280681569](https://jules.google.com/task/8635724209280681569) started by @wryenmeek*