### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix token leakage in error logs and expression injection in markdown sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,7 @@
 **Vulnerability:** Use of weak MD5 hash without `usedforsecurity=False`.
 **Learning:** `hashlib.md5()` triggers `bandit` scanners and FIPS enforcement unless explicitly marked as non-security related.
 **Prevention:** Always pass `usedforsecurity=False` when using MD5 for checksums or versioning to suppress false positives and ensure compatibility in strict environments.
+## 2026-06-26 - [Log Injection and Expression Injection]
+**Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
+**Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
+**Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).

--- a/scripts/github_monitor/create_issues.py
+++ b/scripts/github_monitor/create_issues.py
@@ -47,6 +47,13 @@ def _redact_stderr(stderr: str, max_len: int = 200) -> str:
     truncated = stderr[:max_len]
     # Redact 40-char hex strings (git SHAs / token fragments).
     truncated = re.sub(r"[0-9a-fA-F]{40,}", "<redacted>", truncated)
+    truncated = re.sub(r"ghp_[A-Za-z0-9_]+", "[REDACTED]", truncated)
+    truncated = re.sub(r"github_pat_[A-Za-z0-9_]+", "[REDACTED]", truncated)
+    truncated = re.sub(r"gho_[A-Za-z0-9_]+", "[REDACTED]", truncated)
+    truncated = re.sub(
+        r"Authorization:[ \t]*\S+(?:[ \t]+\S+)?", "[REDACTED]", truncated, flags=re.IGNORECASE
+    )
+    truncated = re.sub(r"[A-Za-z0-9+/=]{30,}", "[REDACTED]", truncated)
     return truncated.strip()
 
 
@@ -73,6 +80,7 @@ def _sanitize_gh_md(value: str, max_len: int = 200) -> str:
         s,
         flags=re.IGNORECASE,
     )
+    s = s.replace("${{", "[expr]").replace("}}", "[expr]")
     return s[:max_len].strip()
 
 

--- a/tests/github_monitor/test_create_issues.py
+++ b/tests/github_monitor/test_create_issues.py
@@ -62,6 +62,14 @@ class TestSanitizeGhMd:
         assert ">" not in result
         assert "@evil" not in result
         assert "![" not in result
+
+    def test_strips_github_actions_expressions(self) -> None:
+        assert _sanitize_gh_md("${{ secrets.GITHUB_TOKEN }}") == "[expr] secrets.GITHUB_TOKEN [expr]"
+        assert _sanitize_gh_md("some ${{ expr }} here") == "some [expr] expr [expr] here"
+
+    def test_combined_sanitization_fixes_preserved(self) -> None:
+        raw = "fixes #1 <script>@evil `tick` ![img](x)"
+        result = _sanitize_gh_md(raw)
         assert "fixes #1" not in result.lower()
 
 


### PR DESCRIPTION
This PR implements a security enhancement in `scripts/github_monitor/create_issues.py`.
It strengthens error log redaction to ensure GitHub tokens and Authorization headers are not leaked if the `gh` CLI or upstream API throws an error. It also neutralizes GitHub Actions expressions in markdown outputs to prevent potential expression injection (`${{ ... }}`) vulnerabilities when issues are rendered. Tests were updated to reflect these enhancements.

---
*PR created automatically by Jules for task [1696965835275074160](https://jules.google.com/task/1696965835275074160) started by @wryenmeek*