### PR TITLE
feat(analysis): wire long-context tier per-call check through ChatBucket (#414)

### DIFF
--- a/docs/research/copilot-agent-cost-baseline-2026-06-27.md
+++ b/docs/research/copilot-agent-cost-baseline-2026-06-27.md
@@ -124,7 +124,7 @@ Chat usage is much more diverse model-wise. The 7K-inference GPT-5.4 line and 3.
 
 2. **Failure heuristic has false positives.** A legitimate <5s no-op dispatch (e.g., a check that finds nothing to do) would be counted as a failure. The aggregated 100% failure rate on `gpt-5.5` across many agents over 750+ invocations is too consistent to be false-positive — it's the quota pattern. Smaller agents need manual triage.
 
-3. **Long-context tier is now modeled in `pricing.py` (both CLI-side and Chat-side biases remain).** `gpt-5.4`, `gpt-5.5`, and `gemini-3.1-pro` publish a separate Long-context tier (2× input / 1.5× output) above 272K input tokens (272K for OpenAI, 200K for Gemini). As of issue #401, `pricing.py` stores these rates and `estimate_cost_usd` selects the correct tier when the caller supplies the per-call input-token count via `input_tokens_for_threshold` — the API is available. Chat-side OTEL events expose per-call `gen_ai.usage.input_tokens`, making the data available to enable the per-call threshold check; however, the wiring through `ChatBucket.est_cost_usd` is not yet implemented and will land in a follow-up issue. CLI-side sub-agent telemetry exposes only aggregate `totalTokens` with no input/output split, so the per-call threshold is not applicable there either. Both CLI-side (aggregate token granularity prevents per-call threshold) and Chat-side (wiring pending) biases remain until the follow-up lands.
+3. **Long-context tier is now modeled in `pricing.py`, and the Chat-side wiring is implemented (CLI-side bias remains).** `gpt-5.4`, `gpt-5.5`, and `gemini-3.1-pro` publish a separate Long-context tier (2× input / 1.5× output) above 272K input tokens (272K for OpenAI, 200K for Gemini). As of issue #401, `pricing.py` stores these rates and `estimate_cost_usd` selects the correct tier when the caller supplies the per-call input-token count via `input_tokens_for_threshold` — the API is available. As of issue #414, Chat-side OTEL events now preserve per-call threshold decisions during `collect_chat` aggregation and `ChatBucket.est_cost_usd` sums Default-tier and long-context-tier shares accordingly. CLI-side sub-agent telemetry still exposes only aggregate `totalTokens` with no per-call input/output split, so the per-call threshold is not applicable there; the remaining long-context bias is CLI-only.
 
 4. **VS Code OTEL is one large file (18 GB on 06-21).** Future runs should stream-parse efficiently; the current tool does so but takes ~2 min on cold disk cache.
 
@@ -158,6 +158,7 @@ All deferred items have been filed as `ready-for-agent` GitHub issues:
 
 - **[#400](https://github.com/wryenmeek/knowledgebase/issues/400)** — Expand `tests/analysis/` coverage: fail-soft contracts, OTEL parser, renderer smoke (P1/P2/P3 blocks from the test-engineer review)
 - **[#401](https://github.com/wryenmeek/knowledgebase/issues/401)** — ~~Add long-context tier pricing to `scripts/analysis/pricing.py`~~ **Implemented** — long-context rates now stored in `ModelPrice`; `estimate_cost_usd` tier-selects when `input_tokens_for_threshold` is supplied.
+- **[#414](https://github.com/wryenmeek/knowledgebase/issues/414)** — ~~Wire long-context tier per-call check through `ChatBucket`~~ **Implemented** — Chat OTEL now routes per-call tokens into Default-tier vs long-context-tier shares before computing aggregate cost.
 - **[#402](https://github.com/wryenmeek/knowledgebase/issues/402)** — Apply blended-rate to Chat-side cost math (fix the structural overestimate noted in Caveat §5)
 - **[#403](https://github.com/wryenmeek/knowledgebase/issues/403)** — Per-event timestamp filter for `--days` window (close the mtime-granularity gap noted in Caveat §6)
 
@@ -210,4 +211,3 @@ Expected effect (re-measure in 7d):
 - Eliminates the ~706 silent-failure gpt-5.5 dispatches from the v1 report
 - Caps the xhigh-effort spend by routing big-volume agents to non-effort-capable Anthropic models
 - Tests whether `gpt-5.4-mini high` and `gpt-5.3-codex medium` produce work quality matching the sonnet/opus baselines
-

--- a/scripts/analysis/cost_baseline.py
+++ b/scripts/analysis/cost_baseline.py
@@ -294,12 +294,20 @@ class ChatBucket:
             input_rate=price.input_per_m,
             output_rate=price.output_per_m,
         )
-        long_input_rate = price.long_context_input_per_m or price.input_per_m
-        long_output_rate = price.long_context_output_per_m or price.output_per_m
+        long_input_rate = (
+            price.long_context_input_per_m
+            if price.long_context_input_per_m is not None
+            else price.input_per_m
+        )
+        long_output_rate = (
+            price.long_context_output_per_m
+            if price.long_context_output_per_m is not None
+            else price.output_per_m
+        )
         total += share_cost(
-            input_tokens=self.long_context_input_tokens,
-            output_tokens=self.long_context_output_tokens,
-            cached_input_tokens=self.long_context_cached_input_tokens,
+            input_tokens=max(self.long_context_input_tokens, 0),
+            output_tokens=max(self.long_context_output_tokens, 0),
+            cached_input_tokens=max(self.long_context_cached_input_tokens, 0),
             input_rate=long_input_rate,
             output_rate=long_output_rate,
         )

--- a/scripts/analysis/cost_baseline.py
+++ b/scripts/analysis/cost_baseline.py
@@ -42,12 +42,16 @@ aligned with sibling analyzers in ``scripts/validation/`` and
   Without ``--strict-window``, a long-running session whose ``events.jsonl``
   was appended recently contributes all of its events, including those older
   than the cutoff.
-* Pricing table now models long-context tiers (see ``pricing.py``) for
-  ``gpt-5.4``, ``gpt-5.5``, ``gemini-3.1-pro``. The per-call threshold check
-  is not yet wired through ``ChatBucket.est_cost_usd``; CLI-side estimates
-  also remain Default-tier because ``subagent.completed.totalTokens`` is
-  aggregate (no per-call input/output split). Both wirings are tracked as
-  follow-ups.
+* Pricing table models long-context tiers (see ``pricing.py``) for
+  ``gpt-5.4``, ``gpt-5.5``, ``gemini-3.1-pro``. The Chat-side per-call
+  threshold check is now wired (#414): ``collect_chat`` routes each
+  inference call's tokens into the Default-tier or long-context-tier share
+  of ``ChatBucket`` based on whether that call's input-token count exceeds
+  ``price.input_threshold_tokens``; ``ChatBucket.est_cost_usd`` then sums
+  the two shares. CLI-side estimates remain Default-tier only:
+  ``subagent.completed.totalTokens`` is aggregate with no per-call
+  input/output split, so the per-call threshold check cannot be applied
+  on the CLI path.
 * Failure heuristic (``totalTokens=0`` AND ``totalToolCalls=0`` AND
   ``durationMs<5000ms``) may false-positive on legitimate fast no-op
   dispatches. Aggregated 100% failure-rate rows on a single model across
@@ -193,7 +197,9 @@ class AgentBucket:
 class ChatBucket:
     """Per-model VS Code Copilot Chat aggregate.
 
-    ``est_cost_usd`` uses an Option B-then-A strategy (#402):
+    ``est_cost_usd`` uses an Option B-then-A strategy (#402), applied
+    independently to the Default-tier share and any long-context-tier share
+    (#414):
 
     * **Option B (exact split):** If OTEL provides
       ``gen_ai.usage.cache_read_input_tokens`` (or the alternate
@@ -208,6 +214,22 @@ class ChatBucket:
     Both options are materially more accurate than the previous approach of
     charging 100% at the fresh-input rate (the former structural overestimate
     of ~10× on the cached portion for Anthropic models).
+
+    ``collect_chat`` now preserves per-call long-context threshold decisions by
+    aggregating two shares inside the same bucket:
+
+    * ``input_tokens`` / ``output_tokens`` / ``cached_input_tokens`` remain the
+      **total** tokens across all calls for the model.
+    * ``long_context_*`` fields track the subset of tokens from calls whose
+      per-call ``gen_ai.usage.input_tokens`` exceeded
+      ``price.input_threshold_tokens``.
+
+    ``est_cost_usd`` computes the Default-tier cost for
+    ``total - long_context`` plus the long-context cost for the subset. For the
+    long-context fresh-input share, Anthropic cache-write pricing remains
+    authoritative when present; otherwise the long-context input rate is used.
+    Cached-read pricing is unchanged between tiers (the provider docs do not
+    publish a separate long-context cached-read rate).
     """
 
     model: str
@@ -215,6 +237,9 @@ class ChatBucket:
     input_tokens: int
     output_tokens: int
     cached_input_tokens: int = 0
+    long_context_input_tokens: int = 0
+    long_context_output_tokens: int = 0
+    long_context_cached_input_tokens: int = 0
     chat_cache_share: float | None = None  # None → blended_rate default (0.70)
 
     @property
@@ -222,35 +247,63 @@ class ChatBucket:
         price = PRICING.get(self.model)
         if price is None:
             return 0.0
-        # Option B: exact split when per-event cached tokens are available.
-        if self.cached_input_tokens > 0:
-            fresh = max(self.input_tokens - self.cached_input_tokens, 0)
+
+        def share_cost(
+            *,
+            input_tokens: int,
+            output_tokens: int,
+            cached_input_tokens: int,
+            input_rate: float,
+            output_rate: float,
+        ) -> float:
+            if input_tokens <= 0 and output_tokens <= 0:
+                return 0.0
             fresh_rate = (
                 price.cache_write_per_m
                 if price.cache_write_per_m is not None
-                else price.input_per_m
+                else input_rate
             )
+            if cached_input_tokens > 0:
+                fresh = max(input_tokens - cached_input_tokens, 0)
+                return (
+                    fresh * fresh_rate
+                    + cached_input_tokens * price.cached_per_m
+                    + output_tokens * output_rate
+                ) / 1_000_000.0
+
+            cache_frac = (
+                self.chat_cache_share if self.chat_cache_share is not None else 0.70
+            )
+            fresh_input = input_tokens * (1.0 - cache_frac)
+            cached_input = input_tokens * cache_frac
             return (
-                fresh * fresh_rate
-                + self.cached_input_tokens * price.cached_per_m
-                + self.output_tokens * price.output_per_m
+                fresh_input * fresh_rate
+                + cached_input * price.cached_per_m
+                + output_tokens * output_rate
             ) / 1_000_000.0
-        # Option A: blended-rate fallback.
-        cache_frac = (
-            self.chat_cache_share if self.chat_cache_share is not None else 0.70
+
+        default_input = max(self.input_tokens - self.long_context_input_tokens, 0)
+        default_output = max(self.output_tokens - self.long_context_output_tokens, 0)
+        default_cached = max(
+            self.cached_input_tokens - self.long_context_cached_input_tokens, 0
         )
-        fresh_input = self.input_tokens * (1.0 - cache_frac)
-        cached_input = self.input_tokens * cache_frac
-        fresh_rate = (
-            price.cache_write_per_m
-            if price.cache_write_per_m is not None
-            else price.input_per_m
+        total = share_cost(
+            input_tokens=default_input,
+            output_tokens=default_output,
+            cached_input_tokens=default_cached,
+            input_rate=price.input_per_m,
+            output_rate=price.output_per_m,
         )
-        return (
-            fresh_input * fresh_rate
-            + cached_input * price.cached_per_m
-            + self.output_tokens * price.output_per_m
-        ) / 1_000_000.0
+        long_input_rate = price.long_context_input_per_m or price.input_per_m
+        long_output_rate = price.long_context_output_per_m or price.output_per_m
+        total += share_cost(
+            input_tokens=self.long_context_input_tokens,
+            output_tokens=self.long_context_output_tokens,
+            cached_input_tokens=self.long_context_cached_input_tokens,
+            input_rate=long_input_rate,
+            output_rate=long_output_rate,
+        )
+        return total
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -259,6 +312,9 @@ class ChatBucket:
             "input_tokens": self.input_tokens,
             "cached_input_tokens": self.cached_input_tokens,
             "output_tokens": self.output_tokens,
+            "long_context_input_tokens": self.long_context_input_tokens,
+            "long_context_cached_input_tokens": self.long_context_cached_input_tokens,
+            "long_context_output_tokens": self.long_context_output_tokens,
             "est_cost_usd": round(self.est_cost_usd, 4),
         }
 
@@ -742,6 +798,12 @@ def collect_chat(
     alternate ``gen_ai.usage.cached_input_tokens``), the exact cached split
     is accumulated per model. Otherwise, ``ChatBucket.est_cost_usd`` falls
     back to a blended-rate estimate using ``chat_cache_share`` (default 0.70).
+
+    Per-call long-context threshold decisions are preserved in aggregate form:
+    calls whose ``gen_ai.usage.input_tokens`` exceed the model's
+    ``input_threshold_tokens`` are accumulated into the bucket's
+    ``long_context_*`` fields, while the top-level token fields remain totals
+    across all calls for that model.
     """
     cutoff = _epoch_cutoff(days)
     raw: dict[str, dict[str, int]] = defaultdict(
@@ -750,6 +812,9 @@ def collect_chat(
             "input_tokens": 0,
             "output_tokens": 0,
             "cached_input_tokens": 0,
+            "long_context_input_tokens": 0,
+            "long_context_output_tokens": 0,
+            "long_context_cached_input_tokens": 0,
         }
     )
     skipped = {"files": 0, "lines": 0}
@@ -759,8 +824,10 @@ def collect_chat(
             continue
         bucket = raw[model]
         bucket["inferences"] += 1
-        bucket["input_tokens"] += _coerce_int(attrs.get("gen_ai.usage.input_tokens"))
-        bucket["output_tokens"] += _coerce_int(attrs.get("gen_ai.usage.output_tokens"))
+        input_tokens = _coerce_int(attrs.get("gen_ai.usage.input_tokens"))
+        output_tokens = _coerce_int(attrs.get("gen_ai.usage.output_tokens"))
+        bucket["input_tokens"] += input_tokens
+        bucket["output_tokens"] += output_tokens
         # Option B: pick up exact cached-token count when OTEL provides it.
         cached = _coerce_int(
             attrs.get("gen_ai.usage.cache_read_input_tokens")
@@ -768,6 +835,15 @@ def collect_chat(
             attrs.get("gen_ai.usage.cached_input_tokens")
         )
         bucket["cached_input_tokens"] += cached
+        price = PRICING.get(model)
+        if (
+            price is not None
+            and price.input_threshold_tokens is not None
+            and input_tokens > price.input_threshold_tokens
+        ):
+            bucket["long_context_input_tokens"] += input_tokens
+            bucket["long_context_output_tokens"] += output_tokens
+            bucket["long_context_cached_input_tokens"] += cached
     chat_buckets = tuple(
         ChatBucket(
             model=model,
@@ -775,6 +851,9 @@ def collect_chat(
             input_tokens=v["input_tokens"],
             output_tokens=v["output_tokens"],
             cached_input_tokens=v["cached_input_tokens"],
+            long_context_input_tokens=v["long_context_input_tokens"],
+            long_context_output_tokens=v["long_context_output_tokens"],
+            long_context_cached_input_tokens=v["long_context_cached_input_tokens"],
             chat_cache_share=chat_cache_share,
         )
         for model, v in raw.items()

--- a/tests/analysis/test_cost_baseline_chat.py
+++ b/tests/analysis/test_cost_baseline_chat.py
@@ -28,7 +28,7 @@ from scripts.analysis.cost_baseline import (
     ChatBucket,
     collect_chat,
 )
-from scripts.analysis.pricing import PRICING
+from scripts.analysis.pricing import ModelPrice, PRICING
 
 
 # ======================================================================
@@ -478,6 +478,173 @@ def test_chat_bucket_falls_back_to_input_per_m_when_cache_write_per_m_is_none() 
         + 100_000 * price.output_per_m
     ) / 1_000_000.0
     assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+# ======================================================================
+# #414 — long-context tier routing on Chat path
+# ======================================================================
+
+
+def test_chat_bucket_below_threshold_uses_default_tier() -> None:
+    """A below-threshold call stays on the Default tier."""
+    price = PRICING["gpt-5.5"]
+    b = ChatBucket(
+        model="gpt-5.5",
+        inferences=1,
+        input_tokens=100_000,
+        output_tokens=10_000,
+        long_context_input_tokens=0,
+        long_context_output_tokens=0,
+    )
+    expected = (
+        0.30 * 100_000 * price.input_per_m
+        + 0.70 * 100_000 * price.cached_per_m
+        + 10_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+def test_chat_bucket_above_threshold_uses_long_context_tier() -> None:
+    """An above-threshold call uses the long-context rates."""
+    price = PRICING["gpt-5.5"]
+    assert price.long_context_input_per_m is not None
+    assert price.long_context_output_per_m is not None
+    b = ChatBucket(
+        model="gpt-5.5",
+        inferences=1,
+        input_tokens=300_000,
+        output_tokens=12_000,
+        long_context_input_tokens=300_000,
+        long_context_output_tokens=12_000,
+    )
+    expected = (
+        0.30 * 300_000 * price.long_context_input_per_m
+        + 0.70 * 300_000 * price.cached_per_m
+        + 12_000 * price.long_context_output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+
+
+def test_chat_bucket_mixed_threshold_accumulates_correctly() -> None:
+    """Default-tier and long-context-tier shares sum correctly in one bucket."""
+    price = PRICING["gpt-5.5"]
+    assert price.long_context_input_per_m is not None
+    assert price.long_context_output_per_m is not None
+    b = ChatBucket(
+        model="gpt-5.5",
+        inferences=2,
+        input_tokens=400_000,
+        output_tokens=15_000,
+        long_context_input_tokens=300_000,
+        long_context_output_tokens=12_000,
+    )
+    default_cost = (
+        0.30 * 100_000 * price.input_per_m
+        + 0.70 * 100_000 * price.cached_per_m
+        + 3_000 * price.output_per_m
+    ) / 1_000_000.0
+    long_cost = (
+        0.30 * 300_000 * price.long_context_input_per_m
+        + 0.70 * 300_000 * price.cached_per_m
+        + 12_000 * price.long_context_output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - (default_cost + long_cost)) < 1e-9
+
+
+def test_collect_chat_routes_per_call_tokens_by_threshold(tmp_path: Path) -> None:
+    """collect_chat preserves long-context routing in aggregate bucket fields."""
+    events = [
+        _otel_inference_event(model="gpt-5.5", input_tokens=100_000, output_tokens=10_000),
+        _otel_inference_event(
+            model="gpt-5.5",
+            input_tokens=300_000,
+            output_tokens=12_000,
+            cached_input_tokens=50_000,
+        ),
+        _otel_inference_event(
+            model="claude-sonnet-4.6",
+            input_tokens=250_000,
+            output_tokens=8_000,
+        ),
+    ]
+    _write_otel_session(tmp_path, "vscode-otel-threshold.jsonl", events)
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+    by_model = {b.model: b for b in buckets}
+
+    gpt = by_model["gpt-5.5"]
+    assert gpt.input_tokens == 400_000
+    assert gpt.output_tokens == 22_000
+    assert gpt.cached_input_tokens == 50_000
+    assert gpt.long_context_input_tokens == 300_000
+    assert gpt.long_context_output_tokens == 12_000
+    assert gpt.long_context_cached_input_tokens == 50_000
+
+    claude = by_model["claude-sonnet-4.6"]
+    assert claude.input_tokens == 250_000
+    assert claude.long_context_input_tokens == 0
+    assert claude.long_context_output_tokens == 0
+    assert claude.long_context_cached_input_tokens == 0
+
+
+def test_chat_bucket_unknown_threshold_field_falls_back_to_default() -> None:
+    """Models without input_threshold_tokens never populate long-context fields."""
+    b = ChatBucket(
+        model="claude-sonnet-4.5",
+        inferences=1,
+        input_tokens=500_000,
+        output_tokens=10_000,
+        long_context_input_tokens=0,
+        long_context_output_tokens=0,
+        long_context_cached_input_tokens=0,
+    )
+    price = PRICING["claude-sonnet-4.5"]
+    fresh_rate = price.cache_write_per_m if price.cache_write_per_m is not None else price.input_per_m
+    expected = (
+        0.30 * 500_000 * fresh_rate
+        + 0.70 * 500_000 * price.cached_per_m
+        + 10_000 * price.output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+    assert b.long_context_input_tokens == 0
+
+
+def test_chat_bucket_long_context_share_honors_cache_write_premium(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthetic threshold model with cache_write premium uses that premium."""
+    synthetic = ModelPrice(
+        input_per_m=3.00,
+        cached_per_m=0.30,
+        output_per_m=15.00,
+        cache_write_per_m=3.75,
+        long_context_input_per_m=6.00,
+        long_context_output_per_m=22.50,
+        input_threshold_tokens=200_000,
+    )
+    monkeypatch.setitem(PRICING, "claude-long-context-test", synthetic)
+    b = ChatBucket(
+        model="claude-long-context-test",
+        inferences=1,
+        input_tokens=300_000,
+        output_tokens=10_000,
+        cached_input_tokens=100_000,
+        long_context_input_tokens=300_000,
+        long_context_output_tokens=10_000,
+        long_context_cached_input_tokens=100_000,
+    )
+    expected = (
+        200_000 * synthetic.cache_write_per_m
+        + 100_000 * synthetic.cached_per_m
+        + 10_000 * synthetic.long_context_output_per_m
+    ) / 1_000_000.0
+    wrong_without_premium = (
+        200_000 * synthetic.long_context_input_per_m
+        + 100_000 * synthetic.cached_per_m
+        + 10_000 * synthetic.long_context_output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - expected) < 1e-9
+    assert b.est_cost_usd != wrong_without_premium
 
 
 # ======================================================================

--- a/tests/analysis/test_cost_baseline_chat.py
+++ b/tests/analysis/test_cost_baseline_chat.py
@@ -525,6 +525,31 @@ def test_chat_bucket_above_threshold_uses_long_context_tier() -> None:
     assert abs(b.est_cost_usd - expected) < 1e-9
 
 
+def test_collect_chat_at_threshold_stays_on_default_tier(tmp_path: Path) -> None:
+    """Exactly-threshold calls stay on the Default tier (strict `>` check)."""
+    price = PRICING["gpt-5.5"]
+    assert price.input_threshold_tokens is not None
+    _write_otel_session(
+        tmp_path,
+        "vscode-otel-at-threshold.jsonl",
+        [
+            _otel_inference_event(
+                model="gpt-5.5",
+                input_tokens=price.input_threshold_tokens,
+                output_tokens=5_000,
+            )
+        ],
+    )
+
+    buckets, _ = collect_chat(tmp_path, days=30)
+    assert len(buckets) == 1
+    bucket = buckets[0]
+    assert bucket.input_tokens == price.input_threshold_tokens
+    assert bucket.long_context_input_tokens == 0
+    assert bucket.long_context_output_tokens == 0
+    assert bucket.long_context_cached_input_tokens == 0
+
+
 def test_chat_bucket_mixed_threshold_accumulates_correctly() -> None:
     """Default-tier and long-context-tier shares sum correctly in one bucket."""
     price = PRICING["gpt-5.5"]
@@ -553,6 +578,7 @@ def test_chat_bucket_mixed_threshold_accumulates_correctly() -> None:
 
 def test_collect_chat_routes_per_call_tokens_by_threshold(tmp_path: Path) -> None:
     """collect_chat preserves long-context routing in aggregate bucket fields."""
+    assert PRICING["claude-sonnet-4.6"].input_threshold_tokens is None
     events = [
         _otel_inference_event(model="gpt-5.5", input_tokens=100_000, output_tokens=10_000),
         _otel_inference_event(
@@ -585,6 +611,34 @@ def test_collect_chat_routes_per_call_tokens_by_threshold(tmp_path: Path) -> Non
     assert claude.long_context_input_tokens == 0
     assert claude.long_context_output_tokens == 0
     assert claude.long_context_cached_input_tokens == 0
+
+
+def test_chat_bucket_mixed_cached_shares_subtract_cleanly() -> None:
+    """Default-tier and long-context cached shares subtract without drift."""
+    price = PRICING["gpt-5.5"]
+    assert price.long_context_input_per_m is not None
+    assert price.long_context_output_per_m is not None
+    b = ChatBucket(
+        model="gpt-5.5",
+        inferences=2,
+        input_tokens=400_000,
+        output_tokens=15_000,
+        cached_input_tokens=80_000,
+        long_context_input_tokens=300_000,
+        long_context_output_tokens=12_000,
+        long_context_cached_input_tokens=50_000,
+    )
+    default_cost = (
+        70_000 * price.input_per_m
+        + 30_000 * price.cached_per_m
+        + 3_000 * price.output_per_m
+    ) / 1_000_000.0
+    long_cost = (
+        250_000 * price.long_context_input_per_m
+        + 50_000 * price.cached_per_m
+        + 12_000 * price.long_context_output_per_m
+    ) / 1_000_000.0
+    assert abs(b.est_cost_usd - (default_cost + long_cost)) < 1e-9
 
 
 def test_chat_bucket_unknown_threshold_field_falls_back_to_default() -> None:

--- a/tests/analysis/test_pricing.py
+++ b/tests/analysis/test_pricing.py
@@ -308,6 +308,26 @@ def test_long_context_rates_strictly_greater_than_default_rates() -> None:
         )
 
 
+def test_no_model_has_both_cache_write_and_long_context_input_rates() -> None:
+    """Guard ChatBucket.share_cost semantics if pricing grows a new combo.
+
+    cost_baseline.ChatBucket currently treats ``cache_write_per_m`` as
+    authoritative for fresh-input pricing whenever it is present. If a future
+    model declares both ``cache_write_per_m`` and ``long_context_input_per_m``,
+    revisit that logic before merging the pricing-table change.
+    """
+    offenders = {
+        model_id
+        for model_id, price in PRICING.items()
+        if price.cache_write_per_m is not None
+        and price.long_context_input_per_m is not None
+    }
+    assert offenders == set(), (
+        "Models declaring both cache_write_per_m and long_context_input_per_m "
+        f"require a share_cost() review: {sorted(offenders)}"
+    )
+
+
 # ---------- Long-context share-sum validation ----------
 
 


### PR DESCRIPTION
## Summary

Wire the long-context tier through the Chat OTEL path by preserving each call's threshold decision during `collect_chat` aggregation and summing Default-tier + long-context-tier shares inside `ChatBucket.est_cost_usd`.

This fixes the remaining gap from #412/#413: Chat OTEL events expose per-call `gen_ai.usage.input_tokens`, so the analyzer can now correctly bill `gpt-5.4`, `gpt-5.5`, and `gemini-3.1-pro` at long-context rates when a call crosses the model threshold.

Closes #414.

## Design

- `collect_chat` now accumulates both total tokens and `long_context_*` token subsets per model.
- The per-call routing check happens at aggregation time using `price.input_threshold_tokens`.
- `ChatBucket.est_cost_usd` computes:
  - Default-tier cost for `total - long_context`
  - Long-context cost for the `long_context_*` subset
- Anthropic fresh-input pricing continues to use `cache_write_per_m` when present; cached-read pricing remains unchanged because no distinct long-context cached-read rate is published.

## Backward compatibility

- Models without `input_threshold_tokens` remain 100% on the Default tier.
- CLI-side estimates still cannot apply the threshold because `subagent.completed.totalTokens` is aggregate and lacks per-call input/output splits; the module docstring still documents this limitation.
- Existing Chat blended-rate and exact-split behavior remains intact inside each share.

## Acceptance criteria

- [x] Chat performs a per-call threshold check for affected models
- [x] Long-context tier rates apply when a call exceeds the threshold
- [x] `pricing.py` already declares the long-context tier metadata used here
- [x] Tests cover below-threshold, above-threshold, mixed-share accumulation, and routing
- [x] CLI-side aggregate-token limitation remains documented

## Test plan

- `python3 -m pytest tests/analysis/test_cost_baseline_chat.py -q`
- `python3 -m pytest tests/analysis/ -q`
- `python3 -m pytest tests/ -q -x`

## Co-authored-by

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
