### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix hardcoded bind all interfaces

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+## 2026-06-27 - [Hardcoded 0.0.0.0 Binding]
+**Vulnerability:** WSGI and webhook receivers defaulted to binding to 0.0.0.0.
+**Learning:** Hardcoding a bind to 0.0.0.0 inadvertently exposes local services to all network interfaces, triggering Bandit B104.
+**Prevention:** Use an environment variable like os.environ.get('HOST', '127.0.0.1') for the bind address. This allows it to be overridden for containers while remaining secure by default.

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WSGI and webhook receivers defaulted to binding to 0.0.0.0.
🎯 Impact: Hardcoding a bind to 0.0.0.0 inadvertently exposes local services to all network interfaces.
🔧 Fix: Use an environment variable os.environ.get('HOST', '127.0.0.1') for the bind address.
✅ Verification: Run `bandit -r scripts/ tests/ .github/ -f json -o bandit-results.json` to verify the security scan passes.

---
*PR created automatically by Jules for task [11659165998611836431](https://jules.google.com/task/11659165998611836431) started by @wryenmeek*