### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix MD5 usage for FIPS/bandit compliance in tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,7 @@
 **Vulnerability:** Use of weak MD5 hash without `usedforsecurity=False`.
 **Learning:** `hashlib.md5()` triggers `bandit` scanners and FIPS enforcement unless explicitly marked as non-security related.
 **Prevention:** Always pass `usedforsecurity=False` when using MD5 for checksums or versioning to suppress false positives and ensure compatibility in strict environments.
+## 2026-06-27 - [Fix Bandit Alert for MD5 Usage in tests]
+**Vulnerability:** Use of weak MD5 hash without `usedforsecurity=False` in `tests/drive_monitor/test_fetch_content.py` and `tests/kb/test_audit_workspace_friction_queries.py`.
+**Learning:** `hashlib.md5()` triggers `bandit` scanners and FIPS enforcement unless explicitly marked as non-security related, even in test files.
+**Prevention:** Always pass `usedforsecurity=False` when using MD5 for checksums, mock fingerprints, or versioning to suppress false positives and ensure compatibility in strict environments.

--- a/tests/drive_monitor/test_fetch_content.py
+++ b/tests/drive_monitor/test_fetch_content.py
@@ -21,7 +21,7 @@ from scripts.drive_monitor.fetch_content import fetch_content
 # ---------------------------------------------------------------------------
 
 NORMALIZED_BYTES = b"# My Document\n\nContent.\n"
-MD5 = hashlib.md5(b"raw-pdf-content").hexdigest()
+MD5 = hashlib.md5(b"raw-pdf-content", usedforsecurity=False).hexdigest()
 SHA256 = hashlib.sha256(NORMALIZED_BYTES).hexdigest()
 
 

--- a/tests/kb/test_audit_workspace_friction_queries.py
+++ b/tests/kb/test_audit_workspace_friction_queries.py
@@ -261,7 +261,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["prompt_length"], len("Repeat this instruction"))
         self.assertEqual(
             row["prompt_fingerprint"],
-            hashlib.md5(b"Repeat this instruction").hexdigest(),
+            hashlib.md5(b"Repeat this instruction", usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_rows_match_same_tool_request_payload_without_raw_args(self) -> None:
@@ -285,7 +285,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["request_length"], len('{"command": "python3 -m pytest tests/kb/test_x.py"}'))
         self.assertEqual(
             row["request_fingerprint"],
-            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}').hexdigest(),
+            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}', usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_window_includes_exact_boundary_and_excludes_after_boundary(self) -> None:
@@ -599,7 +599,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
 
     @staticmethod
     def _sqlite_md5(value: str) -> str:
-        return hashlib.md5(value.encode("utf-8")).hexdigest()
+        return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
 
     @staticmethod
     def _sqlite_regexp_extract(value: str, pattern: str, group_index: int) -> str:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: MD5 was used in test files without `usedforsecurity=False`. This triggers `bandit` scanner warnings and creates issues in strict environments enforcing FIPS compliance since MD5 is considered a weak cryptographic algorithm.
🎯 Impact: Security scanning and test execution in strict environments might fail.
🔧 Fix: Appended `usedforsecurity=False` in `hashlib.md5(...)` usage.
✅ Verification: Ran unit tests via `pytest` to confirm they continue to execute cleanly.

---
*PR created automatically by Jules for task [17688218314429229658](https://jules.google.com/task/17688218314429229658) started by @wryenmeek*