### PR TITLE
fix(headings): pre-normalize CRLF and bare CR in extract_headings (#409)

### DIFF
--- a/scripts/kb/CONTEXT.md
+++ b/scripts/kb/CONTEXT.md
@@ -1,6 +1,6 @@
 ---
 scope: module
-last_updated: 2026-06-23
+last_updated: 2026-06-28
 ---
 
 # CONTEXT — scripts/kb/

--- a/scripts/kb/page_template_utils.py
+++ b/scripts/kb/page_template_utils.py
@@ -278,17 +278,20 @@ def extract_headings(body: str) -> set[str]:
     ``splitlines()`` to avoid materializing an O(N) line array. Skips
     headings inside fenced code blocks (``` or ~~~).
 
-    **Bare CR limitation:** Only LF (``\\n``) is treated as a line break.
-    Bare CR (Classic Mac) and CRLF input where the CR is treated as part of
-    the heading text are NOT detected. Practical impact is negligible:
-    bare-CR files are extinct, and CRLF is handled because the LF still
-    splits the line (the trailing CR ends up inside ``.strip()``'s scope).
-    Documented for completeness rather than fixed because the streaming
-    branch would require a regex to be CR-aware, which costs more than
-    the lost compatibility is worth.
+    CRLF and bare CR (Classic Mac) line endings are normalized to LF before
+    streaming, so all three common line-ending conventions are handled correctly.
+    The normalization is guarded by an ``\\r`` membership test so LF-only bodies
+    (the common case) pay only a single O(N) scan rather than two replace passes.
     """
     headings: set[str] = set()
     in_fenced_block = False
+
+    # Normalize line endings: CRLF → LF, then bare CR → LF.
+    # The streaming find('\n') loop only treats LF as a break;
+    # this guards against Classic-Mac CR-only files producing
+    # silently empty heading lists.
+    if "\r" in body:
+        body = body.replace("\r\n", "\n").replace("\r", "\n")
 
     def _maybe_add(line: str) -> None:
         nonlocal in_fenced_block

--- a/tests/kb/test_extract_headings.py
+++ b/tests/kb/test_extract_headings.py
@@ -73,11 +73,15 @@ def test_unclosed_fence_at_eof_then_trailing_heading_via_lf() -> None:
 
 
 def test_crlf_line_endings_still_extract_headings() -> None:
-    """CRLF input: the LF still splits the line; the trailing CR is part
-    of the heading text but gets normalized by ``.strip()``.
-    """
+    """CRLF input: normalized to LF before streaming."""
     body = "# H1\r\n# H2\r\n"
     assert extract_headings(body) == {"# H1", "# H2"}
+
+
+def test_bare_cr_line_endings_extract_headings() -> None:
+    """Bare CR (Classic Mac) input: normalized to LF before streaming."""
+    body = "# Title\r## Sub\rbody text\r"
+    assert extract_headings(body) == {"# Title", "## Sub"}
 
 
 def test_non_heading_lines_ignored() -> None:


### PR DESCRIPTION
## Summary

Implements #409. The `find('\n')`-streaming rewrite in PR #387 only treated LF as a line break. Bare CR (Classic Mac, pre-2001) input produced silently empty heading lists, which could break `check_page_template` validation downstream with no obvious cause. CRLF already worked via `.strip()`, but this makes the guarantee explicit and documented.

The fix adds a guarded one-pass normalization at the top of `extract_headings`: if the body contains `\r`, replace `\r\n → \n` then bare `\r → \n` before streaming. The `if "\r" in body:` guard preserves the O(1) fast path for LF-only bodies (the overwhelmingly common case).

> **Note:** Issue #409 carried a "Defer" decision. This PR implements it per explicit user request to implement all ready-for-agent issues — the fix is trivial, defensive, and has clear acceptance criteria.

## Closes #409

## Acceptance criteria

- [x] Bare-CR pre-normalization added to `extract_headings`
- [x] New test covering bare-CR input (`test_bare_cr_line_endings_extract_headings`)
- [x] Existing CRLF test still passes (`test_crlf_line_endings_still_extract_headings`)
- [x] Bare-CR limitation removed from docstring

## Files changed

- `scripts/kb/page_template_utils.py` — added `\r`-guard normalization block; updated docstring
- `tests/kb/test_extract_headings.py` — added `test_bare_cr_line_endings_extract_headings`; tightened CRLF test docstring

## Test plan

```
python3 -m pytest tests/kb/test_extract_headings.py -v
# → 23 passed

python3 -m pytest tests/kb/ -q
# → 1920 passed, 2371 subtests passed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
