### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Hardcoded 0.0.0.0 Binding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Token exposure via stderr logs and expression injection (`${{ ... }}`) via GitHub-flavoured markdown rendering.
 **Learning:** API error messages can contain sensitive credentials (e.g., `ghp_`, `github_pat_`, base64 strings) which can be exposed if stderr is not properly redacted. GitHub markdown might trigger side effects if `${{ ... }}` expressions are not neutralized.
 **Prevention:** Centralize and ensure consistent markdown sanitization and error log redaction across all scripts interfacing with external platforms (like GitHub and Google Drive).
+
+## 2026-07-09 - [Hardcoded 0.0.0.0 Binding]
+**Vulnerability:** WSGI entrypoints and webhook receivers defaulted to binding to `0.0.0.0`, potentially exposing them to unintended networks.
+**Learning:** Binding to `0.0.0.0` by default is a security risk (Bandit B104) because it listens on all available interfaces. Local fallback ensures security while allowing container environments to explicitly configure network exposure.
+**Prevention:** Use an environment variable with a safe local fallback like `os.environ.get('HOST', '127.0.0.1')` instead of hardcoding `0.0.0.0`.

--- a/scripts/drive_monitor/relay_http.py
+++ b/scripts/drive_monitor/relay_http.py
@@ -113,7 +113,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = DriveRelayWsgiApp.from_env()

--- a/scripts/github_monitor/relay_http.py
+++ b/scripts/github_monitor/relay_http.py
@@ -178,7 +178,7 @@ def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[byt
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--host", default=os.environ.get("HOST", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8080")))
     args = parser.parse_args()
     application = GitHubRelayWsgiApp.from_env()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: WSGI entrypoints and webhook receivers defaulted to binding to 0.0.0.0, potentially exposing them to unintended networks.
🎯 Impact: A malicious actor could exploit this to connect to these services from unintended networks.
🔧 Fix: Changed the default bind host to use an environment variable with a safe local fallback (os.environ.get('HOST', '127.0.0.1')).
✅ Verification: Run tests and inspect the modified files to ensure the bind host defaults to a safe local IP address.

---
*PR created automatically by Jules for task [4061425218777040125](https://jules.google.com/task/4061425218777040125) started by @wryenmeek*