### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak MD5 hashing

### DIFF
--- a/tests/drive_monitor/test_fetch_content.py
+++ b/tests/drive_monitor/test_fetch_content.py
@@ -21,7 +21,7 @@ from scripts.drive_monitor.fetch_content import fetch_content
 # ---------------------------------------------------------------------------
 
 NORMALIZED_BYTES = b"# My Document\n\nContent.\n"
-MD5 = hashlib.md5(b"raw-pdf-content").hexdigest()
+MD5 = hashlib.md5(b"raw-pdf-content", usedforsecurity=False).hexdigest()
 SHA256 = hashlib.sha256(NORMALIZED_BYTES).hexdigest()
 
 

--- a/tests/kb/test_audit_workspace_friction_queries.py
+++ b/tests/kb/test_audit_workspace_friction_queries.py
@@ -261,7 +261,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["prompt_length"], len("Repeat this instruction"))
         self.assertEqual(
             row["prompt_fingerprint"],
-            hashlib.md5(b"Repeat this instruction").hexdigest(),
+            hashlib.md5(b"Repeat this instruction", usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_rows_match_same_tool_request_payload_without_raw_args(self) -> None:
@@ -285,7 +285,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
         self.assertEqual(row["request_length"], len('{"command": "python3 -m pytest tests/kb/test_x.py"}'))
         self.assertEqual(
             row["request_fingerprint"],
-            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}').hexdigest(),
+            hashlib.md5(b'{"command": "python3 -m pytest tests/kb/test_x.py"}', usedforsecurity=False).hexdigest(),
         )
 
     def test_retry_loop_window_includes_exact_boundary_and_excludes_after_boundary(self) -> None:
@@ -599,7 +599,7 @@ class AuditWorkspaceFrictionQueryTests(unittest.TestCase):
 
     @staticmethod
     def _sqlite_md5(value: str) -> str:
-        return hashlib.md5(value.encode("utf-8")).hexdigest()
+        return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
 
     @staticmethod
     def _sqlite_regexp_extract(value: str, pattern: str, group_index: int) -> str:


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix weak MD5 hashing

🚨 Severity: MEDIUM
💡 Vulnerability: Use of MD5 hashing algorithm without usedforsecurity=False, which can trigger security scanners and violate FIPS policies.
🎯 Impact: Security scanners like bandit will flag this as a vulnerability. Environments running in FIPS mode will fail with a ValueError.
🔧 Fix: Added usedforsecurity=False to hashlib.md5() calls in test files where it is used for non-security purposes like fingerprinting.
✅ Verification: Ran full pytest suite, and verified bandit scan no longer flags these issues.

---
*PR created automatically by Jules for task [14950561228011056866](https://jules.google.com/task/14950561228011056866) started by @wryenmeek*