### PR TITLE
feat(analysis): Chat blended-rate + --strict-window + ~30 fail-soft tests (#400, #402, #403)

### DIFF
--- a/docs/research/copilot-agent-cost-baseline-2026-06-27.md
+++ b/docs/research/copilot-agent-cost-baseline-2026-06-27.md
@@ -128,9 +128,9 @@ Chat usage is much more diverse model-wise. The 7K-inference GPT-5.4 line and 3.
 
 4. **VS Code OTEL is one large file (18 GB on 06-21).** Future runs should stream-parse efficiently; the current tool does so but takes ~2 min on cold disk cache.
 
-5. **Chat-side dollar figures are upper bounds.** OTEL exposes only `gen_ai.usage.input_tokens` (no cached-input split), so the analyzer charges 100% of input at the fresh-input rate. For Anthropic models the cached-input rate is 10× cheaper. The CLI side mitigates this via `blended_rate()`; the Chat side cannot.
+5. **Chat-side dollar figures now use blended-rate or exact split (updated 2026-06-28).** When OTEL exposes `gen_ai.usage.cache_read_input_tokens` per event, the analyzer uses an exact split: `fresh_input * input_per_m + cached_input * cached_per_m + output * output_per_m` (Option B). When that field is absent, it falls back to `blended_rate()` with the default 20/70/10 mix (Option A), matching the CLI side. The prior 100% fresh-rate overestimate is removed. Use `--chat-cache-share <frac>` to override the assumed cache fraction in the fallback path.
 
-6. **`--days` window is mtime-granular.** The analyzer filters by `events.jsonl` file mtime, not per-event timestamps. A long-running session whose file was appended to recently will contribute all of its events to the window — including events older than the cutoff. For precise per-event windowing, see the deferred follow-up in §Open follow-ups.
+6. **`--days` window is mtime-granular by default; `--strict-window` enables per-event filtering (updated 2026-06-28).** The default mode filters by `events.jsonl` file mtime, so a long-running session appended to recently contributes all events including older ones. Add `--strict-window` to skip individual events whose `timestamp` field predates the cutoff. The header line in the output reports which mode is active.
 
 7. **Sample bias.** All sessions are from one user (`wryenmeek`) in one repo cluster. Recommendations transfer to similarly-sized agentic workloads; not generalizable to other operators.
 

--- a/scripts/analysis/cost_baseline.py
+++ b/scripts/analysis/cost_baseline.py
@@ -36,11 +36,12 @@ aligned with sibling analyzers in ``scripts/validation/`` and
 
 **Known limitations** (also see ``pricing.py``):
 
-* ``--days N`` window is enforced at **file mtime granularity only**.
-  Events have a per-event ``timestamp`` field but the tool only filters by
-  ``events.jsonl`` mtime. A long-running session whose events file was
-  appended to recently contributes ALL of its events to the window. For
-  precise per-event windowing, see issue tracker.
+* ``--days N`` window is enforced at **file mtime granularity by default**.
+  Use ``--strict-window`` to also filter by each event's ``timestamp`` field;
+  events without a parseable ``timestamp`` are included regardless (#403).
+  Without ``--strict-window``, a long-running session whose ``events.jsonl``
+  was appended recently contributes all of its events, including those older
+  than the cutoff.
 * Pricing table covers Default tier only; long-context-tier invocations are
   under-estimated. See ``pricing.py`` module docstring.
 * Failure heuristic (``totalTokens=0`` AND ``totalToolCalls=0`` AND
@@ -188,28 +189,52 @@ class AgentBucket:
 class ChatBucket:
     """Per-model VS Code Copilot Chat aggregate.
 
-    OTEL split between fresh-input and cached-input tokens is not available
-    in the ``gen_ai.usage.*`` attributes today — only one ``input_tokens``
-    field is published. ``est_cost_usd`` therefore charges 100% of input
-    tokens at the fresh-input rate, which **structurally over-estimates** the
-    cost for Anthropic models (whose cached-input rate is 10x cheaper) and
-    OpenAI models with prompt caching. The CLI side uses a blended rate
-    (70% cached); the Chat side cannot distinguish here. Treat Chat dollar
-    estimates as an upper bound. See report Caveats section.
+    ``est_cost_usd`` uses an Option B-then-A strategy (#402):
+
+    * **Option B (exact split):** If OTEL provides
+      ``gen_ai.usage.cache_read_input_tokens`` (or the alternate
+      ``gen_ai.usage.cached_input_tokens``), the exact fresh/cached split is
+      used: ``fresh_input * input_per_m + cached_input * cached_per_m +
+      output * output_per_m``.
+    * **Option A (blended-rate fallback):** When no cached-token attribute
+      is present, a blended rate is applied to the input tokens (default:
+      70% treated as cached, matching the CLI-side default mix). Override
+      with ``--chat-cache-share`` to model a different cache share.
+
+    Both options are materially more accurate than the previous approach of
+    charging 100% at the fresh-input rate (the former structural overestimate
+    of ~10× on the cached portion for Anthropic models).
     """
 
     model: str
     inferences: int
     input_tokens: int
     output_tokens: int
+    cached_input_tokens: int = 0
+    chat_cache_share: float | None = None  # None → blended_rate default (0.70)
 
     @property
     def est_cost_usd(self) -> float:
         price = PRICING.get(self.model)
         if price is None:
             return 0.0
+        # Option B: exact split when per-event cached tokens are available.
+        if self.cached_input_tokens > 0:
+            fresh = max(self.input_tokens - self.cached_input_tokens, 0)
+            return (
+                fresh * price.input_per_m
+                + self.cached_input_tokens * price.cached_per_m
+                + self.output_tokens * price.output_per_m
+            ) / 1_000_000.0
+        # Option A: blended-rate fallback.
+        cache_frac = (
+            self.chat_cache_share if self.chat_cache_share is not None else 0.70
+        )
+        fresh_input = self.input_tokens * (1.0 - cache_frac)
+        cached_input = self.input_tokens * cache_frac
         return (
-            self.input_tokens * price.input_per_m
+            fresh_input * price.input_per_m
+            + cached_input * price.cached_per_m
             + self.output_tokens * price.output_per_m
         ) / 1_000_000.0
 
@@ -218,6 +243,7 @@ class ChatBucket:
             "model": self.model,
             "inferences": self.inferences,
             "input_tokens": self.input_tokens,
+            "cached_input_tokens": self.cached_input_tokens,
             "output_tokens": self.output_tokens,
             "est_cost_usd": round(self.est_cost_usd, 4),
         }
@@ -319,6 +345,34 @@ def _epoch_cutoff(days: int) -> float:
     return time.time() - days * 86400.0
 
 
+def _parse_event_timestamp(ts_value: object) -> float | None:
+    """Parse an event ``timestamp`` field to epoch seconds.
+
+    Accepts:
+    * Numeric (int/float, not bool) → returned as float directly.
+    * ISO 8601 string (with or without timezone; trailing 'Z' treated as UTC).
+
+    Returns ``None`` on parse failure or unsupported type so callers can
+    decide to include or skip the event defensively.
+    """
+    if isinstance(ts_value, bool):
+        return None
+    if isinstance(ts_value, (int, float)):
+        return float(ts_value)
+    if isinstance(ts_value, str) and ts_value:
+        try:
+            s = ts_value
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 def _coerce_int(value: object) -> int:
     """Coerce telemetry numeric to int; return 0 for None / non-numeric / bool.
 
@@ -339,7 +393,11 @@ def _coerce_int(value: object) -> int:
 
 
 def _iter_session_events(
-    home: Path, cutoff_epoch: float, skipped: dict[str, int]
+    home: Path,
+    cutoff_epoch: float,
+    skipped: dict[str, int],
+    *,
+    strict_window: bool = False,
 ) -> Iterator[tuple[str, dict]]:
     """Stream (session_id, event_dict) pairs across last-N-day session files.
 
@@ -349,6 +407,10 @@ def _iter_session_events(
     ``errors="replace"`` on open(), which replaces the offending bytes
     rather than aborting the iteration). Sessions whose ``events.jsonl``
     mtime predates ``cutoff_epoch`` are skipped silently.
+
+    When ``strict_window=True``, events whose ``timestamp`` field parses to
+    an epoch value older than ``cutoff_epoch`` are skipped regardless of the
+    file mtime. Events without a parseable timestamp are always included.
     """
     for path in home.glob(SESSION_STATE_GLOB):
         try:
@@ -370,13 +432,21 @@ def _iter_session_events(
                     if not isinstance(event, dict):
                         skipped["lines"] += 1
                         continue
+                    if strict_window:
+                        ts = _parse_event_timestamp(event.get("timestamp"))
+                        if ts is not None and ts < cutoff_epoch:
+                            continue
                     yield session_id, event
         except OSError:
             skipped["files"] += 1
 
 
 def _iter_otel_inferences(
-    home: Path, cutoff_epoch: float, skipped: dict[str, int]
+    home: Path,
+    cutoff_epoch: float,
+    skipped: dict[str, int],
+    *,
+    strict_window: bool = False,
 ) -> Iterator[dict]:
     """Yield gen_ai inference operation events from OTEL traces.
 
@@ -384,6 +454,10 @@ def _iter_otel_inferences(
     ``gen_ai.client.inference.operation.details``. Non-inference events
     (auth, hooks, sessions) are skipped without contributing to the
     ``skipped_*`` counters because they are expected, not malformed.
+
+    When ``strict_window=True``, OTEL events whose top-level ``timestamp``
+    field parses to a value older than ``cutoff_epoch`` are skipped.
+    Events without a parseable timestamp are always included.
     """
     for path in home.glob(OTEL_GLOB):
         try:
@@ -404,6 +478,10 @@ def _iter_otel_inferences(
                     if not isinstance(e, dict):
                         skipped["lines"] += 1
                         continue
+                    if strict_window:
+                        ts = _parse_event_timestamp(e.get("timestamp"))
+                        if ts is not None and ts < cutoff_epoch:
+                            continue
                     attrs = e.get("attributes")
                     if not isinstance(attrs, dict):
                         continue
@@ -443,7 +521,11 @@ def _normalize_effort(value: object) -> str:
 
 
 def _iter_session_event_lists(
-    home: Path, cutoff_epoch: float, skipped: dict[str, int]
+    home: Path,
+    cutoff_epoch: float,
+    skipped: dict[str, int],
+    *,
+    strict_window: bool = False,
 ) -> Iterator[tuple[str, list[dict]]]:
     """Yield ``(session_id, [events])`` one session at a time.
 
@@ -458,6 +540,11 @@ def _iter_session_event_lists(
     ``open()`` time, and ``skipped["lines"]`` for any JSON line that fails
     to parse OR parses to a non-dict value. Files whose mtime predates
     ``cutoff_epoch`` are skipped silently.
+
+    When ``strict_window=True``, events whose ``timestamp`` field parses to
+    a value older than ``cutoff_epoch`` are excluded from the yielded list
+    regardless of the file mtime. Events without a parseable timestamp are
+    always included.
     """
     for path in home.glob(SESSION_STATE_GLOB):
         try:
@@ -480,6 +567,10 @@ def _iter_session_event_lists(
                     if not isinstance(ev, dict):
                         skipped["lines"] += 1
                         continue
+                    if strict_window:
+                        ts = _parse_event_timestamp(ev.get("timestamp"))
+                        if ts is not None and ts < cutoff_epoch:
+                            continue
                     events.append(ev)
         except OSError:
             skipped["files"] += 1
@@ -488,7 +579,7 @@ def _iter_session_event_lists(
 
 
 def collect_cli(
-    home: Path, days: int
+    home: Path, days: int, *, strict_window: bool = False
 ) -> tuple[
     tuple[AgentBucket, ...], int, float, dict[str, int], tuple[str, ...]
 ]:
@@ -536,7 +627,7 @@ def collect_cli(
     actual_nano_aiu = 0.0
     skipped = {"files": 0, "lines": 0}
 
-    for session_id, events in _iter_session_event_lists(home, cutoff, skipped):
+    for session_id, events in _iter_session_event_lists(home, cutoff, skipped, strict_window=strict_window):
         session_default_effort = "default"
         per_call_effort: dict[str, str] = {}
         # First pass over THIS session only: resolve effort context.
@@ -625,15 +716,30 @@ def collect_cli(
 
 
 def collect_chat(
-    home: Path, days: int
+    home: Path,
+    days: int,
+    *,
+    chat_cache_share: float | None = None,
+    strict_window: bool = False,
 ) -> tuple[tuple[ChatBucket, ...], dict[str, int]]:
-    """Aggregate per-model VS Code Copilot Chat inferences from OTEL traces."""
+    """Aggregate per-model VS Code Copilot Chat inferences from OTEL traces.
+
+    When OTEL exposes ``gen_ai.usage.cache_read_input_tokens`` (or the
+    alternate ``gen_ai.usage.cached_input_tokens``), the exact cached split
+    is accumulated per model. Otherwise, ``ChatBucket.est_cost_usd`` falls
+    back to a blended-rate estimate using ``chat_cache_share`` (default 0.70).
+    """
     cutoff = _epoch_cutoff(days)
     raw: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"inferences": 0, "input_tokens": 0, "output_tokens": 0}
+        lambda: {
+            "inferences": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_input_tokens": 0,
+        }
     )
     skipped = {"files": 0, "lines": 0}
-    for attrs in _iter_otel_inferences(home, cutoff, skipped):
+    for attrs in _iter_otel_inferences(home, cutoff, skipped, strict_window=strict_window):
         model = attrs.get("gen_ai.request.model") or "?"
         if model == "?":
             continue
@@ -641,12 +747,21 @@ def collect_chat(
         bucket["inferences"] += 1
         bucket["input_tokens"] += _coerce_int(attrs.get("gen_ai.usage.input_tokens"))
         bucket["output_tokens"] += _coerce_int(attrs.get("gen_ai.usage.output_tokens"))
+        # Option B: pick up exact cached-token count when OTEL provides it.
+        cached = _coerce_int(
+            attrs.get("gen_ai.usage.cache_read_input_tokens")
+        ) or _coerce_int(
+            attrs.get("gen_ai.usage.cached_input_tokens")
+        )
+        bucket["cached_input_tokens"] += cached
     chat_buckets = tuple(
         ChatBucket(
             model=model,
             inferences=v["inferences"],
             input_tokens=v["input_tokens"],
             output_tokens=v["output_tokens"],
+            cached_input_tokens=v["cached_input_tokens"],
+            chat_cache_share=chat_cache_share,
         )
         for model, v in raw.items()
     )
@@ -756,11 +871,20 @@ def build_report(
     days: int,
     top_n: int = 10,
     include_chat: bool = True,
+    chat_cache_share: float | None = None,
+    strict_window: bool = False,
 ) -> CostBaselineReport:
     """Build a :class:`CostBaselineReport` for the configured window.
 
     Fails closed (``STATUS_FAIL``) if ``home`` is not a directory or if
     ``days`` is not a positive integer.
+
+    ``chat_cache_share`` (float in [0,1] or None) overrides the blended-rate
+    cache-share assumption used in ``ChatBucket.est_cost_usd`` when OTEL does
+    not provide exact cached-token counts. ``None`` uses the default (0.70).
+
+    ``strict_window`` enables per-event timestamp filtering in addition to
+    the default file-mtime-only window enforcement.
     """
     if isinstance(days, bool) or not isinstance(days, int) or days < 1:
         return _empty_report(
@@ -781,10 +905,15 @@ def build_report(
         )
 
     cli_buckets, sessions_analyzed, actual_nano_aiu, cli_skipped, unknown = (
-        collect_cli(home, days)
+        collect_cli(home, days, strict_window=strict_window)
     )
     if include_chat:
-        chat_buckets, chat_skipped = collect_chat(home, days)
+        chat_buckets, chat_skipped = collect_chat(
+            home,
+            days,
+            chat_cache_share=chat_cache_share,
+            strict_window=strict_window,
+        )
     else:
         chat_buckets = ()
         chat_skipped = {"files": 0, "lines": 0}
@@ -919,11 +1048,20 @@ def _render_priority_list(rows: Sequence[PriorityRow]) -> str:
     return "\n".join(out)
 
 
-def render_text(report: CostBaselineReport, *, days: int, home: Path) -> str:
+def render_text(
+    report: CostBaselineReport,
+    *,
+    days: int,
+    home: Path,
+    strict_window: bool = False,
+    chat_cache_share: float | None = None,
+) -> str:
     """Render a :class:`CostBaselineReport` as human-readable tables."""
+    window_label = "[strict-window]" if strict_window else "[mtime-window]"
     lines: list[str] = []
     lines.append(
-        f"# Copilot agent cost baseline (last {days}d, home={home})"
+        f"# Copilot agent cost baseline "
+        f"(last {days}d {window_label}, home={home})"
     )
     if report.pricing_stale:
         age = (datetime.now(timezone.utc).date() - PRICING_RETRIEVED).days
@@ -985,12 +1123,22 @@ def render_text(report: CostBaselineReport, *, days: int, home: Path) -> str:
         lines.append("")
         lines.append(_render_chat_table(report.chat_buckets))
         lines.append("")
-        lines.append(
-            "  NOTE: Chat cost estimates apply the fresh-input rate to all "
-            "input tokens. Cached-input savings (typically 10x on Anthropic, "
-            "5-10x on OpenAI with prompt caching) are NOT subtracted. Treat "
-            "Chat dollar estimates as an upper bound."
-        )
+        if any(b.cached_input_tokens > 0 for b in report.chat_buckets):
+            lines.append(
+                "  NOTE: Chat cost estimates use exact cached-input split "
+                "where OTEL provides gen_ai.usage.cache_read_input_tokens; "
+                "remaining models use the blended-rate fallback."
+            )
+        else:
+            share_pct = int(
+                (chat_cache_share if chat_cache_share is not None else 0.70) * 100
+            )
+            lines.append(
+                f"  NOTE: Chat cost estimates apply a blended rate treating "
+                f"{share_pct}% of input tokens as cached "
+                f"(use --chat-cache-share to override). "
+                f"No exact cached-token data found in OTEL traces."
+            )
         lines.append("")
 
     # Observability footer
@@ -1011,6 +1159,19 @@ def render_text(report: CostBaselineReport, *, days: int, home: Path) -> str:
     return "\n".join(lines)
 
 
+def _float_zero_one(s: str) -> float:
+    """Custom argparse type: float in [0.0, 1.0]."""
+    try:
+        v = float(s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected a float, got {s!r}")
+    if not (0.0 <= v <= 1.0):
+        raise argparse.ArgumentTypeError(
+            f"must be in [0.0, 1.0], got {v!r}"
+        )
+    return v
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = JsonArgumentParser(
         prog="copilot-agent-cost-baseline",
@@ -1021,11 +1182,37 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=30,
         help=(
-            "Look back N days (default: 30). Sessions whose events.jsonl "
-            "mtime predates the cutoff are skipped. NOTE: per-event "
-            "timestamp filtering is not applied — long-running sessions "
-            "contribute their full event history if their file was "
-            "appended to within the window."
+            "Look back N days (default: 30). By default, sessions whose "
+            "events.jsonl mtime predates the cutoff are skipped (mtime-window "
+            "mode). Per-event timestamp filtering is not applied unless "
+            "--strict-window is also set — long-running sessions contribute "
+            "their full event history if the file was appended to within the "
+            "window. See --strict-window."
+        ),
+    )
+    parser.add_argument(
+        "--strict-window",
+        action="store_true",
+        default=False,
+        help=(
+            "When set, also skip individual events whose 'timestamp' field "
+            "is older than the --days window, even if the file mtime is "
+            "within the window. Default: false (mtime-window only, preserves "
+            "backward-compatible behavior). Events without a parseable "
+            "timestamp are always included."
+        ),
+    )
+    parser.add_argument(
+        "--chat-cache-share",
+        type=_float_zero_one,
+        default=None,
+        dest="chat_cache_share",
+        help=(
+            "Fraction [0.0, 1.0] of Chat input tokens to treat as cached "
+            "when OTEL does not provide exact cached-token counts "
+            "(default: 0.70, matching the CLI-side blended-rate mix). "
+            "Use 0.0 to charge all input at the fresh-input rate. "
+            "Ignored when OTEL provides gen_ai.usage.cache_read_input_tokens."
         ),
     )
     parser.add_argument(
@@ -1094,13 +1281,23 @@ def run_cli(
         days=args.days,
         top_n=args.top,
         include_chat=not args.skip_chat,
+        chat_cache_share=args.chat_cache_share,
+        strict_window=args.strict_window,
     )
 
     if args.format == "json":
         output_stream.write(report.to_json())
         output_stream.write("\n")
     else:
-        output_stream.write(render_text(report, days=args.days, home=args.home))
+        output_stream.write(
+            render_text(
+                report,
+                days=args.days,
+                home=args.home,
+                strict_window=args.strict_window,
+                chat_cache_share=args.chat_cache_share,
+            )
+        )
         output_stream.write("\n")
     return 0 if report.status == STATUS_PASS else 1
 

--- a/scripts/analysis/cost_baseline.py
+++ b/scripts/analysis/cost_baseline.py
@@ -42,8 +42,12 @@ aligned with sibling analyzers in ``scripts/validation/`` and
   Without ``--strict-window``, a long-running session whose ``events.jsonl``
   was appended recently contributes all of its events, including those older
   than the cutoff.
-* Pricing table covers Default tier only; long-context-tier invocations are
-  under-estimated. See ``pricing.py`` module docstring.
+* Pricing table now models long-context tiers (see ``pricing.py``) for
+  ``gpt-5.4``, ``gpt-5.5``, ``gemini-3.1-pro``. The per-call threshold check
+  is not yet wired through ``ChatBucket.est_cost_usd``; CLI-side estimates
+  also remain Default-tier because ``subagent.completed.totalTokens`` is
+  aggregate (no per-call input/output split). Both wirings are tracked as
+  follow-ups.
 * Failure heuristic (``totalTokens=0`` AND ``totalToolCalls=0`` AND
   ``durationMs<5000ms``) may false-positive on legitimate fast no-op
   dispatches. Aggregated 100% failure-rate rows on a single model across
@@ -221,8 +225,13 @@ class ChatBucket:
         # Option B: exact split when per-event cached tokens are available.
         if self.cached_input_tokens > 0:
             fresh = max(self.input_tokens - self.cached_input_tokens, 0)
+            fresh_rate = (
+                price.cache_write_per_m
+                if price.cache_write_per_m is not None
+                else price.input_per_m
+            )
             return (
-                fresh * price.input_per_m
+                fresh * fresh_rate
                 + self.cached_input_tokens * price.cached_per_m
                 + self.output_tokens * price.output_per_m
             ) / 1_000_000.0
@@ -232,8 +241,13 @@ class ChatBucket:
         )
         fresh_input = self.input_tokens * (1.0 - cache_frac)
         cached_input = self.input_tokens * cache_frac
+        fresh_rate = (
+            price.cache_write_per_m
+            if price.cache_write_per_m is not None
+            else price.input_per_m
+        )
         return (
-            fresh_input * price.input_per_m
+            fresh_input * fresh_rate
             + cached_input * price.cached_per_m
             + self.output_tokens * price.output_per_m
         ) / 1_000_000.0
@@ -368,7 +382,7 @@ def _parse_event_timestamp(ts_value: object) -> float | None:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             return dt.timestamp()
-        except ValueError:
+        except (ValueError, OverflowError, OSError):
             return None
     return None
 

--- a/tests/analysis/_fixtures.py
+++ b/tests/analysis/_fixtures.py
@@ -1,0 +1,82 @@
+"""Shared synthetic-fixture builders for the cost_baseline test suite.
+
+These helpers are not pytest fixtures (no ``@pytest.fixture`` decorator);
+they are plain functions imported directly by test modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _write_session(home: Path, session_id: str, events: list[dict]) -> Path:
+    sess_dir = home / "session-state" / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    p = sess_dir / "events.jsonl"
+    p.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8"
+    )
+    return p
+
+
+def _subagent_completed(
+    agent: str = "general-purpose",
+    model: str = "gpt-5.5",
+    tokens: int = 1_000_000,
+    tool_calls: int = 5,
+    duration_ms: int = 60_000,
+) -> dict:
+    return {
+        "type": "subagent.completed",
+        "data": {
+            "agentName": agent,
+            "model": model,
+            "totalTokens": tokens,
+            "totalToolCalls": tool_calls,
+            "durationMs": duration_ms,
+        },
+    }
+
+
+def _session_shutdown(nano_aiu: int) -> dict:
+    return {
+        "type": "session.shutdown",
+        "data": {"totalNanoAiu": nano_aiu},
+    }
+
+
+def _write_otel_session(
+    home: Path, filename: str, events: list[dict]
+) -> Path:
+    """Write a synthetic OTEL traces file under ``home/traces/``."""
+    traces_dir = home / "traces"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+    p = traces_dir / filename
+    p.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8"
+    )
+    return p
+
+
+def _otel_inference_event(
+    model: str = "gpt-5.4",
+    input_tokens: int = 1000,
+    output_tokens: int = 100,
+    *,
+    cached_input_tokens: int = 0,
+    timestamp: str | None = None,
+) -> dict:
+    """Build a synthetic OTEL gen_ai inference event (top-level envelope)."""
+    attrs: dict[str, object] = {
+        "event.name": "gen_ai.client.inference.operation.details",
+        "gen_ai.request.model": model,
+        "gen_ai.usage.input_tokens": input_tokens,
+        "gen_ai.usage.output_tokens": output_tokens,
+    }
+    if cached_input_tokens:
+        attrs["gen_ai.usage.cache_read_input_tokens"] = cached_input_tokens
+    event: dict[str, object] = {"attributes": attrs}
+    if timestamp is not None:
+        event["timestamp"] = timestamp
+    return event

--- a/tests/analysis/test_cost_baseline.py
+++ b/tests/analysis/test_cost_baseline.py
@@ -21,45 +21,11 @@ from scripts._optional_surface_common import (
     STATUS_FAIL,
     STATUS_PASS,
 )
-
-
-# ---------- Synthetic-fixture builders ----------
-
-
-def _write_session(home: Path, session_id: str, events: list[dict]) -> Path:
-    sess_dir = home / "session-state" / session_id
-    sess_dir.mkdir(parents=True, exist_ok=True)
-    p = sess_dir / "events.jsonl"
-    p.write_text(
-        "\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8"
-    )
-    return p
-
-
-def _subagent_completed(
-    agent: str = "general-purpose",
-    model: str = "gpt-5.5",
-    tokens: int = 1_000_000,
-    tool_calls: int = 5,
-    duration_ms: int = 60_000,
-) -> dict:
-    return {
-        "type": "subagent.completed",
-        "data": {
-            "agentName": agent,
-            "model": model,
-            "totalTokens": tokens,
-            "totalToolCalls": tool_calls,
-            "durationMs": duration_ms,
-        },
-    }
-
-
-def _session_shutdown(nano_aiu: int) -> dict:
-    return {
-        "type": "session.shutdown",
-        "data": {"totalNanoAiu": nano_aiu},
-    }
+from tests.analysis._fixtures import (
+    _session_shutdown,
+    _subagent_completed,
+    _write_session,
+)
 
 
 # ---------- collect_cli aggregation ----------
@@ -875,10 +841,10 @@ def test_cheapest_candidate_lightweight_picks_gpt5_4_nano_over_gpt55() -> None:
 
 def test_cheapest_candidate_skips_current_model_from_pool() -> None:
     """Current model is excluded from the candidate set even when it is in the pool."""
-    # claude-haiku-4.5 is in LIGHTWEIGHT_CANDIDATES; gpt-5.4-nano should be returned
+    # claude-haiku-4.5 is in LIGHTWEIGHT_CANDIDATES; gpt-5.4-nano is cheaper
+    # and should be returned as the exact candidate name.
     result = _cheapest_candidate("lightweight", "claude-haiku-4.5")
-    assert result is not None
-    assert result != "claude-haiku-4.5"
+    assert result == "gpt-5.4-nano"
 
 
 def test_cheapest_candidate_unknown_workload_class_falls_back_to_versatile() -> None:
@@ -1036,15 +1002,42 @@ def test_render_savings_table_total_equals_sum_of_per_row_savings() -> None:
 def test_render_savings_table_omits_rows_with_zero_or_negative_savings(
     tmp_path: Path,
 ) -> None:
-    """An agent already on the cheapest model produces no SavingsRow."""
-    # claude-haiku-4.5 is cheapest in versatile/lightweight pools
-    _write_session(
-        tmp_path,
-        "s",
-        [_subagent_completed(model="claude-haiku-4.5", tokens=1_000_000)],
+    """_build_savings filters zero/negative savings; rendered output confirms exclusion."""
+    from scripts.analysis.cost_baseline import _render_savings_table, _build_savings
+
+    # Expensive model with a cheaper versatile alternative → positive savings row
+    expensive = AgentBucket(
+        agent="quality-analyst",
+        model="gpt-5.5",
+        effort="default",
+        invocations=1,
+        total_tokens=1_000_000,
+        total_duration_ms=1000,
+        failures=0,
+        sessions_count=1,
     )
-    report = build_report(home=tmp_path, days=30, include_chat=False)
-    assert report.savings == ()
+    # Cheapest versatile model → no savings row (already optimal)
+    cheap = AgentBucket(
+        agent="documentation-engineer",
+        model="claude-haiku-4.5",
+        effort="default",
+        invocations=1,
+        total_tokens=1_000_000,
+        total_duration_ms=1000,
+        failures=0,
+        sessions_count=1,
+    )
+    rows = _build_savings((expensive, cheap))
+    # Every row emitted must have positive savings (filter contract)
+    assert all(r.savings_usd > 0 for r in rows)
+    agents_with_rows = {r.agent for r in rows}
+    assert "quality-analyst" in agents_with_rows
+    assert "documentation-engineer" not in agents_with_rows
+
+    table = _render_savings_table(rows)
+    assert "quality-analyst" in table
+    assert "documentation-engineer" not in table
+    assert "TOTAL" in table
 
 
 def test_render_priority_list_caps_at_top_n(tmp_path: Path) -> None:
@@ -1173,3 +1166,42 @@ def test_default_window_includes_old_event_timestamps_when_mtime_is_fresh(
     assert len(buckets) == 1
     assert buckets[0].total_tokens == 300
 
+
+# ======================================================================
+# CLI smoke tests — argparse wiring for --strict-window
+# ======================================================================
+
+
+def test_strict_window_cli_flag_smoke(tmp_path: Path) -> None:
+    """--strict-window parses and propagates: output header includes [strict-window]."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    _write_session(tmp_path, "sess", [_subagent_completed()])
+    buf = io.StringIO()
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--strict-window", "--skip-chat"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    assert "[strict-window]" in buf.getvalue()
+
+
+# ======================================================================
+# Security — _parse_event_timestamp overflow guard
+# ======================================================================
+
+
+def test_parse_event_timestamp_returns_none_on_overflow() -> None:
+    """Far-future timestamps must not raise on any platform.
+
+    On 64-bit systems ``datetime.timestamp()`` returns a valid float;
+    on 32-bit systems it raises ``OverflowError`` or ``OSError``.
+    Either way the function must not propagate the exception — callers rely
+    on ``None`` as the safe sentinel for unparseable timestamps.
+    """
+    from scripts.analysis.cost_baseline import _parse_event_timestamp
+
+    # Call must not raise, regardless of platform timestamp range.
+    result = _parse_event_timestamp("9999-12-31T23:59:59+00:00")
+    assert result is None or isinstance(result, float)

--- a/tests/analysis/test_cost_baseline.py
+++ b/tests/analysis/test_cost_baseline.py
@@ -806,3 +806,370 @@ def test_multiple_session_start_events_last_one_wins(tmp_path: Path) -> None:
     )
     buckets, _, _, _, _ = collect_cli(tmp_path, days=30)
     assert buckets[0].effort == "xhigh"
+
+
+# ======================================================================
+# P1 tests (#400) — collect_cli / _cheapest_candidate gaps
+# ======================================================================
+
+
+def test_collect_cli_handles_agent_none_or_missing_as_question_mark(
+    tmp_path: Path,
+) -> None:
+    """agentName=None and absent agentName both map to '?'."""
+    _write_session(
+        tmp_path,
+        "s-none",
+        [
+            {
+                "type": "subagent.completed",
+                "data": {
+                    "agentName": None,
+                    "model": "gpt-5.5",
+                    "totalTokens": 100,
+                    "totalToolCalls": 1,
+                    "durationMs": 1000,
+                },
+            }
+        ],
+    )
+    _write_session(
+        tmp_path,
+        "s-missing",
+        [
+            {
+                "type": "subagent.completed",
+                "data": {
+                    "model": "gpt-5.5",
+                    "totalTokens": 200,
+                    "totalToolCalls": 1,
+                    "durationMs": 1000,
+                },
+            }
+        ],
+    )
+    buckets, _, _, _, _ = collect_cli(tmp_path, days=30)
+    assert all(b.agent == "?" for b in buckets)
+
+
+def test_iter_session_events_skips_unreadable_files(tmp_path: Path) -> None:
+    """An events.jsonl that is actually a directory raises OSError on open → skipped."""
+    from scripts.analysis.cost_baseline import _iter_session_events, _epoch_cutoff
+
+    # Make events.jsonl a directory — stat() succeeds but open() raises IsADirectoryError
+    sess_dir = tmp_path / "session-state" / "sess-dir"
+    (sess_dir / "events.jsonl").mkdir(parents=True)
+
+    skipped: dict[str, int] = {"files": 0, "lines": 0}
+    events = list(_iter_session_events(tmp_path, _epoch_cutoff(30), skipped))
+
+    assert events == []
+    assert skipped["files"] >= 1
+
+
+def test_cheapest_candidate_lightweight_picks_gpt5_4_nano_over_gpt55() -> None:
+    """gpt-5.4-nano is the cheapest lightweight candidate; returned over gpt-5.5."""
+    result = _cheapest_candidate("lightweight", "gpt-5.5")
+    assert result == "gpt-5.4-nano"
+
+
+def test_cheapest_candidate_skips_current_model_from_pool() -> None:
+    """Current model is excluded from the candidate set even when it is in the pool."""
+    # claude-haiku-4.5 is in LIGHTWEIGHT_CANDIDATES; gpt-5.4-nano should be returned
+    result = _cheapest_candidate("lightweight", "claude-haiku-4.5")
+    assert result is not None
+    assert result != "claude-haiku-4.5"
+
+
+def test_cheapest_candidate_unknown_workload_class_falls_back_to_versatile() -> None:
+    """An unknown workload class falls back to the VERSATILE_CANDIDATES pool."""
+    result_unknown = _cheapest_candidate("nonexistent-class", "gpt-5.5")
+    result_versatile = _cheapest_candidate("versatile", "gpt-5.5")
+    assert result_unknown == result_versatile
+
+
+def test_cheapest_candidate_returns_none_when_no_pool_member_is_cheaper() -> None:
+    """When the current model is already the cheapest in the pool, None is returned."""
+    # gpt-5.4-nano is the cheapest lightweight model; no cheaper alternative exists
+    result = _cheapest_candidate("lightweight", "gpt-5.4-nano")
+    assert result is None
+
+
+# ======================================================================
+# P2 tests (#400) — integration / render / pricing-freshness
+# ======================================================================
+
+
+def test_main_smoke_writes_expected_section_headers(tmp_path: Path) -> None:
+    """Integration: run_cli writes the three expected section headers."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    _write_session(tmp_path, "sess", [_subagent_completed()])
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--skip-chat"],
+        output_stream=buf,
+    )
+    output = buf.getvalue()
+    assert rc == 0
+    assert "## CLI sub-agent baseline" in output
+    assert "## Savings projection" in output
+    assert "## Experimentation priority" in output
+
+
+def test_main_skip_chat_flag_omits_chat_section(tmp_path: Path) -> None:
+    """--skip-chat suppresses the VS Code Copilot Chat section."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--skip-chat"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    assert "VS Code Copilot Chat" not in buf.getvalue()
+
+
+def test_main_empty_home_does_not_crash(tmp_path: Path) -> None:
+    """Missing home directory → STATUS_FAIL with REASON_CODE_MISSING_COPILOT_HOME."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    missing = tmp_path / "does-not-exist"
+    rc = run_cli(["--home", str(missing), "--days", "30"], output_stream=buf)
+    assert rc == 1
+    assert REASON_CODE_MISSING_COPILOT_HOME in buf.getvalue()
+
+
+def test_pricing_freshness_warning_emitted_when_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale PRICING_RETRIEVED date triggers the WARNING line in text output."""
+    import io
+    import scripts.analysis.cost_baseline as cb
+    from datetime import date
+
+    monkeypatch.setattr(cb, "PRICING_RETRIEVED", date(2020, 1, 1))
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--skip-chat"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    assert "WARNING" in buf.getvalue()
+
+
+def test_pricing_freshness_no_warning_when_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A current PRICING_RETRIEVED date emits no WARNING line."""
+    import io
+    import scripts.analysis.cost_baseline as cb
+    from datetime import date
+
+    monkeypatch.setattr(cb, "PRICING_RETRIEVED", date.today())
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--skip-chat"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    assert "WARNING" not in buf.getvalue()
+
+
+def test_render_baseline_table_sorts_by_cost_descending(tmp_path: Path) -> None:
+    """build_report emits cli_buckets sorted by est_cost_usd descending."""
+    _write_session(
+        tmp_path,
+        "s-cheap",
+        [_subagent_completed(model="claude-haiku-4.5", tokens=100_000)],
+    )
+    _write_session(
+        tmp_path,
+        "s-expensive",
+        [_subagent_completed(model="gpt-5.5", tokens=10_000_000)],
+    )
+    report = build_report(home=tmp_path, days=30, include_chat=False)
+    costs = [b.est_cost_usd for b in report.cli_buckets]
+    assert costs == sorted(costs, reverse=True)
+
+
+def test_render_savings_table_total_equals_sum_of_per_row_savings() -> None:
+    """_render_savings_table TOTAL line equals sum of per-row savings."""
+    from scripts.analysis.cost_baseline import _render_savings_table, SavingsRow
+
+    rows = (
+        SavingsRow(
+            agent="a",
+            current_model="gpt-5.5",
+            current_effort="default",
+            current_cost_usd=10.0,
+            alt_model="claude-haiku-4.5",
+            alt_cost_usd=2.0,
+            savings_usd=8.0,
+            reduction_pct=80.0,
+        ),
+        SavingsRow(
+            agent="b",
+            current_model="gpt-5.5",
+            current_effort="default",
+            current_cost_usd=5.0,
+            alt_model="claude-haiku-4.5",
+            alt_cost_usd=1.0,
+            savings_usd=4.0,
+            reduction_pct=80.0,
+        ),
+    )
+    table = _render_savings_table(rows)
+    expected_total = sum(r.savings_usd for r in rows)
+    assert f"{expected_total:.2f}" in table
+    assert "TOTAL" in table
+
+
+def test_render_savings_table_omits_rows_with_zero_or_negative_savings(
+    tmp_path: Path,
+) -> None:
+    """An agent already on the cheapest model produces no SavingsRow."""
+    # claude-haiku-4.5 is cheapest in versatile/lightweight pools
+    _write_session(
+        tmp_path,
+        "s",
+        [_subagent_completed(model="claude-haiku-4.5", tokens=1_000_000)],
+    )
+    report = build_report(home=tmp_path, days=30, include_chat=False)
+    assert report.savings == ()
+
+
+def test_render_priority_list_caps_at_top_n(tmp_path: Path) -> None:
+    """_build_priority respects the top_n cap."""
+    for i in range(5):
+        _write_session(
+            tmp_path,
+            f"s{i}",
+            [_subagent_completed(agent=f"agent-{i}", tokens=1_000_000)],
+        )
+    report = build_report(home=tmp_path, days=30, top_n=3, include_chat=False)
+    assert len(report.priority) == 3
+
+
+# ======================================================================
+# P3 tests (#400) — schema / invariant guards
+# ======================================================================
+
+
+def test_agent_class_maps_only_to_known_workload_classes() -> None:
+    """Every entry in AGENT_CLASS must map to a recognised workload class."""
+    from scripts.analysis.cost_baseline import AGENT_CLASS
+
+    valid_classes = {"lightweight", "versatile", "powerful"}
+    for agent, cls in AGENT_CLASS.items():
+        assert cls in valid_classes, (
+            f"agent {agent!r} mapped to unknown class {cls!r}"
+        )
+
+
+def test_candidate_pool_models_are_in_pricing_table() -> None:
+    """Every model in the workload-class candidate pools must be in PRICING."""
+    from scripts.analysis.pricing import (
+        LIGHTWEIGHT_CANDIDATES,
+        POWERFUL_CANDIDATES,
+        PRICING,
+        VERSATILE_CANDIDATES,
+    )
+
+    for model in (
+        *LIGHTWEIGHT_CANDIDATES,
+        *VERSATILE_CANDIDATES,
+        *POWERFUL_CANDIDATES,
+    ):
+        assert model in PRICING, (
+            f"{model!r} in a candidate pool but absent from PRICING table"
+        )
+
+
+def test_agent_bucket_failure_rate_handles_zero_invocations() -> None:
+    """failure_rate must not divide by zero when invocations == 0."""
+    b = AgentBucket(
+        agent="x",
+        model="claude-haiku-4.5",
+        invocations=0,
+        total_tokens=0,
+        total_duration_ms=0,
+        failures=0,
+        sessions_count=0,
+    )
+    assert b.failure_rate == 0.0
+
+
+def test_main_json_format_flag_emits_valid_json(tmp_path: Path) -> None:
+    """--format json produces parseable JSON with expected top-level keys."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    buf = io.StringIO()
+    _write_session(tmp_path, "s", [_subagent_completed()])
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--format", "json", "--skip-chat"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    doc = json.loads(buf.getvalue())
+    assert doc["status"] == STATUS_PASS
+    assert "cli_buckets" in doc
+    assert "chat_buckets" in doc
+
+
+# ======================================================================
+# #403 — --strict-window per-event timestamp filtering
+# ======================================================================
+
+
+def test_strict_window_excludes_old_event_timestamps_when_mtime_is_fresh(
+    tmp_path: Path,
+) -> None:
+    """mtime=fresh + old event timestamps → strict mode excludes all events."""
+    from datetime import datetime, timezone
+
+    old_ts = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+    _write_session(
+        tmp_path,
+        "sess",
+        [
+            {**_subagent_completed(tokens=500), "timestamp": old_ts},
+            {**_subagent_completed(tokens=200), "timestamp": old_ts},
+        ],
+    )
+
+    # Default mode: both events included (file mtime is fresh)
+    buckets_default, _, _, _, _ = collect_cli(tmp_path, days=30)
+    assert len(buckets_default) == 1
+    assert buckets_default[0].total_tokens == 700
+
+    # Strict mode: old-timestamp events filtered out
+    buckets_strict, _, _, _, _ = collect_cli(tmp_path, days=30, strict_window=True)
+    assert len(buckets_strict) == 0
+
+
+def test_default_window_includes_old_event_timestamps_when_mtime_is_fresh(
+    tmp_path: Path,
+) -> None:
+    """Without --strict-window, old event timestamps don't block inclusion."""
+    from datetime import datetime, timezone
+
+    old_ts = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+    _write_session(
+        tmp_path,
+        "sess",
+        [{**_subagent_completed(tokens=300), "timestamp": old_ts}],
+    )
+    buckets, _, _, _, _ = collect_cli(tmp_path, days=30)
+    assert len(buckets) == 1
+    assert buckets[0].total_tokens == 300
+

--- a/tests/analysis/test_cost_baseline_chat.py
+++ b/tests/analysis/test_cost_baseline_chat.py
@@ -187,7 +187,11 @@ def test_collect_chat_handles_missing_token_fields_as_zero(
 
 
 def test_chat_bucket_est_cost_uses_blended_rate_fallback() -> None:
-    """#402 Option A: without cached tokens, 70% of input treated as cached."""
+    """#402 Option A: without cached tokens, 70% of input treated as cached.
+
+    Fresh input is billed at cache_write_per_m for Anthropic models (mirrors
+    the blended_rate() conservatism; see P2 code-review finding).
+    """
     b = ChatBucket(
         model="claude-sonnet-4.6",
         inferences=1,
@@ -195,9 +199,15 @@ def test_chat_bucket_est_cost_uses_blended_rate_fallback() -> None:
         output_tokens=100_000,
     )
     price = PRICING["claude-sonnet-4.6"]
+    # Fresh input uses cache_write_per_m for Anthropic (P2 fix).
+    fresh_rate = (
+        price.cache_write_per_m
+        if price.cache_write_per_m is not None
+        else price.input_per_m
+    )
     # Default mix: 70% cached, 30% fresh
     expected = (
-        0.30 * 1_000_000 * price.input_per_m
+        0.30 * 1_000_000 * fresh_rate
         + 0.70 * 1_000_000 * price.cached_per_m
         + 100_000 * price.output_per_m
     ) / 1_000_000.0
@@ -218,7 +228,10 @@ def test_chat_bucket_est_cost_zero_for_unknown_model() -> None:
 
 
 def test_chat_bucket_with_cached_input_tokens_uses_exact_split() -> None:
-    """#402 Option B: when cached_input_tokens > 0, exact split is applied."""
+    """#402 Option B: when cached_input_tokens > 0, exact split is applied.
+
+    Fresh input is billed at cache_write_per_m for Anthropic models (P2 fix).
+    """
     cached = 700_000
     total_input = 1_000_000
     fresh = total_input - cached
@@ -231,8 +244,13 @@ def test_chat_bucket_with_cached_input_tokens_uses_exact_split() -> None:
         cached_input_tokens=cached,
     )
     price = PRICING["claude-sonnet-4.6"]
+    fresh_rate = (
+        price.cache_write_per_m
+        if price.cache_write_per_m is not None
+        else price.input_per_m
+    )
     expected = (
-        fresh * price.input_per_m
+        fresh * fresh_rate
         + cached * price.cached_per_m
         + 100_000 * price.output_per_m
     ) / 1_000_000.0
@@ -351,8 +369,13 @@ def test_collect_chat_accumulates_otel_cached_input_tokens(tmp_path: Path) -> No
     price = PRICING["claude-sonnet-4.6"]
     total_fresh = 1500 - 1000  # 500
     total_output = 100 + 100   # from default _otel_inference_event output_tokens=100
+    fresh_rate = (
+        price.cache_write_per_m
+        if price.cache_write_per_m is not None
+        else price.input_per_m
+    )
     expected_exact = (
-        total_fresh * price.input_per_m
+        total_fresh * fresh_rate
         + 1000 * price.cached_per_m
         + total_output * price.output_per_m
     ) / 1_000_000.0
@@ -391,3 +414,91 @@ def test_strict_window_excludes_old_otel_event_timestamps(tmp_path: Path) -> Non
     buckets_strict, _ = collect_chat(tmp_path, days=30, strict_window=True)
     assert len(buckets_strict) == 1
     assert buckets_strict[0].input_tokens == 500
+
+
+# ======================================================================
+# P2 — cache_write_per_m for Anthropic fresh input
+# ======================================================================
+
+
+def test_chat_bucket_uses_cache_write_per_m_for_anthropic_fresh_input() -> None:
+    """P2: Anthropic fresh input is billed at cache_write_per_m, not input_per_m.
+
+    claude-sonnet-4.5 has cache_write_per_m=3.75 and input_per_m=3.00.
+    Both Option B paths must use cache_write_per_m for the fresh share.
+    """
+    price = PRICING["claude-sonnet-4.5"]
+    assert price.cache_write_per_m is not None
+    assert price.cache_write_per_m != price.input_per_m
+
+    cached = 700_000
+    total_input = 1_000_000
+    fresh = total_input - cached
+
+    b = ChatBucket(
+        model="claude-sonnet-4.5",
+        inferences=1,
+        input_tokens=total_input,
+        output_tokens=100_000,
+        cached_input_tokens=cached,
+    )
+    expected_with_cache_write = (
+        fresh * price.cache_write_per_m
+        + cached * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    wrong_with_input_per_m = (
+        fresh * price.input_per_m
+        + cached * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected_with_cache_write) < 1e-9
+    assert b.est_cost_usd != wrong_with_input_per_m
+
+
+def test_chat_bucket_falls_back_to_input_per_m_when_cache_write_per_m_is_none() -> None:
+    """P2: When cache_write_per_m is None (OpenAI), fresh input uses input_per_m."""
+    price = PRICING["gpt-5.4"]
+    assert price.cache_write_per_m is None
+
+    cached = 700_000
+    total_input = 1_000_000
+    fresh = total_input - cached
+
+    b = ChatBucket(
+        model="gpt-5.4",
+        inferences=1,
+        input_tokens=total_input,
+        output_tokens=100_000,
+        cached_input_tokens=cached,
+    )
+    expected = (
+        fresh * price.input_per_m
+        + cached * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+# ======================================================================
+# CLI smoke test — --chat-cache-share argparse wiring
+# ======================================================================
+
+
+def test_chat_cache_share_cli_flag_smoke(tmp_path: Path) -> None:
+    """--chat-cache-share 0.5 parses and wires through: blended-rate note shows 50%."""
+    import io
+    from scripts.analysis.cost_baseline import run_cli
+
+    _write_otel_session(
+        tmp_path,
+        "vscode-otel-test.jsonl",
+        [_otel_inference_event(model="gpt-5.4", input_tokens=1000)],
+    )
+    buf = io.StringIO()
+    rc = run_cli(
+        ["--home", str(tmp_path), "--days", "30", "--chat-cache-share", "0.5"],
+        output_stream=buf,
+    )
+    assert rc == 0
+    assert "50%" in buf.getvalue()

--- a/tests/analysis/test_cost_baseline_chat.py
+++ b/tests/analysis/test_cost_baseline_chat.py
@@ -1,0 +1,393 @@
+"""Tests for Chat/OTEL path in ``scripts.analysis.cost_baseline`` (#400, #402).
+
+Covers:
+* ``_iter_otel_inferences`` filtering and fail-soft behavior
+* ``collect_chat`` aggregation and token handling
+* ``ChatBucket.est_cost_usd`` — #402 blended-rate (Option A) and exact-split
+  (Option B) implementations
+* ``--chat-cache-share`` CLI flag wiring
+
+Synthetic fixture builders are imported from ``_fixtures`` to avoid duplication
+with ``test_cost_baseline.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.analysis._fixtures import (
+    _otel_inference_event,
+    _subagent_completed,
+    _write_otel_session,
+    _write_session,
+)
+from scripts.analysis.cost_baseline import (
+    ChatBucket,
+    collect_chat,
+)
+from scripts.analysis.pricing import PRICING
+
+
+# ======================================================================
+# P1 tests — _iter_otel_inferences fail-soft contracts
+# ======================================================================
+
+
+def test_iter_otel_inferences_filters_to_inference_operation_details_only(
+    tmp_path: Path,
+) -> None:
+    """Only events with the exact inference event.name are yielded."""
+    from scripts.analysis.cost_baseline import _iter_otel_inferences, _epoch_cutoff
+
+    inference_event = _otel_inference_event(model="gpt-5.4", input_tokens=500)
+    non_inference = {
+        "attributes": {
+            "event.name": "some.other.event",
+            "gen_ai.request.model": "gpt-5.5",
+        }
+    }
+    _write_otel_session(
+        tmp_path, "vscode-otel-test.jsonl", [inference_event, non_inference]
+    )
+
+    skipped: dict[str, int] = {"files": 0, "lines": 0}
+    results = list(_iter_otel_inferences(tmp_path, _epoch_cutoff(30), skipped))
+
+    assert len(results) == 1
+    assert results[0]["gen_ai.request.model"] == "gpt-5.4"
+    # Non-inference events are expected (not malformed); skipped count stays 0
+    assert skipped["lines"] == 0
+
+
+def test_iter_otel_inferences_skips_events_with_no_attributes_dict(
+    tmp_path: Path,
+) -> None:
+    """Events missing attributes or with non-dict attributes are silently skipped."""
+    from scripts.analysis.cost_baseline import _iter_otel_inferences, _epoch_cutoff
+
+    events = [
+        {"no_attributes_key": "here"},
+        {"attributes": "a-string-not-a-dict"},
+        {"attributes": 42},
+        _otel_inference_event(model="claude-sonnet-4.6"),
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    skipped: dict[str, int] = {"files": 0, "lines": 0}
+    results = list(_iter_otel_inferences(tmp_path, _epoch_cutoff(30), skipped))
+
+    assert len(results) == 1
+    assert results[0]["gen_ai.request.model"] == "claude-sonnet-4.6"
+    assert skipped["lines"] == 0  # silently skipped, not malformed JSON
+
+
+def test_iter_otel_inferences_skips_malformed_json_lines(
+    tmp_path: Path,
+) -> None:
+    """JSON parse errors increment skipped['lines'] and do not abort iteration."""
+    from scripts.analysis.cost_baseline import _iter_otel_inferences, _epoch_cutoff
+
+    valid_line = json.dumps(_otel_inference_event())
+    content = valid_line + "\n{ not valid json\n" + valid_line + "\n"
+    p = tmp_path / "traces" / "vscode-otel-test.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+    skipped: dict[str, int] = {"files": 0, "lines": 0}
+    results = list(_iter_otel_inferences(tmp_path, _epoch_cutoff(30), skipped))
+
+    assert len(results) == 2
+    assert skipped["lines"] == 1
+
+
+# ======================================================================
+# P1 tests — collect_chat aggregation
+# ======================================================================
+
+
+def test_collect_chat_excludes_events_with_missing_or_none_model(
+    tmp_path: Path,
+) -> None:
+    """Events with None or missing gen_ai.request.model are dropped (not '?')."""
+    events = [
+        _otel_inference_event(model="gpt-5.4"),
+        {
+            "attributes": {
+                "event.name": "gen_ai.client.inference.operation.details",
+                # model key absent
+            }
+        },
+        {
+            "attributes": {
+                "event.name": "gen_ai.client.inference.operation.details",
+                "gen_ai.request.model": None,
+            }
+        },
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+
+    assert len(buckets) == 1
+    assert buckets[0].model == "gpt-5.4"
+
+
+def test_collect_chat_aggregates_input_output_tokens_per_model(
+    tmp_path: Path,
+) -> None:
+    """Multiple events for the same model are summed into one ChatBucket."""
+    events = [
+        _otel_inference_event(model="gpt-5.4", input_tokens=1000, output_tokens=100),
+        _otel_inference_event(model="gpt-5.4", input_tokens=500, output_tokens=50),
+        _otel_inference_event(
+            model="claude-sonnet-4.6", input_tokens=2000, output_tokens=200
+        ),
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+    by_model = {b.model: b for b in buckets}
+
+    assert by_model["gpt-5.4"].inferences == 2
+    assert by_model["gpt-5.4"].input_tokens == 1500
+    assert by_model["gpt-5.4"].output_tokens == 150
+    assert by_model["claude-sonnet-4.6"].inferences == 1
+    assert by_model["claude-sonnet-4.6"].input_tokens == 2000
+
+
+def test_collect_chat_handles_missing_token_fields_as_zero(
+    tmp_path: Path,
+) -> None:
+    """Events without token fields contribute 0 tokens, not an error."""
+    events = [
+        {
+            "attributes": {
+                "event.name": "gen_ai.client.inference.operation.details",
+                "gen_ai.request.model": "gpt-5.4",
+                # no token fields
+            }
+        }
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+
+    assert len(buckets) == 1
+    assert buckets[0].input_tokens == 0
+    assert buckets[0].output_tokens == 0
+    assert buckets[0].est_cost_usd == 0.0
+
+
+# ======================================================================
+# P1 tests — ChatBucket.est_cost_usd (post-#402 behavior)
+# ======================================================================
+
+
+def test_chat_bucket_est_cost_uses_blended_rate_fallback() -> None:
+    """#402 Option A: without cached tokens, 70% of input treated as cached."""
+    b = ChatBucket(
+        model="claude-sonnet-4.6",
+        inferences=1,
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+    )
+    price = PRICING["claude-sonnet-4.6"]
+    # Default mix: 70% cached, 30% fresh
+    expected = (
+        0.30 * 1_000_000 * price.input_per_m
+        + 0.70 * 1_000_000 * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+def test_chat_bucket_est_cost_zero_for_unknown_model() -> None:
+    """A model absent from PRICING returns 0.0 (not a crash)."""
+    b = ChatBucket(
+        model="unknown-model-xyz", inferences=1, input_tokens=1000, output_tokens=100
+    )
+    assert b.est_cost_usd == 0.0
+
+
+# ======================================================================
+# #402 — exact-split (Option B) and blended-rate override
+# ======================================================================
+
+
+def test_chat_bucket_with_cached_input_tokens_uses_exact_split() -> None:
+    """#402 Option B: when cached_input_tokens > 0, exact split is applied."""
+    cached = 700_000
+    total_input = 1_000_000
+    fresh = total_input - cached
+
+    b = ChatBucket(
+        model="claude-sonnet-4.6",
+        inferences=1,
+        input_tokens=total_input,
+        output_tokens=100_000,
+        cached_input_tokens=cached,
+    )
+    price = PRICING["claude-sonnet-4.6"]
+    expected = (
+        fresh * price.input_per_m
+        + cached * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+def test_chat_bucket_exact_split_cheaper_than_blended_for_anthropic() -> None:
+    """Exact split with 70% cached should produce lower cost than 100%-fresh."""
+    b_exact = ChatBucket(
+        model="claude-opus-4.7",
+        inferences=1,
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+        cached_input_tokens=700_000,
+    )
+    # Old (pre-#402) upper-bound: all input at fresh rate
+    price = PRICING["claude-opus-4.7"]
+    old_cost = (
+        1_000_000 * price.input_per_m + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert b_exact.est_cost_usd < old_cost
+
+
+def test_chat_bucket_falls_back_to_blended_rate_when_cached_tokens_absent() -> None:
+    """#402 Option A: cached_input_tokens == 0 → blended-rate fallback (not fresh-only)."""
+    b = ChatBucket(
+        model="gpt-5.4",
+        inferences=1,
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+        cached_input_tokens=0,
+    )
+    price = PRICING["gpt-5.4"]
+    cache_frac = 0.70  # default
+    expected_blended = (
+        (1.0 - cache_frac) * 1_000_000 * price.input_per_m
+        + cache_frac * 1_000_000 * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    expected_fresh_only = (
+        1_000_000 * price.input_per_m + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected_blended) < 1e-9
+    # Must be strictly less than fresh-only (which was the pre-#402 approach)
+    assert b.est_cost_usd < expected_fresh_only
+
+
+def test_chat_cache_share_cli_flag_overrides_default_mix() -> None:
+    """#402: chat_cache_share field on ChatBucket overrides the 0.70 default."""
+    price = PRICING["gpt-5.4"]
+
+    # cache_share=0.0 → all input at fresh rate (upper bound)
+    b_no_cache = ChatBucket(
+        model="gpt-5.4",
+        inferences=1,
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+        cached_input_tokens=0,
+        chat_cache_share=0.0,
+    )
+    expected_no_cache = (
+        1_000_000 * price.input_per_m + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b_no_cache.est_cost_usd - expected_no_cache) < 1e-9
+
+    # cache_share=0.9 → 90% of input at cached rate
+    b_high_cache = ChatBucket(
+        model="gpt-5.4",
+        inferences=1,
+        input_tokens=1_000_000,
+        output_tokens=100_000,
+        cached_input_tokens=0,
+        chat_cache_share=0.90,
+    )
+    expected_high_cache = (
+        0.10 * 1_000_000 * price.input_per_m
+        + 0.90 * 1_000_000 * price.cached_per_m
+        + 100_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b_high_cache.est_cost_usd - expected_high_cache) < 1e-9
+
+    # Higher cache share → lower cost (since cached_per_m < input_per_m)
+    assert b_high_cache.est_cost_usd < b_no_cache.est_cost_usd
+
+
+def test_chat_cache_share_wires_through_collect_chat(tmp_path: Path) -> None:
+    """--chat-cache-share is plumbed from collect_chat to each ChatBucket."""
+    events = [_otel_inference_event(model="gpt-5.4", input_tokens=1_000_000, output_tokens=100_000)]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    # 0% cache → highest cost (all fresh)
+    buckets_0, _ = collect_chat(tmp_path, days=30, chat_cache_share=0.0)
+    # 90% cache → lowest cost
+    buckets_90, _ = collect_chat(tmp_path, days=30, chat_cache_share=0.90)
+
+    assert len(buckets_0) == 1
+    assert len(buckets_90) == 1
+    assert buckets_0[0].est_cost_usd > buckets_90[0].est_cost_usd
+
+
+def test_collect_chat_accumulates_otel_cached_input_tokens(tmp_path: Path) -> None:
+    """#402 Option B: gen_ai.usage.cache_read_input_tokens is summed per model."""
+    events = [
+        _otel_inference_event(model="claude-sonnet-4.6", input_tokens=1_000, cached_input_tokens=700),
+        _otel_inference_event(model="claude-sonnet-4.6", input_tokens=500, cached_input_tokens=300),
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+
+    assert len(buckets) == 1
+    b = buckets[0]
+    assert b.cached_input_tokens == 1000  # 700 + 300
+    assert b.input_tokens == 1500
+    # Exact split must be used (cached_input_tokens > 0)
+    price = PRICING["claude-sonnet-4.6"]
+    total_fresh = 1500 - 1000  # 500
+    total_output = 100 + 100   # from default _otel_inference_event output_tokens=100
+    expected_exact = (
+        total_fresh * price.input_per_m
+        + 1000 * price.cached_per_m
+        + total_output * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected_exact) < 1e-9
+    # Exact split should be cheaper than all-input-at-fresh-rate (+ output)
+    fresh_only = (
+        1500 * price.input_per_m + total_output * price.output_per_m
+    ) / 1_000_000.0
+    assert b.est_cost_usd < fresh_only
+
+
+# ======================================================================
+# #403 — strict-window for OTEL events
+# ======================================================================
+
+
+def test_strict_window_excludes_old_otel_event_timestamps(tmp_path: Path) -> None:
+    """--strict-window skips OTEL events with timestamps older than the window."""
+    from datetime import datetime, timezone
+
+    old_ts = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+    fresh_ts = datetime.now(timezone.utc).isoformat()
+
+    events = [
+        {**_otel_inference_event(model="gpt-5.4", input_tokens=1000), "timestamp": old_ts},
+        {**_otel_inference_event(model="gpt-5.4", input_tokens=500), "timestamp": fresh_ts},
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-test.jsonl", events)
+
+    # Default: both events included
+    buckets_default, _ = collect_chat(tmp_path, days=30)
+    assert len(buckets_default) == 1
+    assert buckets_default[0].input_tokens == 1500
+
+    # Strict: only the fresh event included
+    buckets_strict, _ = collect_chat(tmp_path, days=30, strict_window=True)
+    assert len(buckets_strict) == 1
+    assert buckets_strict[0].input_tokens == 500


### PR DESCRIPTION
## Summary

Three related issues combined into one PR to avoid merge conflicts on `scripts/analysis/cost_baseline.py` and `tests/analysis/test_cost_baseline.py`.

Closes #402, #403, #400.

---

## #402 — Chat blended-rate (Option B-with-A-fallback)

**Problem:** `ChatBucket.est_cost_usd` was multiplying all `gen_ai.usage.input_tokens` at the fresh-input rate (100%). For Anthropic models with heavy prompt caching, the cached-input rate is 10× cheaper, making Chat figures structural overestimates. The CLI side already used `blended_rate()`.

**Implementation:**

- **Option B (exact split):** When OTEL exposes `gen_ai.usage.cache_read_input_tokens` (or alias `gen_ai.usage.cached_input_tokens`) per event, `collect_chat()` accumulates `cached_input_tokens` into `ChatBucket`. `ChatBucket.est_cost_usd` then uses: `fresh_input × input_per_m + cached × cached_per_m + output × output_per_m`.
- **Option A (blended fallback):** When no per-event cached-token count is present (`ChatBucket.cached_input_tokens == 0`), applies `blended_rate()` with the 20/70/10 default mix, matching the CLI side. Output tokens are always billed at the full output rate.
- **`--chat-cache-share FLOAT`** CLI flag (range [0, 1]) overrides the cache fraction assumption in the blended-rate path.

**Acceptance criteria:**
- [x] `ChatBucket.est_cost_usd` uses exact split when `cached_input_tokens > 0`
- [x] Falls back to blended-rate when OTEL cached tokens are absent
- [x] `--chat-cache-share` wired through CLI → `collect_chat` → `ChatBucket`
- [x] Report NOTE section updated (shows exact-split or blended-rate annotation)
- [x] Tests: `test_chat_bucket_with_cached_input_tokens_uses_exact_split`, `test_chat_bucket_falls_back_to_blended_rate_when_cached_tokens_absent`, `test_chat_cache_share_cli_flag_overrides_default_mix`

---

## #403 — Per-event timestamp filter (`--strict-window`)

**Problem:** `--days N` only filtered by `events.jsonl` file mtime. Long-running sessions whose file was appended to recently contributed ALL events, including ones months old.

**Implementation:**

- `_parse_event_timestamp(ts_value)` helper handles ISO 8601 strings (including `Z` suffix) and numeric epoch values; returns `None` on any failure.
- `strict_window: bool = False` parameter threaded through `_iter_session_events`, `_iter_otel_inferences`, `_iter_session_event_lists`, `collect_cli`, `collect_chat`, `build_report`, `render_text`.
- `--strict-window` CLI flag (default `False` for backward compatibility). When set, events with parseable timestamps older than the cutoff are skipped; events with non-parseable timestamps always pass (fail-safe).
- Report header now shows `[strict-window]` or `[mtime-window]`.
- `--days` argparse help updated to describe both behaviors.

**Acceptance criteria:**
- [x] `--strict-window` flag present in `--help`
- [x] Default mode unchanged (no per-event filtering)
- [x] Strict mode skips events older than cutoff; missing timestamps pass through
- [x] Header output self-documenting (`[strict-window]` / `[mtime-window]`)
- [x] Tests: `test_strict_window_excludes_old_event_timestamps_when_mtime_is_fresh`, `test_default_window_includes_old_event_timestamps_when_mtime_is_fresh`, `test_iter_otel_inferences_strict_window_skips_old_events`

---

## #400 — ~34 new tests in `tests/analysis/`

**Files:**

- **`tests/analysis/_fixtures.py`** (new, 82 lines) — shared helpers: `_write_session`, `_subagent_completed`, `_session_shutdown`, `_write_otel_session`, `_otel_inference_event`. Extracted to avoid duplication.
- **`tests/analysis/test_cost_baseline_chat.py`** (new, 393 lines) — 13 Chat/OTEL/#402 tests.
- **`tests/analysis/test_cost_baseline.py`** (modified, +367 lines) — 21 new P1/P2/P3 + #403 tests.

Main file split justified: existing file was 808 lines before additions (> 350-line threshold).

P1 tests (all new):
- [x] `test_collect_cli_handles_agent_none_or_missing_as_question_mark`
- [x] `test_iter_session_events_skips_unreadable_files`
- [x] `test_cheapest_candidate_lightweight_picks_gpt5_4_nano_over_gpt55`
- [x] `test_cheapest_candidate_skips_current_model_from_pool`
- [x] `test_cheapest_candidate_unknown_workload_class_falls_back_to_versatile`
- [x] `test_cheapest_candidate_returns_none_when_no_pool_member_is_cheaper`
- [x] `test_iter_otel_inferences_filters_to_inference_operation_details_only`
- [x] `test_iter_otel_inferences_skips_events_with_no_attributes_dict`
- [x] `test_iter_otel_inferences_skips_malformed_json_lines`
- [x] `test_collect_chat_excludes_events_with_missing_or_none_model`
- [x] `test_collect_chat_aggregates_input_output_tokens_per_model`
- [x] `test_collect_chat_handles_missing_token_fields_as_zero`
- [x] `test_chat_bucket_est_cost_uses_exact_input_output_split` (post-#402 behavior)
- [x] `test_chat_bucket_est_cost_zero_for_unknown_model`

P2 tests (all new):
- [x] `test_main_smoke_writes_expected_section_headers`
- [x] `test_main_skip_chat_flag_omits_chat_section`
- [x] `test_main_empty_home_does_not_crash`
- [x] `test_pricing_freshness_warning_emitted_when_stale`
- [x] `test_pricing_freshness_no_warning_when_fresh`
- [x] `test_render_baseline_table_sorts_by_cost_descending`
- [x] `test_render_savings_table_total_equals_sum_of_per_row_savings`
- [x] `test_render_savings_table_omits_rows_with_zero_or_negative_savings`
- [x] `test_render_priority_list_caps_at_top_n`

P3 tests (all new):
- [x] `test_agent_class_maps_only_to_known_workload_classes`
- [x] `test_candidate_pool_models_are_in_pricing_table`
- [x] `test_agent_bucket_failure_rate_handles_zero_invocations`
- [x] `test_main_json_format_flag_emits_valid_json`

#402 tests (all new):
- [x] `test_chat_bucket_with_cached_input_tokens_uses_exact_split`
- [x] `test_chat_bucket_falls_back_to_blended_rate_when_cached_tokens_absent`
- [x] `test_chat_cache_share_cli_flag_overrides_default_mix`
- [x] `test_collect_chat_accumulates_otel_cached_input_tokens`

#403 tests (all new):
- [x] `test_strict_window_excludes_old_event_timestamps_when_mtime_is_fresh`
- [x] `test_default_window_includes_old_event_timestamps_when_mtime_is_fresh`
- [x] `test_iter_otel_inferences_strict_window_skips_old_events`

---

## Test plan

```
$ python3 -m pytest tests/analysis/ -v
108 passed in 1.31s

$ python3 -m pytest tests/ -q -x
2523 passed, 2371 subtests passed in 125.43s

$ python3 -m scripts.analysis.cost_baseline --help | grep -E "strict|cache-share|days"
  --days DAYS           Look back N days (default: 30). By default, sessions
  --strict-window       When set, also skip individual events whose...
  --chat-cache-share CHAT_CACHE_SHARE
```

---

## Research doc

Updated `docs/research/copilot-agent-cost-baseline-2026-06-27.md` Caveats §5 and §6 to reflect that the 100% fresh-rate overestimate is resolved (#402) and that `--strict-window` is now available (#403).

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
