### PR TITLE
feat(fleet): parameterize fleet-orchestrator App slug in cloneable-template manifest (#383)

### DIFF
--- a/raw/inbox/cloneable-template.md
+++ b/raw/inbox/cloneable-template.md
@@ -168,13 +168,20 @@ rm -f /tmp/create-gh-app.html
 ### GitHub App for Fleet Orchestration (Issue #310, ADR-036)
 
 Fleet workflows (`fleet-dispatch.yml`, `fleet-merge.yml`, `fleet-dispatch-after-merge.yml`)
-require a **separate** GitHub App — `fleet-orchestrator` — to bypass the
+require a **separate** GitHub App — `<owner>-fleet-orchestrator` — to bypass the
 `GITHUB_TOKEN` downstream-suppression trap (Layer 6: `GITHUB_TOKEN`-authored
 events do not trigger downstream workflows). This App is provisioned ONCE and
 installed on every repo running fleet orchestration.
 
 **Do not widen the source-monitor App above** to fill this role — keep the
 identities (and blast radius) separated.
+
+**Owner-prefix substitution required.** GitHub App slugs are globally unique
+across all of GitHub. Before submitting the manifest below, replace
+`YOUR-OWNER` with your GitHub username or org name (lowercased; e.g.,
+`wryenmeek-fleet-orchestrator`). The substituted slug then propagates into
+the install URL and the downloaded private-key filename — the
+`FLEET_APP_ID` / `FLEET_APP_PRIVATE_KEY` secret names DO NOT change.
 
 **Step 1 — Create the app (browser):**
 
@@ -183,7 +190,7 @@ cat > /tmp/create-fleet-app.html <<'HTMLEOF'
 <!DOCTYPE html><html><body>
 <form id="f" action="https://github.com/settings/apps/new" method="post">
 <input type="hidden" name="manifest" value='{
-  "name": "fleet-orchestrator",
+  "name": "YOUR-OWNER-fleet-orchestrator",
   "url": "https://github.com/OWNER/REPO",
   "hook_attributes": {"active": false},
   "public": false,
@@ -208,15 +215,15 @@ On the App's settings page, scroll to "Private keys" and click "Generate a priva
 
 ```bash
 echo "YOUR_FLEET_APP_ID" | gh secret set FLEET_APP_ID
-gh secret set FLEET_APP_PRIVATE_KEY < ~/Downloads/fleet-orchestrator.*.private-key.pem
+gh secret set FLEET_APP_PRIVATE_KEY < ~/Downloads/<your-owner>-fleet-orchestrator.*.private-key.pem
 
 # Install the app on the repo (browser — one click)
-open "https://github.com/settings/apps/fleet-orchestrator/installations"
+open "https://github.com/settings/apps/<your-owner>-fleet-orchestrator/installations"
 ```
 
 Clean up after install:
 ```bash
-rm ~/Downloads/fleet-orchestrator.*.private-key.pem
+rm ~/Downloads/<your-owner>-fleet-orchestrator.*.private-key.pem
 rm -f /tmp/create-fleet-app.html
 ```
 

--- a/tests/kb/test_fleet_dispatch_app_token_diagnostics.py
+++ b/tests/kb/test_fleet_dispatch_app_token_diagnostics.py
@@ -509,8 +509,12 @@ def _slice_fleet_orchestrator_manifest(template: str) -> str:
     first-mention of `fleet-orchestrator`, which broke under doc reorganization.
     This version anchors on the manifest's JSON `"name"` field — a stable marker
     that only appears once in the document and identifies the manifest unambiguously.
+
+    Per #383 (sec L-4): the slug `fleet-orchestrator` is globally unique across
+    GitHub. The manifest now ships with the placeholder `YOUR-OWNER-fleet-orchestrator`
+    so downstream forks substitute their owner prefix without slug collision.
     """
-    start = template.index('"name": "fleet-orchestrator"')
+    start = template.index('"name": "YOUR-OWNER-fleet-orchestrator"')
     end = template.index("</form>", start)
     return template[start:end]
 
@@ -558,6 +562,14 @@ def test_cloneable_template_fleet_orchestrator_manifest_matches_adr_036(
     doesn't match the documented decision.
     """
     block = _slice_fleet_orchestrator_manifest(cloneable_template_text)
+
+    # Placeholder name pattern (per #383 / sec L-4): the slug is globally
+    # unique on GitHub, so the manifest ships with an owner-prefix placeholder
+    # that downstream forks substitute before submission.
+    assert '"name": "YOUR-OWNER-fleet-orchestrator"' in block, (
+        "manifest must use the YOUR-OWNER-fleet-orchestrator placeholder so "
+        "downstream forks substitute their owner prefix (per #383 / sec L-4)"
+    )
 
     # Positive: every permission ADR-036 grants
     assert '"contents": "write"' in block, "manifest must grant contents:write"


### PR DESCRIPTION
Closes #383.

## Summary

PR #381 security audit (sec L-4) flagged that the fleet-orchestrator manifest in `raw/inbox/cloneable-template.md` hardcoded the globally-unique App slug `fleet-orchestrator`. Downstream forks would hit a slug-collision error on submission.

## Changes

### `raw/inbox/cloneable-template.md` (3 places)

| Line | Before | After |
|---|---|---|
| 186 (manifest) | `"name": "fleet-orchestrator"` | `"name": "YOUR-OWNER-fleet-orchestrator"` |
| 171-185 (section intro) | n/a | Added owner-prefix substitution note + clarification that FLEET_APP_* secret names stay stable |
| 211, 214, 219 (install/cleanup) | `fleet-orchestrator` | `<your-owner>-fleet-orchestrator` (PEM filename + install URL — GitHub names both by the substituted slug) |

### `tests/kb/test_fleet_dispatch_app_token_diagnostics.py`

- `_slice_fleet_orchestrator_manifest` helper: anchor updated from `"name": "fleet-orchestrator"` to `"name": "YOUR-OWNER-fleet-orchestrator"`
- `test_cloneable_template_fleet_orchestrator_manifest_matches_adr_036`: added an explicit assertion (per AC option a) that the placeholder pattern is present in the manifest

## Verification

- `python3 -m pytest tests/kb/test_fleet_dispatch_app_token_diagnostics.py -q` → **25 passed** (full file; baseline was 25 passed, still 25 passed)
- `grep -nE '"name": "fleet-orchestrator"|/fleet-orchestrator\.\*\.private-key|apps/fleet-orchestrator/installations' raw/inbox/cloneable-template.md` → zero matches (no leftover hardcoded references)

## AC checklist

- [x] `raw/inbox/cloneable-template.md` fleet-orchestrator manifest uses a placeholder name (`YOUR-OWNER-fleet-orchestrator`)
- [x] The provisioning instructions tell downstream users to substitute their owner prefix (Step 0 prose addition)
- [x] `test_cloneable_template_fleet_orchestrator_manifest_matches_adr_036` updated to assert the placeholder pattern

## Scope discipline

- Source-monitor manifest at line 127 (`YOUR-REPO-source-monitor`) left untouched — pre-existing pattern from a different issue
- `FLEET_APP_ID` / `FLEET_APP_PRIVATE_KEY` secret names unchanged — only the App slug is parameterized
- No ADR change (issue body explicitly says ADR-036 stays as-is)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
