### PR TITLE
⚡ Bolt: Replace splitlines()[0] with O(1) single line extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2024-05-19 - Avoid Intermediate Set Creation for Dict Views
 **Learning:** In Python 3, dictionary views (`dict.keys()`, `dict.items()`) behave identically to sets and fully support set operations (like `-`, `&`, `|`, `^`). Converting them explicitly to sets (`set(d.keys()) - other_set`) is an anti-pattern that creates an unnecessary, memory-allocating intermediate object. Similarly, `set1 - set(d.keys())` allocates a new set, whereas `set1.difference(d)` iterates over `d` directly and is faster.
 **Action:** Always prefer native dictionary view operations (e.g., `d.keys() - other_set` or `set1.difference(d)`) to avoid intermediate O(N) memory allocations during set arithmetic.
+
+## 2026-06-25 - [Performance] Optimized Python String Slicing vs splitlines()
+**Learning:** Using `text.splitlines()[0]` on large text strings creates a heavy memory footprint by tokenizing the entire string into an `O(N)` array just to extract the first line. For fast-path single-line extraction, using `.find('\n')` on strings or `.readline()` on files achieves true `O(1)` space allocation.
+**Action:** When extracting a single line from a large text document, use `nl_pos = text.find('\n')` and slice `text[:nl_pos]` (or `file.readline()` for files) to avoid memory latency and garbage collection overhead.

--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -26,7 +26,9 @@ LOG_PATH = Path("wiki/log.md")
 # exclusive_write_lock concurrently from multiple threads without adding a
 # threading.Lock around this counter.
 _HELD_LOCK_COUNTS: dict[Path, int] = {}
-_LOCK_UNAVAILABLE_HINT = "retry after the competing process completes, or remove the lock file if it is stale"
+_LOCK_UNAVAILABLE_HINT = (
+    "retry after the competing process completes, or remove the lock file if it is stale"
+)
 
 
 def _resolved_governance_sibling_locks(repo_root: Path) -> dict[Path, str]:
@@ -37,14 +39,16 @@ def _resolved_governance_sibling_locks(repo_root: Path) -> dict[Path, str]:
     }
 
 
-def _can_cohold_with_held_sibling(
-    target_lock_path: str, held_sibling_lock_path: str
-) -> bool:
+def _can_cohold_with_held_sibling(target_lock_path: str, held_sibling_lock_path: str) -> bool:
     """Allow approved same-process lock nesting with enforced acquisition order."""
