### PR TITLE
⚡ Bolt: Optimize memory usage in check_locality_ratchet by avoiding splitlines()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,6 @@
 ## 2024-05-19 - Avoid Intermediate Set Creation for Dict Views
 **Learning:** In Python 3, dictionary views (`dict.keys()`, `dict.items()`) behave identically to sets and fully support set operations (like `-`, `&`, `|`, `^`). Converting them explicitly to sets (`set(d.keys()) - other_set`) is an anti-pattern that creates an unnecessary, memory-allocating intermediate object. Similarly, `set1 - set(d.keys())` allocates a new set, whereas `set1.difference(d)` iterates over `d` directly and is faster.
 **Action:** Always prefer native dictionary view operations (e.g., `d.keys() - other_set` or `set1.difference(d)`) to avoid intermediate O(N) memory allocations during set arithmetic.
+## 2024-05-23 - Avoid len(splitlines()) for simple line counting
+**Learning:** Using `len(content.splitlines())` on large text files allocates an O(N) memory array of all lines, which is inefficient when only the total count is needed.
+**Action:** Use `content.count('\n') + (0 if content.endswith('\n') else 1) if content else 0` to achieve O(1) memory line counting.

--- a/scripts/hooks/check_locality_ratchet.py
+++ b/scripts/hooks/check_locality_ratchet.py
@@ -244,7 +244,8 @@ def _agents_matrix_body_lines(content: str) -> set[int]:
 
 
 def _gated_lines(path: str, content: str) -> set[int]:
-    line_count = len(content.splitlines())
+    # OPTIMIZATION: O(1) memory line counting to avoid allocating an array for every line
+    line_count = content.count('\n') + (0 if content.endswith('\n') else 1) if content else 0
     if path == COPILOT_INSTRUCTIONS_PATH:
         return _copilot_gated_lines(content)
     if path == AGENTS_PATH:


### PR DESCRIPTION
💡 What: Replaced `len(content.splitlines())` with an O(1) memory counting approach (`content.count('\n') + ...`) in `scripts/hooks/check_locality_ratchet.py`.
🎯 Why: Calling `.splitlines()` allocates a list containing every line of the file in memory, which is inefficient when we only need the total count of lines.
📊 Impact: Reduces memory overhead from O(N) (array allocation) to O(1) for line counting in `check_locality_ratchet.py`.
🔬 Measurement: Run the tests in `tests/kb/test_locality_ratchet.py` to ensure line counting logic still behaves correctly.

---
*PR created automatically by Jules for task [39413509330658448](https://jules.google.com/task/39413509330658448) started by @wryenmeek*