### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure host binding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+
+## 2024-07-04 - Insecure Default Bind Interface in Webhook Receivers
+**Vulnerability:** WSGI webhook receivers (`relay_http.py`) defaulted to binding to all interfaces (`0.0.0.0`).
+**Learning:** Exposing test/relay endpoints to `0.0.0.0` unintentionally allows any network interface to connect unauthenticated to the WSGI application, posing a network exposure risk.
+**Prevention:** Explicitly default bind `--host` to loopback (`127.0.0.1`) when writing WSGI entrypoints or webhook receivers unless explicitly intended to be exposed globally.

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Webhook relay receivers defaulted to binding to all interfaces (`0.0.0.0`) in `scripts/drive_monitor/relay_http.py` and `scripts/github_monitor/relay_http.py`.
🎯 Impact: A development or relay server might unintentionally expose endpoints unauthenticated to the broader network.
🔧 Fix: Changed default bind interface to loopback (`127.0.0.1`).
✅ Verification: Run `pytest` on `tests/github_monitor/` and `tests/drive_monitor/` to ensure no functionality is broken. Bandit scans no longer flag `B104`.

---
*PR created automatically by Jules for task [12470877474623369641](https://jules.google.com/task/12470877474623369641) started by @wryenmeek*