### PR TITLE
refactor(tests): finalize shared fixture audit for cost_baseline suite (#415)

### DIFF
--- a/tests/analysis/_fixtures.py
+++ b/tests/analysis/_fixtures.py
@@ -2,6 +2,23 @@
 
 These helpers are not pytest fixtures (no ``@pytest.fixture`` decorator);
 they are plain functions imported directly by test modules.
+
+**Exported surface** (cross-file helpers only):
+
+* ``_write_session`` — write a synthetic CLI ``events.jsonl`` session file.
+* ``_subagent_completed`` — build a ``subagent.completed`` event dict.
+* ``_session_shutdown`` — build a ``session.shutdown`` event dict.
+* ``_write_otel_session`` — write a synthetic OTEL traces file.
+* ``_otel_inference_event`` — build a ``gen_ai.client.inference...`` OTEL event.
+
+Helpers that are *not* here by design
+--------------------------------------
+``_session_start``, ``_task_tool_start``, and ``_subagent_with_id`` remain
+local to ``test_cost_baseline.py``.  Those helpers produce CLI session-event
+shapes that are only needed for the effort-capture / bucket-attribution tests
+in that file and are not shared with ``test_cost_baseline_chat.py`` (which
+tests OTEL-based chat aggregation) or ``test_pricing.py``.  Moving them here
+would add cross-file coupling without any duplication benefit.
 """
 
 from __future__ import annotations

--- a/tests/analysis/test_cost_baseline.py
+++ b/tests/analysis/test_cost_baseline.py
@@ -365,6 +365,12 @@ def test_collect_cli_ignores_bool_nano_aiu(tmp_path: Path) -> None:
 
 
 # ---------- Effort capture (session default + per-call override) ----------
+#
+# The three helpers below (_session_start, _task_tool_start, _subagent_with_id)
+# are intentionally local to this file.  They produce CLI session-event shapes
+# used only by the effort-capture / bucket-attribution tests below and are not
+# shared with test_cost_baseline_chat.py or test_pricing.py.
+# See _fixtures.py module docstring for the cross-file fixture audit rationale.
 
 
 def _session_start(reasoning_effort: str = "default") -> dict:


### PR DESCRIPTION
## Summary

Closes #415.

Full audit of `tests/analysis/` for shared fixture opportunities following the partial dedup in #413.

## Audit findings

**No additional helpers should be moved to `_fixtures.py`.**

The three local helpers that remained in `test_cost_baseline.py` after #413 were examined:

| Helper | Used in | Cross-file candidate? |
|---|---|---|
| `_session_start` | `test_cost_baseline.py` only | ❌ CLI/session-event shape, unused by chat/pricing tests |
| `_task_tool_start` | `test_cost_baseline.py` only | ❌ CLI tool.execution_start shape, unused by chat/pricing tests |
| `_subagent_with_id` | `test_cost_baseline.py` only | ❌ Thin wrapper around `_subagent_completed`; no cross-file need |

`test_cost_baseline_chat.py` (including #414's new long-context tests) uses only OTEL-event shapes — it imports `_otel_inference_event` and `_write_otel_session` from `_fixtures.py`, not CLI session-event builders. `test_pricing.py` has no shared fixture builders at all.

## Changes made

| File | Change |
|---|---|
| `tests/analysis/_fixtures.py` | Expanded module docstring: enumerates the exported surface and explicitly documents why `_session_start`, `_task_tool_start`, `_subagent_with_id` remain local |
| `tests/analysis/test_cost_baseline.py` | Added block comment above the local helper section cross-referencing the `_fixtures.py` rationale |

No production code was touched. No test logic was changed.

## Verification

```
python3 -m pytest tests/analysis/ -v   →  131 passed
python3 -m pytest tests/ -q -x         →  2551 passed
```

## Stacking note

This PR is stacked on top of `feat/issue-414-chat-long-context-wiring` (#414). Parent agent should rebase/merge in order: #414 → #415.