-    return held_sibling_lock_path == contracts.WRITE_LOCK_PATH and target_lock_path in {
-        contracts.GITHUB_SOURCES_LOCK_PATH,
-        contracts.DRIVE_SOURCES_LOCK_PATH,
-    }
+    return (
+        held_sibling_lock_path == contracts.WRITE_LOCK_PATH
+        and target_lock_path
+        in {
+            contracts.GITHUB_SOURCES_LOCK_PATH,
+            contracts.DRIVE_SOURCES_LOCK_PATH,
+        }
+    )
 
 
 def governed_artifact_contract_for_path(
@@ -131,9 +135,7 @@ class LockUnavailableError(RuntimeError):
             return
 
         self.holder_pid = holder_details.pid
-        self.holder_started_at = _format_unix_seconds_utc(
-            holder_details.started_at_unix_seconds
-        )
+        self.holder_started_at = _format_unix_seconds_utc(holder_details.started_at_unix_seconds)
         self.holder_context_hash = _lock_holder_context_hash(holder_details)
         holder_alive = _holder_process_is_alive(
             holder_details.pid,
@@ -176,9 +178,7 @@ class _LockHolderDetails:
 def _format_unix_seconds_utc(unix_seconds: float) -> str:
     """Render unix seconds as UTC ISO-8601 (`YYYY-MM-DDTHH:MM:SSZ`)."""
 
-    return datetime.fromtimestamp(unix_seconds, tz=timezone.utc).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
+    return datetime.fromtimestamp(unix_seconds, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _lock_holder_context_hash(holder_details: _LockHolderDetails) -> str:
@@ -187,9 +187,7 @@ def _lock_holder_context_hash(holder_details: _LockHolderDetails) -> str:
     Canonical payload format is exactly ``<pid>\t<start_time_unix_seconds:.6f>\n``.
     """
 
-    canonical_payload = (
-        f"{holder_details.pid}\t{holder_details.started_at_unix_seconds:.6f}\n"
-    )
+    canonical_payload = f"{holder_details.pid}\t{holder_details.started_at_unix_seconds:.6f}\n"
     return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
 
 
@@ -326,9 +324,7 @@ def _read_lock_holder_details(lock_file_path: Path) -> _LockHolderDetails | None
     return _LockHolderDetails(pid=pid, started_at_unix_seconds=started_at)
 
 
-def _holder_process_is_alive(
-    pid: int, *, expected_started_at_unix_seconds: float
-) -> bool | None:
+def _holder_process_is_alive(pid: int, *, expected_started_at_unix_seconds: float) -> bool | None:
     """Return holder liveness: ``True`` alive, ``False`` dead/reused, ``None`` unknown."""
 
     try:
@@ -445,9 +441,7 @@ def _acquire_sibling_governance_lock(
                     ) from exc
                 with sibling_lock_file:
                     try:
-                        fcntl.flock(
-                            sibling_lock_file.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB
-                        )
+                        fcntl.flock(sibling_lock_file.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
                     except OSError as exc:
                         raise LockUnavailableError(
                             sibling_lock_path,
@@ -498,9 +492,7 @@ def exclusive_write_lock(
         return
 
     try:
-        abs_lock, resolved_lock, lock_file = _open_lock_file(
-            root, lock_path, create=True
-        )
+        abs_lock, resolved_lock, lock_file = _open_lock_file(root, lock_path, create=True)
     except OSError as exc:
         raise LockUnavailableError(lock_path, lock_file_path=abs_lock) from exc
 
@@ -522,9 +514,7 @@ def exclusive_write_lock(
         _write_lock_holder_details(lock_file)
 
         try:
-            _HELD_LOCK_COUNTS[resolved_lock] = (
-                _HELD_LOCK_COUNTS.get(resolved_lock, 0) + 1
-            )
+            _HELD_LOCK_COUNTS[resolved_lock] = _HELD_LOCK_COUNTS.get(resolved_lock, 0) + 1
             yield abs_lock
         finally:
             remaining = _HELD_LOCK_COUNTS.get(resolved_lock, 0) - 1
@@ -553,10 +543,7 @@ def atomic_replace_governed_artifact(
     contract = governed_artifact_contract_for_path(path)
     if contract is None:
         raise ValueError(f"unsupported governed artifact: {path}")
-    if (
-        contract.write_strategy
-        != contracts.ArtifactWriteStrategy.ATOMIC_REPLACE_UNDER_LOCK.value
-    ):
+    if contract.write_strategy != contracts.ArtifactWriteStrategy.ATOMIC_REPLACE_UNDER_LOCK.value:
         raise ValueError(f"artifact does not support atomic replace: {contract.path}")
 
     root = Path(repo_root).resolve(strict=False)
@@ -643,9 +630,7 @@ def write_text_capturing_previous(path: Path, content: str) -> tuple[bool, str |
     ``write_text_if_changed``.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    previous_content: str | None = (
-        path.read_text(encoding="utf-8") if path.exists() else None
-    )
+    previous_content: str | None = path.read_text(encoding="utf-8") if path.exists() else None
     if previous_content == content:
         return False, previous_content
     with path.open("w", encoding="utf-8", newline="\n") as handle:
@@ -664,9 +649,7 @@ def check_no_symlink_path(path: Path) -> None:
         current = current.parent
 
 
-def write_text_capturing_previous_safe(
-    path: Path, content: str
-) -> tuple[bool, str | None]:
+def write_text_capturing_previous_safe(path: Path, content: str) -> tuple[bool, str | None]:
     """Like ``write_text_capturing_previous`` but with symlink and atomic-write guards.
 
     Rejects symlinks anywhere in the path chain, and uses a temp-file + rename to
@@ -679,9 +662,7 @@ def write_text_capturing_previous_safe(
     if path.exists() or path.is_symlink():
         check_no_symlink_path(path)
 
-    previous_content: str | None = (
-        path.read_text(encoding="utf-8") if path.exists() else None
-    )
+    previous_content: str | None = path.read_text(encoding="utf-8") if path.exists() else None
     if previous_content == content:
         return False, previous_content
 
@@ -762,12 +743,7 @@ def validate_log_entry(entry: str) -> str:
     if not isinstance(entry, str):
         raise ValueError("entry must be a string")
     normalized = entry.strip()
-    if (
-        not normalized
-        or not normalized.startswith("- ")
-        or "\n" in normalized
-        or "\r" in normalized
-    ):
+    if not normalized or not normalized.startswith("- ") or "\n" in normalized or "\r" in normalized:
         raise ValueError(
             "entry must be a single non-empty markdown bullet beginning with '- '"
         )

--- a/scripts/kb/write_utils.py
+++ b/scripts/kb/write_utils.py
@@ -26,9 +26,7 @@ LOG_PATH = Path("wiki/log.md")
 # exclusive_write_lock concurrently from multiple threads without adding a
 # threading.Lock around this counter.
 _HELD_LOCK_COUNTS: dict[Path, int] = {}
-_LOCK_UNAVAILABLE_HINT = (
-    "retry after the competing process completes, or remove the lock file if it is stale"
-)
+_LOCK_UNAVAILABLE_HINT = "retry after the competing process completes, or remove the lock file if it is stale"
 
 
 def _resolved_governance_sibling_locks(repo_root: Path) -> dict[Path, str]:
@@ -39,16 +37,14 @@ def _resolved_governance_sibling_locks(repo_root: Path) -> dict[Path, str]:
     }
 
 
-def _can_cohold_with_held_sibling(target_lock_path: str, held_sibling_lock_path: str) -> bool:
+def _can_cohold_with_held_sibling(
+    target_lock_path: str, held_sibling_lock_path: str
+) -> bool:
     """Allow approved same-process lock nesting with enforced acquisition order."""
-    return (
-        held_sibling_lock_path == contracts.WRITE_LOCK_PATH
-        and target_lock_path
-        in {
-            contracts.GITHUB_SOURCES_LOCK_PATH,
-            contracts.DRIVE_SOURCES_LOCK_PATH,
-        }
-    )
+    return held_sibling_lock_path == contracts.WRITE_LOCK_PATH and target_lock_path in {
+        contracts.GITHUB_SOURCES_LOCK_PATH,
+        contracts.DRIVE_SOURCES_LOCK_PATH,
+    }
 
 
 def governed_artifact_contract_for_path(
@@ -135,7 +131,9 @@ class LockUnavailableError(RuntimeError):
             return
 
         self.holder_pid = holder_details.pid
-        self.holder_started_at = _format_unix_seconds_utc(holder_details.started_at_unix_seconds)
+        self.holder_started_at = _format_unix_seconds_utc(
+            holder_details.started_at_unix_seconds
+        )
         self.holder_context_hash = _lock_holder_context_hash(holder_details)
         holder_alive = _holder_process_is_alive(
             holder_details.pid,
@@ -178,7 +176,9 @@ class _LockHolderDetails:
 def _format_unix_seconds_utc(unix_seconds: float) -> str:
     """Render unix seconds as UTC ISO-8601 (`YYYY-MM-DDTHH:MM:SSZ`)."""
 
-    return datetime.fromtimestamp(unix_seconds, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.fromtimestamp(unix_seconds, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
 
 
 def _lock_holder_context_hash(holder_details: _LockHolderDetails) -> str:
@@ -187,7 +187,9 @@ def _lock_holder_context_hash(holder_details: _LockHolderDetails) -> str:
     Canonical payload format is exactly ``<pid>\t<start_time_unix_seconds:.6f>\n``.
     """
 
-    canonical_payload = f"{holder_details.pid}\t{holder_details.started_at_unix_seconds:.6f}\n"
+    canonical_payload = (
+        f"{holder_details.pid}\t{holder_details.started_at_unix_seconds:.6f}\n"
+    )
     return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
 
 
@@ -302,9 +304,12 @@ def _read_lock_holder_details(lock_file_path: Path) -> _LockHolderDetails | None
     """
 
     try:
-        line = lock_file_path.read_text(encoding="utf-8").splitlines()[0].strip()
-    except IndexError:
-        return None
+        # OPTIMIZATION: Read only the first line via open().readline() instead of reading
+        # the entire file and parsing it into an O(N) array with .splitlines()[0].
+        with lock_file_path.open(encoding="utf-8") as f:
+            line = f.readline().strip()
+        if not line:
+            return None
     except (OSError, UnicodeDecodeError):
         return None
 
@@ -321,7 +326,9 @@ def _read_lock_holder_details(lock_file_path: Path) -> _LockHolderDetails | None
     return _LockHolderDetails(pid=pid, started_at_unix_seconds=started_at)
 
 
-def _holder_process_is_alive(pid: int, *, expected_started_at_unix_seconds: float) -> bool | None:
+def _holder_process_is_alive(
+    pid: int, *, expected_started_at_unix_seconds: float
+) -> bool | None:
     """Return holder liveness: ``True`` alive, ``False`` dead/reused, ``None`` unknown."""
 
     try:
@@ -438,7 +445,9 @@ def _acquire_sibling_governance_lock(
                     ) from exc
                 with sibling_lock_file:
                     try:
-                        fcntl.flock(sibling_lock_file.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+                        fcntl.flock(
+                            sibling_lock_file.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB
+                        )
                     except OSError as exc:
                         raise LockUnavailableError(
                             sibling_lock_path,
@@ -489,7 +498,9 @@ def exclusive_write_lock(
         return
 
     try:
-        abs_lock, resolved_lock, lock_file = _open_lock_file(root, lock_path, create=True)
+        abs_lock, resolved_lock, lock_file = _open_lock_file(
+            root, lock_path, create=True
+        )
     except OSError as exc:
         raise LockUnavailableError(lock_path, lock_file_path=abs_lock) from exc
 
@@ -511,7 +522,9 @@ def exclusive_write_lock(
         _write_lock_holder_details(lock_file)
 
         try:
-            _HELD_LOCK_COUNTS[resolved_lock] = _HELD_LOCK_COUNTS.get(resolved_lock, 0) + 1
+            _HELD_LOCK_COUNTS[resolved_lock] = (
+                _HELD_LOCK_COUNTS.get(resolved_lock, 0) + 1
+            )
             yield abs_lock
         finally:
             remaining = _HELD_LOCK_COUNTS.get(resolved_lock, 0) - 1
@@ -540,7 +553,10 @@ def atomic_replace_governed_artifact(
     contract = governed_artifact_contract_for_path(path)
     if contract is None:
         raise ValueError(f"unsupported governed artifact: {path}")
-    if contract.write_strategy != contracts.ArtifactWriteStrategy.ATOMIC_REPLACE_UNDER_LOCK.value:
+    if (
+        contract.write_strategy
+        != contracts.ArtifactWriteStrategy.ATOMIC_REPLACE_UNDER_LOCK.value
+    ):
         raise ValueError(f"artifact does not support atomic replace: {contract.path}")
 
     root = Path(repo_root).resolve(strict=False)
@@ -627,7 +643,9 @@ def write_text_capturing_previous(path: Path, content: str) -> tuple[bool, str |
     ``write_text_if_changed``.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    previous_content: str | None = path.read_text(encoding="utf-8") if path.exists() else None
+    previous_content: str | None = (
+        path.read_text(encoding="utf-8") if path.exists() else None
+    )
     if previous_content == content:
         return False, previous_content
     with path.open("w", encoding="utf-8", newline="\n") as handle:
@@ -646,7 +664,9 @@ def check_no_symlink_path(path: Path) -> None:
         current = current.parent
 
 
-def write_text_capturing_previous_safe(path: Path, content: str) -> tuple[bool, str | None]:
+def write_text_capturing_previous_safe(
+    path: Path, content: str
+) -> tuple[bool, str | None]:
     """Like ``write_text_capturing_previous`` but with symlink and atomic-write guards.
 
     Rejects symlinks anywhere in the path chain, and uses a temp-file + rename to
@@ -659,7 +679,9 @@ def write_text_capturing_previous_safe(path: Path, content: str) -> tuple[bool, 
     if path.exists() or path.is_symlink():
         check_no_symlink_path(path)
 
-    previous_content: str | None = path.read_text(encoding="utf-8") if path.exists() else None
+    previous_content: str | None = (
+        path.read_text(encoding="utf-8") if path.exists() else None
+    )
     if previous_content == content:
         return False, previous_content
 
@@ -740,7 +762,12 @@ def validate_log_entry(entry: str) -> str:
     if not isinstance(entry, str):
         raise ValueError("entry must be a string")
     normalized = entry.strip()
-    if not normalized or not normalized.startswith("- ") or "\n" in normalized or "\r" in normalized:
+    if (
+        not normalized
+        or not normalized.startswith("- ")
+        or "\n" in normalized
+        or "\r" in normalized
+    ):
         raise ValueError(
             "entry must be a single non-empty markdown bullet beginning with '- '"
         )

--- a/scripts/validation/check_commit_scope.py
+++ b/scripts/validation/check_commit_scope.py
@@ -38,29 +38,25 @@ SURFACE = "scripts/validation/check_commit_scope.py"
 # Each token maps to one or more sensitive path prefixes (see _PATH_TO_TOKENS).
 # Pure substring matching is intentionally rejected to prevent false negatives
 # such as ``wikipedia`` matching ``wiki`` or ``Adrian`` matching ``adr``.
-GATE_B_TOKENS: frozenset[str] = frozenset(
-    {
-        "wiki",
-        "schema",
-        "adr",
-        "adrs",
-        "agents",
-        "copilot",
-        "contracts",
-        "write_utils",
-        "spec",
-        "workflows",
-        "pre-commit",
-    }
-)
+GATE_B_TOKENS: frozenset[str] = frozenset({
+    "wiki",
+    "schema",
+    "adr",
+    "adrs",
+    "agents",
+    "copilot",
+    "contracts",
+    "write_utils",
+    "spec",
+    "workflows",
+    "pre-commit",
+})
 
 # Build the regex from the token set (longest tokens first to avoid partial
 # shadowing; the alternation is anchored by \b so ordering is irrelevant for
 # correctness, but longest-first is conventional).
 _GATE_B_TOKEN_RE = re.compile(
-    r"\b(?:"
-    + "|".join(re.escape(t) for t in sorted(GATE_B_TOKENS, key=len, reverse=True))
-    + r")\b",
+    r"\b(?:" + "|".join(re.escape(t) for t in sorted(GATE_B_TOKENS, key=len, reverse=True)) + r")\b",
     re.IGNORECASE,
 )
 
@@ -129,9 +125,11 @@ def check_gate_b(
     if not uncovered:
         return True, []
 
-    needed_tokens = sorted(
-        {tok for surf in uncovered for tok in _PATH_TO_TOKENS.get(surf, ())}
-    )
+    needed_tokens = sorted({
+        tok
+        for surf in uncovered
+        for tok in _PATH_TO_TOKENS.get(surf, ())
+    })
     surfaces_str = ", ".join(f"'{s}'" for s in sorted(uncovered))
     return False, [
         f"Gate B failed: PR touches sensitive path(s) {surfaces_str} but neither "
@@ -191,15 +189,11 @@ def _default_reverts_validator(value: str) -> bool:
         try:
             subprocess.run(
                 ["git", "cat-file", "-e", f"{value}^{{commit}}"],
-                check=True,
-                capture_output=True,
-                timeout=15,
+                check=True, capture_output=True, timeout=15,
             )
             subprocess.run(
                 ["git", "merge-base", "--is-ancestor", value, "main"],
-                check=True,
-                capture_output=True,
-                timeout=15,
+                check=True, capture_output=True, timeout=15,
             )
             return True
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
@@ -213,8 +207,7 @@ def _default_reverts_validator(value: str) -> bool:
             try:
                 result = subprocess.run(
                     ["gh", subcmd, "view", issue_num, "--json", "number"],
-                    capture_output=True,
-                    timeout=15,
+                    capture_output=True, timeout=15,
                 )
                 if result.returncode == 0:
                     return True
@@ -255,9 +248,7 @@ def check_gate_c(
     for key, val in commit_trailers + body_trailers:
         if key.lower() == "reverts":
             val_stripped = val.strip()
-            if _REVERTS_SHA_RE.match(val_stripped) or _REVERTS_REF_RE.match(
-                val_stripped
-            ):
+            if _REVERTS_SHA_RE.match(val_stripped) or _REVERTS_REF_RE.match(val_stripped):
                 if reverts_validator(val_stripped):
                     return True, []
         elif key.lower() == "cleanup":
@@ -278,15 +269,12 @@ def check_gate_c(
 # Subprocess helpers for CI entry point
 # ---------------------------------------------------------------------------
 
-
 def _get_pr_files(pr_number: str) -> list[dict[str, object]]:
     """Return list of changed files with additions/deletions for *pr_number*."""
     try:
         result = subprocess.run(
             ["gh", "pr", "view", pr_number, "--json", "files"],
-            capture_output=True,
-            text=True,
-            timeout=30,
+            capture_output=True, text=True, timeout=30,
         )
         if result.returncode != 0:
             print(
@@ -306,9 +294,7 @@ def _get_last_commit_msg() -> str:
     try:
         result = subprocess.run(
             ["git", "log", "-1", "--format=%B", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=15,
+            capture_output=True, text=True, timeout=15,
         )
         if result.returncode != 0:
             return ""
@@ -321,14 +307,13 @@ def _get_last_commit_msg() -> str:
 # CLI entry point
 # ---------------------------------------------------------------------------
 
-
 def main() -> int:
     pr_number = os.environ.get("PR_NUMBER", "").strip()
     pr_title = os.environ.get("PR_TITLE", "").strip()
     pr_body = os.environ.get("PR_BODY", "")
 
     if not pr_number:
-        print("::error::PR_NUMBER environment variable is required.", file=sys.stderr)
+        print(f"::error::PR_NUMBER environment variable is required.", file=sys.stderr)
         return 1
 
     files = _get_pr_files(pr_number)

--- a/scripts/validation/check_commit_scope.py
+++ b/scripts/validation/check_commit_scope.py
@@ -38,25 +38,29 @@ SURFACE = "scripts/validation/check_commit_scope.py"
 # Each token maps to one or more sensitive path prefixes (see _PATH_TO_TOKENS).
 # Pure substring matching is intentionally rejected to prevent false negatives
 # such as ``wikipedia`` matching ``wiki`` or ``Adrian`` matching ``adr``.
-GATE_B_TOKENS: frozenset[str] = frozenset({
-    "wiki",
-    "schema",
-    "adr",
-    "adrs",
-    "agents",
-    "copilot",
-    "contracts",
-    "write_utils",
-    "spec",
-    "workflows",
-    "pre-commit",
-})
+GATE_B_TOKENS: frozenset[str] = frozenset(
+    {
+        "wiki",
+        "schema",
+        "adr",
+        "adrs",
+        "agents",
+        "copilot",
+        "contracts",
+        "write_utils",
+        "spec",
+        "workflows",
+        "pre-commit",
+    }
+)
 
 # Build the regex from the token set (longest tokens first to avoid partial
 # shadowing; the alternation is anchored by \b so ordering is irrelevant for
 # correctness, but longest-first is conventional).
 _GATE_B_TOKEN_RE = re.compile(
-    r"\b(?:" + "|".join(re.escape(t) for t in sorted(GATE_B_TOKENS, key=len, reverse=True)) + r")\b",
+    r"\b(?:"
+    + "|".join(re.escape(t) for t in sorted(GATE_B_TOKENS, key=len, reverse=True))
+    + r")\b",
     re.IGNORECASE,
 )
 
@@ -103,7 +107,13 @@ def check_gate_b(
     word-boundary token match — in the PR title or the first line of the PR
     body.
     """
-    body_first_line = (pr_body or "").splitlines()[0].strip() if pr_body else ""
+    # OPTIMIZATION: Extract the first line using .find() instead of .splitlines()[0]
+    # to avoid allocating an O(N) list in memory for large PR bodies.
+    body_first_line = ""
+    if pr_body:
+        nl_pos = pr_body.find("\n")
+        body_first_line = (pr_body if nl_pos == -1 else pr_body[:nl_pos]).strip()
+
     combined = f"{pr_title}\n{body_first_line}"
     tokens = _present_tokens(combined)
 
@@ -119,11 +129,9 @@ def check_gate_b(
     if not uncovered:
         return True, []
 
-    needed_tokens = sorted({
-        tok
-        for surf in uncovered
-        for tok in _PATH_TO_TOKENS.get(surf, ())
-    })
+    needed_tokens = sorted(
+        {tok for surf in uncovered for tok in _PATH_TO_TOKENS.get(surf, ())}
+    )
     surfaces_str = ", ".join(f"'{s}'" for s in sorted(uncovered))
     return False, [
         f"Gate B failed: PR touches sensitive path(s) {surfaces_str} but neither "
@@ -183,11 +191,15 @@ def _default_reverts_validator(value: str) -> bool:
         try:
             subprocess.run(
                 ["git", "cat-file", "-e", f"{value}^{{commit}}"],
-                check=True, capture_output=True, timeout=15,
+                check=True,
+                capture_output=True,
+                timeout=15,
             )
             subprocess.run(
                 ["git", "merge-base", "--is-ancestor", value, "main"],
-                check=True, capture_output=True, timeout=15,
+                check=True,
+                capture_output=True,
+                timeout=15,
             )
             return True
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
@@ -201,7 +213,8 @@ def _default_reverts_validator(value: str) -> bool:
             try:
                 result = subprocess.run(
                     ["gh", subcmd, "view", issue_num, "--json", "number"],
-                    capture_output=True, timeout=15,
+                    capture_output=True,
+                    timeout=15,
                 )
                 if result.returncode == 0:
                     return True
@@ -242,7 +255,9 @@ def check_gate_c(
     for key, val in commit_trailers + body_trailers:
         if key.lower() == "reverts":
             val_stripped = val.strip()
-            if _REVERTS_SHA_RE.match(val_stripped) or _REVERTS_REF_RE.match(val_stripped):
+            if _REVERTS_SHA_RE.match(val_stripped) or _REVERTS_REF_RE.match(
+                val_stripped
+            ):
                 if reverts_validator(val_stripped):
                     return True, []
         elif key.lower() == "cleanup":
@@ -263,12 +278,15 @@ def check_gate_c(
 # Subprocess helpers for CI entry point
 # ---------------------------------------------------------------------------
 
+
 def _get_pr_files(pr_number: str) -> list[dict[str, object]]:
     """Return list of changed files with additions/deletions for *pr_number*."""
     try:
         result = subprocess.run(
             ["gh", "pr", "view", pr_number, "--json", "files"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             print(
@@ -288,7 +306,9 @@ def _get_last_commit_msg() -> str:
     try:
         result = subprocess.run(
             ["git", "log", "-1", "--format=%B", "HEAD"],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True,
+            text=True,
+            timeout=15,
         )
         if result.returncode != 0:
             return ""
@@ -301,13 +321,14 @@ def _get_last_commit_msg() -> str:
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+
 def main() -> int:
     pr_number = os.environ.get("PR_NUMBER", "").strip()
     pr_title = os.environ.get("PR_TITLE", "").strip()
     pr_body = os.environ.get("PR_BODY", "")
 
     if not pr_number:
-        print(f"::error::PR_NUMBER environment variable is required.", file=sys.stderr)
+        print("::error::PR_NUMBER environment variable is required.", file=sys.stderr)
         return 1
 
     files = _get_pr_files(pr_number)

--- a/scripts/validation/validate_afk_output.py
+++ b/scripts/validation/validate_afk_output.py
@@ -39,10 +39,12 @@ MODE = "validate"
 # Frontmatter fields that AFK updates may change.
 # For ``quality_assessment``, only the ``freshness_date`` sub-field may change
 # per ADR-014 §4.  The ``updated_at`` field records the AFK timestamp.
-_AFK_ALLOWED_FIELDS: frozenset[str] = frozenset({
-    "updated_at",
-    "quality_assessment",
-})
+_AFK_ALLOWED_FIELDS: frozenset[str] = frozenset(
+    {
+        "updated_at",
+        "quality_assessment",
+    }
+)
 
 _WIKI_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+\.md(?:#[^)]*)?)\)")
 
@@ -67,7 +69,7 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     if end == -1:
         return {}, text
     fm_block = text[4:end]
-    body = text[end + 4:].strip()
+    body = text[end + 4 :].strip()
     try:
         fields = yaml.safe_load(fm_block) or {}
         if not isinstance(fields, dict):
@@ -111,7 +113,9 @@ def validate_afk_output(
     # sub-field may change per ADR-014 §4.
     changed_fields: list[str] = []
     disallowed: list[str] = []
-    all_keys = set(orig_fm) | set(prop_fm)
+    # OPTIMIZATION: Use dict.keys() view operations instead of set()
+    # to avoid allocating unnecessary intermediate set objects in memory.
+    all_keys = orig_fm.keys() | prop_fm.keys()
     for key in all_keys:
         if orig_fm.get(key) != prop_fm.get(key):
             changed_fields.append(key)
@@ -122,55 +126,69 @@ def validate_afk_output(
                     orig_qa = {}
                 if not isinstance(prop_qa, dict):
                     prop_qa = {}
-                for qa_key in set(orig_qa) | set(prop_qa):
-                    if qa_key != "freshness_date" and orig_qa.get(qa_key) != prop_qa.get(qa_key):
+                # OPTIMIZATION: Use dict.keys() view operations instead of set()
+                # to avoid allocating intermediate set objects.
+                for qa_key in orig_qa.keys() | prop_qa.keys():
+                    if qa_key != "freshness_date" and orig_qa.get(
+                        qa_key
+                    ) != prop_qa.get(qa_key):
                         disallowed.append(f"quality_assessment.{qa_key}")
             elif key not in _AFK_ALLOWED_FIELDS:
                 disallowed.append(key)
-    checks.append({
-        "check": "frontmatter_fields",
-        "pass": len(disallowed) == 0,
-        "changed": changed_fields,
-        "disallowed": disallowed,
-    })
+    checks.append(
+        {
+            "check": "frontmatter_fields",
+            "pass": len(disallowed) == 0,
+            "changed": changed_fields,
+            "disallowed": disallowed,
+        }
+    )
 
     # Check 2: No body text changes (after YAML whitespace normalization).
     orig_normalized = _normalize_yaml_whitespace(orig_body)
     prop_normalized = _normalize_yaml_whitespace(prop_body)
     body_unchanged = orig_normalized == prop_normalized
-    checks.append({
-        "check": "body_unchanged",
-        "pass": body_unchanged,
-    })
+    checks.append(
+        {
+            "check": "body_unchanged",
+            "pass": body_unchanged,
+        }
+    )
 
     # Check 3: No citation/SourceRef changes.
     orig_refs = set(SOURCEREF_RE.findall(orig_body))
     prop_refs = set(SOURCEREF_RE.findall(prop_body))
     refs_unchanged = orig_refs == prop_refs
-    checks.append({
-        "check": "citations_unchanged",
-        "pass": refs_unchanged,
-        "added": sorted(prop_refs - orig_refs),
-        "removed": sorted(orig_refs - prop_refs),
-    })
+    checks.append(
+        {
+            "check": "citations_unchanged",
+            "pass": refs_unchanged,
+            "added": sorted(prop_refs - orig_refs),
+            "removed": sorted(orig_refs - prop_refs),
+        }
+    )
 
     # Check 4: No link/topology changes.
     orig_links = set(_WIKI_LINK_RE.findall(orig_body))
     prop_links = set(_WIKI_LINK_RE.findall(prop_body))
     links_unchanged = orig_links == prop_links
-    checks.append({
-        "check": "links_unchanged",
-        "pass": links_unchanged,
-    })
+    checks.append(
+        {
+            "check": "links_unchanged",
+            "pass": links_unchanged,
+        }
+    )
 
     # Check 5: No entity/alias/title changes.
     # With proper YAML parsing, compare title and aliases directly.
     title_unchanged = orig_fm.get("title") == prop_fm.get("title")
     aliases_unchanged = orig_fm.get("aliases") == prop_fm.get("aliases")
-    checks.append({
-        "check": "identity_unchanged",
-        "pass": title_unchanged and aliases_unchanged,
-    })
+    checks.append(
+        {
+            "check": "identity_unchanged",
+            "pass": title_unchanged and aliases_unchanged,
+        }
+    )
 
     all_passed = all(c["pass"] for c in checks)
     failed_checks = [c["check"] for c in checks if not c["pass"]]
@@ -224,9 +242,7 @@ def _args_to_kwargs(args: Any) -> dict[str, Any]:
     try:
         resolved_original = original_path.resolve()
         if not resolved_original.is_relative_to(wiki_root):
-            raise ValueError(
-                f"--original must be within wiki/: {original_path}"
-            )
+            raise ValueError(f"--original must be within wiki/: {original_path}")
     except ValueError as exc:
         raise ValueError(str(exc)) from exc
     return {

--- a/scripts/validation/validate_afk_output.py
+++ b/scripts/validation/validate_afk_output.py
@@ -39,12 +39,10 @@ MODE = "validate"
 # Frontmatter fields that AFK updates may change.
 # For ``quality_assessment``, only the ``freshness_date`` sub-field may change
 # per ADR-014 §4.  The ``updated_at`` field records the AFK timestamp.
-_AFK_ALLOWED_FIELDS: frozenset[str] = frozenset(
-    {
-        "updated_at",
-        "quality_assessment",
-    }
-)
+_AFK_ALLOWED_FIELDS: frozenset[str] = frozenset({
+    "updated_at",
+    "quality_assessment",
+})
 
 _WIKI_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+\.md(?:#[^)]*)?)\)")
 
@@ -69,7 +67,7 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     if end == -1:
         return {}, text
     fm_block = text[4:end]
-    body = text[end + 4 :].strip()
+    body = text[end + 4:].strip()
     try:
         fields = yaml.safe_load(fm_block) or {}
         if not isinstance(fields, dict):
@@ -129,66 +127,54 @@ def validate_afk_output(
                 # OPTIMIZATION: Use dict.keys() view operations instead of set()
                 # to avoid allocating intermediate set objects.
                 for qa_key in orig_qa.keys() | prop_qa.keys():
-                    if qa_key != "freshness_date" and orig_qa.get(
-                        qa_key
-                    ) != prop_qa.get(qa_key):
+                    if qa_key != "freshness_date" and orig_qa.get(qa_key) != prop_qa.get(qa_key):
                         disallowed.append(f"quality_assessment.{qa_key}")
             elif key not in _AFK_ALLOWED_FIELDS:
                 disallowed.append(key)
-    checks.append(
-        {
-            "check": "frontmatter_fields",
-            "pass": len(disallowed) == 0,
-            "changed": changed_fields,
-            "disallowed": disallowed,
-        }
-    )
+    checks.append({
+        "check": "frontmatter_fields",
+        "pass": len(disallowed) == 0,
+        "changed": changed_fields,
+        "disallowed": disallowed,
+    })
 
     # Check 2: No body text changes (after YAML whitespace normalization).
     orig_normalized = _normalize_yaml_whitespace(orig_body)
     prop_normalized = _normalize_yaml_whitespace(prop_body)
     body_unchanged = orig_normalized == prop_normalized
-    checks.append(
-        {
-            "check": "body_unchanged",
-            "pass": body_unchanged,
-        }
-    )
+    checks.append({
+        "check": "body_unchanged",
+        "pass": body_unchanged,
+    })
 
     # Check 3: No citation/SourceRef changes.
     orig_refs = set(SOURCEREF_RE.findall(orig_body))
     prop_refs = set(SOURCEREF_RE.findall(prop_body))
     refs_unchanged = orig_refs == prop_refs
-    checks.append(
-        {
-            "check": "citations_unchanged",
-            "pass": refs_unchanged,
-            "added": sorted(prop_refs - orig_refs),
-            "removed": sorted(orig_refs - prop_refs),
-        }
-    )
+    checks.append({
+        "check": "citations_unchanged",
+        "pass": refs_unchanged,
+        "added": sorted(prop_refs - orig_refs),
+        "removed": sorted(orig_refs - prop_refs),
+    })
 
     # Check 4: No link/topology changes.
     orig_links = set(_WIKI_LINK_RE.findall(orig_body))
     prop_links = set(_WIKI_LINK_RE.findall(prop_body))
     links_unchanged = orig_links == prop_links
-    checks.append(
-        {
-            "check": "links_unchanged",
-            "pass": links_unchanged,
-        }
-    )
+    checks.append({
+        "check": "links_unchanged",
+        "pass": links_unchanged,
+    })
 
     # Check 5: No entity/alias/title changes.
     # With proper YAML parsing, compare title and aliases directly.
     title_unchanged = orig_fm.get("title") == prop_fm.get("title")
     aliases_unchanged = orig_fm.get("aliases") == prop_fm.get("aliases")
-    checks.append(
-        {
-            "check": "identity_unchanged",
-            "pass": title_unchanged and aliases_unchanged,
-        }
-    )
+    checks.append({
+        "check": "identity_unchanged",
+        "pass": title_unchanged and aliases_unchanged,
+    })
 
     all_passed = all(c["pass"] for c in checks)
     failed_checks = [c["check"] for c in checks if not c["pass"]]
@@ -242,7 +228,9 @@ def _args_to_kwargs(args: Any) -> dict[str, Any]:
     try:
         resolved_original = original_path.resolve()
         if not resolved_original.is_relative_to(wiki_root):
-            raise ValueError(f"--original must be within wiki/: {original_path}")
+            raise ValueError(
+                f"--original must be within wiki/: {original_path}"
+            )
     except ValueError as exc:
         raise ValueError(str(exc)) from exc
     return {


### PR DESCRIPTION
💡 What: Replaced usages of `splitlines()[0]` and `set(dict)` with $O(1)$ memory allocation alternatives. Specifically:
- `check_commit_scope.py`: Replaced `pr_body.splitlines()[0]` with a `find('\n')` slice.
- `write_utils.py`: Replaced `.read_text().splitlines()[0]` with `.open().readline()`.
- `validate_afk_output.py`: Replaced `set(orig_fm) | set(prop_fm)` with `orig_fm.keys() | prop_fm.keys()`.

🎯 Why: Using `splitlines()` on a large text block (like a PR body or file) tokenizes the entire string into an $O(N)$ array in memory just to extract the first line. Similarly, passing dictionaries to `set()` creates unnecessary intermediate set objects when dictionary views natively support set operations like unions.

📊 Impact: Reduces memory allocations for single line extraction from $O(N)$ to $O(1)$. Dictionary key set operations avoid large intermediate set allocations, scaling more efficiently with input size.

🔬 Measurement: I ran benchmark scripts internally demonstrating `.find('\n')` and `.readline()` approach constant time extraction vs `.splitlines()` linear scaling time and memory footprints. Tests were verified to pass confirming identical behavior.

---
*PR created automatically by Jules for task [13729261637891467535](https://jules.google.com/task/13729261637891467535) started by @wryenmeek*