### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix WSGI Default Bind Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+
+## 2024-07-05 - [WSGI Default Bind Exposure]
+**Vulnerability:** WSGI and webhook receivers defaulted `--host` to `0.0.0.0`, exposing the server unauthenticated to all network interfaces.
+**Learning:** Defaulting to `0.0.0.0` unintentionally opens the service to external access which violates the principle of least privilege.
+**Prevention:** Explicitly default bind interfaces to `127.0.0.1` for local-only traffic in WSGI entrypoints and internal webhook receivers (addresses Bandit rule B104).

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,10 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    # Security enhancement: Default to 127.0.0.1 to avoid unintentionally exposing
+    # the server unauthenticated to all network interfaces (Bandit B104).
+    # Can be overridden via HOST environment variable for containerized deployments.
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,10 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    # Security enhancement: Default to 127.0.0.1 to avoid unintentionally exposing
+    # the server unauthenticated to all network interfaces (Bandit B104).
+    # Can be overridden via HOST environment variable for containerized deployments.
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
🚨 **Severity:** CRITICAL / HIGH
💡 **Vulnerability:** WSGI entrypoints and webhook receivers (`scripts/drive_monitor/relay_http.py` and `scripts/github_monitor/relay_http.py`) defaulted their `--host` bind address to `0.0.0.0`. 
🎯 **Impact:** Defaulting to `0.0.0.0` unintentionally opens the service to external network interfaces. This violates the principle of least privilege, exposing internal webhook receivers to potentially untrusted or unexpected traffic (Bandit rule B104).
🔧 **Fix:** Changed the default bind address to `os.environ.get("HOST", "127.0.0.1")`. This ensures it defaults securely to `127.0.0.1` for local-only traffic while providing an environment variable fallback (`HOST`) so as not to break containerized deployments. Inline comments were also added explaining the security concern.
✅ **Verification:** Verified by checking the updated files and ensuring the full `pytest` suite passes with `PYTHONPATH=.:/usr/lib/python3/dist-packages pytest`. Learning has been appended to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7019581413969797853](https://jules.google.com/task/7019581413969797853) started by @wryenmeek*