### PR TITLE
docs(adr): resolve HSI SHA placeholders in ADR-033/034 References (#374)

### DIFF
--- a/docs/decisions/ADR-033-fleet-label-driven-dispatch-adoption.md
+++ b/docs/decisions/ADR-033-fleet-label-driven-dispatch-adoption.md
@@ -89,7 +89,7 @@ local behavior should change.
 
 ## References
 
-- `repo://wryenmeek/hot-springs-island/docs/decisions/ADR-030-fleet-label-driven-dispatch.md@<pin SHA at port time>`
+- `repo://wryenmeek/hot-springs-island/docs/decisions/ADR-030-fleet-label-driven-dispatch.md@8e125919652bc10ad0a27e9ea1f0837134f67c93#asset?sha256=2de357a09057a3aa3def436c13b8e65a769a653bd189362f447eb86b14a3f3e5`
 - Issue #350
 - Issue #348
 - `scripts/fleet/fleet-plan.ts`

--- a/docs/decisions/ADR-034-fleet-no-notification-on-quota-saturation.md
+++ b/docs/decisions/ADR-034-fleet-no-notification-on-quota-saturation.md
@@ -68,7 +68,7 @@ if the canary/log visibility channels prove insufficient in production.
 
 ## References
 
-- `repo://wryenmeek/hot-springs-island/docs/decisions/ADR-029-fleet-dispatch-quota-saturation-exit-code.md@<pin SHA at port time>`
+- `repo://wryenmeek/hot-springs-island/docs/decisions/ADR-029-fleet-dispatch-quota-saturation-exit-code.md@affffd1b53a0b84d84fd17fcbaa246b1dcce46c2#asset?sha256=73021ac67c12410fdff59e09119d4227a06f2fd5ca8628ff95ff30cea5b554ad`
 - Issue #349
 - Issue #350
 - `scripts/fleet/_fleet_output.ts`


### PR DESCRIPTION
Resolves #374.

## Summary

Replace `<pin SHA at port time>` placeholders with port-time-resolved canonical SourceRefs in the two ADRs cited in the issue:

- `docs/decisions/ADR-033-fleet-label-driven-dispatch-adoption.md` (References section, HSI ADR-030 line)
- `docs/decisions/ADR-034-fleet-no-notification-on-quota-saturation.md` (References section, HSI ADR-029 line)

## Resolution details

| Target | git_sha | Last touched | sha256 |
|---|---|---|---|
| `wryenmeek/hot-springs-island/docs/decisions/ADR-030-fleet-label-driven-dispatch.md` | `8e125919652bc10ad0a27e9ea1f0837134f67c93` | 2026-06-21 | `2de357a09057a3aa3def436c13b8e65a769a653bd189362f447eb86b14a3f3e5` |
| `wryenmeek/hot-springs-island/docs/decisions/ADR-029-fleet-dispatch-quota-saturation-exit-code.md` | `affffd1b53a0b84d84fd17fcbaa246b1dcce46c2` | 2026-06-23 | `73021ac67c12410fdff59e09119d4227a06f2fd5ca8628ff95ff30cea5b554ad` |

Resolution method:
1. `gh api repos/wryenmeek/hot-springs-island/contents/docs/decisions` to locate the two ADR files
2. `gh api repos/.../commits?path=...&per_page=1` to find the last-touched commit per ADR
3. `gh api .../contents/...?ref=<commit> | jq -r .content | base64 -d | shasum -a 256` for byte-accurate SHA-256

`#asset` is used as the anchor per SPEC.md §SourceRef ("anchor required; use `#asset` when line anchors are not applicable") and `scripts/kb/sourceref.py:18` (`_ANCHOR_RE` accepts the `asset` token).

## ADR evolution classification

**Body-only edit** (per ADR evolution pattern in `.github/copilot-instructions.md`):
- No Status change (still `Accepted`)
- No Decision / Consequences / Rationale changes
- Pure provenance resolution (placeholder → real value), equivalent to fixing a broken link
- → No `docs/decisions/README.md` cascade required
- → No ADR amendment section required

## Verification

- `python3 -m pytest tests/kb/test_adr_readme_status_sync.py tests/kb/test_doc_cascade_completeness.py` → **4 passed, 129 subtests passed**
- `python3 -m pytest tests/kb/ -k "sourceref or source_ref"` → **41 passed, 32 subtests passed**
- `grep "pin SHA at port time" docs/decisions/ADR-033*.md docs/decisions/ADR-034*.md` → no matches (placeholders fully resolved)
- Pre-commit hooks (locality ratchet, ADR cross-ref, frontmatter, etc.) all passed on commit

## Scope discipline

The research doc `docs/research/jules-fleet-cross-portfolio-patterns.md` also contains `<pin SHA at port time>` placeholders for the same HSI ADRs (lines 59, 66), plus other Scribe/vscode-genai placeholders. The issue body explicitly defined affected lines as the two ADR References only, and the research doc is itself the canonical documentation of the port-time-pin contract — placeholders there are intentional. Not touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>