### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix hardcoded bind to all interfaces (Bandit B104)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+
+## 2024-07-08 - Fix Hardcoded Bind to All Interfaces (Bandit B104)
+**Vulnerability:** WSGI webhook receivers (`scripts/drive_monitor/relay_http.py` and `scripts/github_monitor/relay_http.py`) defaulted their bind host to `0.0.0.0`, exposing the service to all network interfaces.
+**Learning:** Defaulting to `0.0.0.0` creates unintended network exposure for services meant for local or containerized environments. It should only be bound explicitly if required.
+**Prevention:** Use an environment variable (e.g., `HOST`) with a safe local fallback like `127.0.0.1` (e.g., `os.environ.get("HOST", "127.0.0.1")`) to ensure security while maintaining compatibility.

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WSGI webhook receivers defaulted their bind host to `0.0.0.0`, potentially exposing the service to all network interfaces unexpectedly.
🎯 Impact: Unintended network exposure could allow unauthorized access to the webhook receivers.
🔧 Fix: Updated the default host to use an environment variable (`HOST`) with a safe local fallback (`127.0.0.1`).
✅ Verification: Run `bandit -r scripts -ll` to verify B104 issues are resolved.

---
*PR created automatically by Jules for task [7479005036288933881](https://jules.google.com/task/7479005036288933881) started by @wryenmeek*