### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default bind address

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+
+## 2026-06-28 - [Secure Default Bind Address]
+**Vulnerability:** WSGI application relays were defaulting to binding to `0.0.0.0` (all network interfaces), unnecessarily exposing them to the local network (Bandit B104).
+**Learning:** Defaulting to `0.0.0.0` increases the attack surface. Applications should default to localhost (`127.0.0.1`) and only be exposed more broadly when explicitly required by the deployment environment (e.g., via environment variables).
+**Prevention:** Always use `os.environ.get('HOST', '127.0.0.1')` for server bind interfaces rather than hardcoding `0.0.0.0`.

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
Updates the WSGI relay HTTP entrypoints to bind to `127.0.0.1` by default rather than `0.0.0.0`, minimizing the attack surface by default while preserving deployment flexibility through the `HOST` environment variable.

---
*PR created automatically by Jules for task [16242515351001145658](https://jules.google.com/task/16242515351001145658) started by @wryenmeek*